### PR TITLE
Add global vs. local path planners, with PRM and RRT examples

### DIFF
--- a/docs/source/yaml/world_schema.rst
+++ b/docs/source/yaml/world_schema.rst
@@ -30,6 +30,14 @@ The world schema looks as follows, where ``<angle brackets>`` are placeholders:
        radius: <value> # Robot radius
        location: <name> # Initial location
        pose: [<x>, <y>, <yaw>] # Initial pose, if not specified will sample
+       path_planner: # Local robot path planner -- generally refers to single-query planners
+         type: rrt # Supported types -- rrt
+         <property>: <planner_property>
+
+   # Global path planner -- generally refers to multi-query planners
+   global_path_planner:
+     type: search_graph # Supported types -- search_graph, prm
+     <property>: <planner_property>
 
    # Rooms
    rooms:

--- a/pyrobosim/examples/test_prm.py
+++ b/pyrobosim/examples/test_prm.py
@@ -2,7 +2,7 @@
 import os
 
 from pyrobosim.core.yaml import WorldYamlLoader
-from pyrobosim.navigation.rrt import RRTPlanner
+from pyrobosim.navigation.prm import PRMPlanner
 from pyrobosim.utils.general import get_data_folder
 from pyrobosim.utils.pose import Pose
 
@@ -12,19 +12,19 @@ loader = WorldYamlLoader()
 w = loader.from_yaml(os.path.join(data_folder, "test_world.yaml"))
 
 
-def test_rrt():
+def test_prm():
     # Create an RRT planner and plan
-    rrt = RRTPlanner(w, bidirectional=True, rrt_connect=False, rrt_star=True)
+    prm = PRMPlanner(w, max_nodes=100, max_connection_dist=1.5)
     start = Pose(x=-0.5, y=-0.5)
     goal = Pose(x=3.0, y=3.0)
     w.robot.set_pose(start)
-    w.robot.set_path_planner(rrt)
+    w.robot.set_path_planner(prm)
     w.current_path = w.robot.plan_path(start, goal)
-    rrt.print_metrics()
+    prm.print_metrics()
 
 
 if __name__=="__main__":
-    test_rrt()
+    test_prm()
 
     import sys
     from pyrobosim.gui.main import PyRoboSimGUI

--- a/pyrobosim/examples/test_prm.py
+++ b/pyrobosim/examples/test_prm.py
@@ -6,14 +6,14 @@ from pyrobosim.navigation.prm import PRMPlanner
 from pyrobosim.utils.general import get_data_folder
 from pyrobosim.utils.pose import Pose
 
-# Load a world
+# Load a test world.
 data_folder = get_data_folder()
 loader = WorldYamlLoader()
 w = loader.from_yaml(os.path.join(data_folder, "test_world.yaml"))
 
 
 def test_prm():
-    # Create an RRT planner and plan
+    """ Creates a PRM planner and plans """
     prm = PRMPlanner(w, max_nodes=100, max_connection_dist=1.5)
     start = Pose(x=-0.5, y=-0.5)
     goal = Pose(x=3.0, y=3.0)

--- a/pyrobosim/examples/test_prm.py
+++ b/pyrobosim/examples/test_prm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 
 from pyrobosim.core.yaml import WorldYamlLoader

--- a/pyrobosim/examples/test_rrt.py
+++ b/pyrobosim/examples/test_rrt.py
@@ -3,7 +3,6 @@ import os
 
 from pyrobosim.core.yaml import WorldYamlLoader
 from pyrobosim.navigation.rrt import RRTPlanner
-from pyrobosim.navigation.trajectory import fill_path_yaws
 from pyrobosim.utils.general import get_data_folder
 from pyrobosim.utils.pose import Pose
 
@@ -13,15 +12,15 @@ if __name__=="__main__":
     data_folder = get_data_folder()
     loader = WorldYamlLoader()
     w = loader.from_yaml(os.path.join(data_folder, "test_world.yaml"))
-    w.search_graph = None
+    w.search_graph = w.path_planner = None
 
     # Create an RRT planner and plan
-    rrt = RRTPlanner(w, bidirectional=True, rrt_connect=True, rrt_star=True)
+    rrt = RRTPlanner(w, bidirectional=True, rrt_connect=False, rrt_star=True)
     start = Pose(x=-0.5, y=-0.5)
     goal = Pose(x=3.0, y=3.0)
     w.robot.set_pose(start)
-    w.current_path = rrt.plan(start, goal)
-    w.current_path = fill_path_yaws(w.current_path)
+    w.robot.set_path_planner(rrt)
+    w.current_path = w.robot.plan_path(start, goal)
 
     print("PATH:")
     for n in w.current_path:
@@ -31,30 +30,8 @@ if __name__=="__main__":
     print(f"Time to plan: {rrt.planning_time} seconds")
     print(f"Number of rewires: {rrt.n_rewires}")
 
-    # Plot hacks: Make this work with the GUI
-    from pyrobosim.gui.world_canvas import WorldCanvas
-    import matplotlib.pyplot as plt
-    wc = WorldCanvas(w)
-
-    managed_fig = plt.figure()
-    canvas_manager = managed_fig.canvas.manager
-    canvas_manager.canvas.figure = wc.fig
-    wc.fig.set_canvas(canvas_manager.canvas)
-
-    wc.show()
-
-    # Plot the RRT
-    for e in rrt.graph.edges:
-        x = (e.n0.pose.x, e.n1.pose.x)
-        y = (e.n0.pose.y, e.n1.pose.y)
-        wc.axes.plot(x, y, "k:", linewidth=1)
-    if rrt.bidirectional:
-        for e in rrt.graph_goal.edges:
-            x = (e.n0.pose.x, e.n1.pose.x)
-            y = (e.n0.pose.y, e.n1.pose.y)
-            wc.axes.plot(x, y, "b--", linewidth=1)
-    
-
-    plt.show()
-
+    import sys
+    from pyrobosim.gui.main import PyRoboSimGUI
+    app = PyRoboSimGUI(w, sys.argv)
+    sys.exit(app.exec_())
     

--- a/pyrobosim/examples/test_rrt.py
+++ b/pyrobosim/examples/test_rrt.py
@@ -16,13 +16,20 @@ if __name__=="__main__":
     w.search_graph = None
 
     # Create an RRT planner and plan
-    rrt = RRTPlanner(w, bidirectional=True, rrt_star=True)
+    rrt = RRTPlanner(w, bidirectional=True, rrt_connect=True, rrt_star=True)
     start = Pose(x=-0.5, y=-0.5)
     goal = Pose(x=3.0, y=3.0)
     w.robot.set_pose(start)
     w.current_path = rrt.plan(start, goal)
     w.current_path = fill_path_yaws(w.current_path)
-    print([n.pose for n in w.current_path])
+
+    print("PATH:")
+    for n in w.current_path:
+        print(n.pose)
+    print("")
+    print(f"Nodes sampled: {rrt.nodes_sampled}")
+    print(f"Time to plan: {rrt.planning_time} seconds")
+    print(f"Number of rewires: {rrt.n_rewires}")
 
     # Plot hacks: Make this work with the GUI
     from pyrobosim.gui.world_canvas import WorldCanvas

--- a/pyrobosim/examples/test_rrt.py
+++ b/pyrobosim/examples/test_rrt.py
@@ -16,9 +16,9 @@ if __name__=="__main__":
     w.search_graph = None
 
     # Create an RRT planner and plan
-    rrt = RRTPlanner(w)
+    rrt = RRTPlanner(w, rrt_star=True)
     start = Pose(x=0.5, y=0.5)
-    goal = Pose(x=3, y=3)
+    goal = Pose(x=3.0, y=3.0)
     w.robot.set_pose(start)
     w.current_path = rrt.plan(start, goal, plot=True)
     w.current_path = fill_path_yaws(w.current_path)

--- a/pyrobosim/examples/test_rrt.py
+++ b/pyrobosim/examples/test_rrt.py
@@ -6,14 +6,14 @@ from pyrobosim.navigation.rrt import RRTPlanner
 from pyrobosim.utils.general import get_data_folder
 from pyrobosim.utils.pose import Pose
 
-# Load a world
+# Load a test world.
 data_folder = get_data_folder()
 loader = WorldYamlLoader()
 w = loader.from_yaml(os.path.join(data_folder, "test_world.yaml"))
 
 
 def test_rrt():
-    # Create an RRT planner and plan
+    """ Creates an RRT planner and plans """
     rrt = RRTPlanner(w, bidirectional=True, rrt_connect=False, rrt_star=True)
     start = Pose(x=-0.5, y=-0.5)
     goal = Pose(x=3.0, y=3.0)

--- a/pyrobosim/examples/test_rrt.py
+++ b/pyrobosim/examples/test_rrt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 
 from pyrobosim.core.yaml import WorldYamlLoader

--- a/pyrobosim/examples/test_rrt.py
+++ b/pyrobosim/examples/test_rrt.py
@@ -16,11 +16,11 @@ if __name__=="__main__":
     w.search_graph = None
 
     # Create an RRT planner and plan
-    rrt = RRTPlanner(w, rrt_star=True)
-    start = Pose(x=0.5, y=0.5)
+    rrt = RRTPlanner(w, bidirectional=True, rrt_star=True)
+    start = Pose(x=-0.5, y=-0.5)
     goal = Pose(x=3.0, y=3.0)
     w.robot.set_pose(start)
-    w.current_path = rrt.plan(start, goal, plot=True)
+    w.current_path = rrt.plan(start, goal)
     w.current_path = fill_path_yaws(w.current_path)
     print([n.pose for n in w.current_path])
 
@@ -41,6 +41,11 @@ if __name__=="__main__":
         x = (e.n0.pose.x, e.n1.pose.x)
         y = (e.n0.pose.y, e.n1.pose.y)
         wc.axes.plot(x, y, "k:", linewidth=1)
+    if rrt.bidirectional:
+        for e in rrt.graph_goal.edges:
+            x = (e.n0.pose.x, e.n1.pose.x)
+            y = (e.n0.pose.y, e.n1.pose.y)
+            wc.axes.plot(x, y, "b--", linewidth=1)
     
 
     plt.show()

--- a/pyrobosim/examples/test_rrt.py
+++ b/pyrobosim/examples/test_rrt.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+import os
+
+from pyrobosim.core.yaml import WorldYamlLoader
+from pyrobosim.navigation.rrt import RRTPlanner
+from pyrobosim.navigation.trajectory import fill_path_yaws
+from pyrobosim.utils.general import get_data_folder
+from pyrobosim.utils.pose import Pose
+
+if __name__=="__main__":
+
+    # Load a world
+    data_folder = get_data_folder()
+    loader = WorldYamlLoader()
+    w = loader.from_yaml(os.path.join(data_folder, "test_world.yaml"))
+    w.search_graph = None
+
+    # Create an RRT planner and plan
+    rrt = RRTPlanner(w)
+    start = Pose(x=0.5, y=0.5)
+    goal = Pose(x=3, y=3)
+    w.robot.set_pose(start)
+    w.current_path = rrt.plan(start, goal, plot=True)
+    w.current_path = fill_path_yaws(w.current_path)
+    print([n.pose for n in w.current_path])
+
+    # Plot hacks: Make this work with the GUI
+    from pyrobosim.gui.world_canvas import WorldCanvas
+    import matplotlib.pyplot as plt
+    wc = WorldCanvas(w)
+
+    managed_fig = plt.figure()
+    canvas_manager = managed_fig.canvas.manager
+    canvas_manager.canvas.figure = wc.fig
+    wc.fig.set_canvas(canvas_manager.canvas)
+
+    wc.show()
+
+    # Plot the RRT
+    for e in rrt.graph.edges:
+        x = (e.n0.pose.x, e.n1.pose.x)
+        y = (e.n0.pose.y, e.n1.pose.y)
+        wc.axes.plot(x, y, "k:", linewidth=1)
+    
+
+    plt.show()
+
+    

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -14,8 +14,8 @@ from ..utils.pose import Pose
 class Robot:
     """ Representation of a robot in the world. """
 
-    def __init__(self, id=0, name="robot", pose=Pose(), 
-                 radius=0.0, height=0.0, path_executor=None):
+    def __init__(self, id=0, name="robot", pose=Pose(), radius=0.0, height=0.0, 
+                 path_planner=None, path_executor=None):
         """ 
         Creates a robot instance.
         
@@ -29,6 +29,8 @@ class Robot:
         :type radius: float, optional
         :param height: Robot height, in meters.
         :type height: float, optional
+        :param path_planner: Path planner for navigation (see e.g. :class:`pyrobosim.navigation.rrt.RRTPlanner`).
+        :type path_planner: PathPlanner, optional
         :param path_executor: Path executor for navigation (see e.g. :class:`pyrobosim.navigation.execution.ConstantVelocityExecutor`).
         :type path_executor: PathExecutor, optional
         """
@@ -40,6 +42,7 @@ class Robot:
         self.height = height
 
         # Navigation properties
+        self.set_path_planner(path_planner)
         self.set_path_executor(path_executor)
         self.executing_nav = False
 
@@ -61,6 +64,31 @@ class Robot:
         """
         self.pose = pose
 
+    def set_path_planner(self, path_planner):
+        """
+        Sets a path planner for navigation.
+        
+        :param path_planner: Path planner for navigation (see e.g. :class:`pyrobosim.navigation.rrt.RRTPlanner`).
+        :type path_planner: PathPlanner, optional
+        """
+        self.path_planner = path_planner
+
+    def plan_path(self, start=None, goal=None):
+        """
+        Plans a path to a goal position.
+
+        :param start: Start pose for the robot. If not specified, will default to the robot pose.
+        :type start: :class:`pyrobosim.utils.pose.Pose`, optional
+        :param goal: Goal pose for the robot. If not specified, will return None.
+        :type goal: :class:`pyrobosim.utils.pose.Pose`, optional
+        """
+        if start is None:
+            start = self.pose
+        if goal is None:
+            warnings.warn("Did no specify a path planning goal. Returning None.")
+            return None
+        return self.path_planner.plan(start, goal)
+
     def set_path_executor(self, path_executor):
         """ 
         Sets a path executor for navigation.
@@ -68,10 +96,10 @@ class Robot:
         :param path_executor: Path executor for navigation (see e.g. :class:`pyrobosim.navigation.execution.ConstantVelocityExecutor`).
         :type path_executor: PathExecutor, optional        
         """
+        self.path_executor = path_executor
         if path_executor is None:
             return
         path_executor.robot = self
-        self.path_executor = path_executor
 
     def follow_path(self, path, realtime_factor=1.0, 
                     use_thread=True, blocking=False):

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -488,7 +488,7 @@ class World:
         return True
 
     def create_search_graph(self, max_edge_dist=np.inf, collision_check_dist=0.1,
-                            create_planner=True):
+                            create_planner=False):
         """ 
         Creates a search graph for the world, as a :class:`pyrobosim.navigation.search_graph.SearchGraph` attribute.
         

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -575,11 +575,11 @@ class World:
             # Plan with the robot's global planner.
             self.current_path = self.path_planner.plan(start_node, goal_node)
 
-            # If we created temporary nodes for search, remove them
-            if created_start_node:
-                self.search_graph.remove(start_node)
-            if created_goal_node:
-                self.search_graph.remove(goal_node)
+        # If we created temporary nodes for search, remove them
+        if created_start_node:
+            self.search_graph.remove(start_node)
+        if created_goal_node:
+            self.search_graph.remove(goal_node)
 
         else:
             warnings.warn("No global or local path planners specified.")

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -582,7 +582,7 @@ class World:
             self.search_graph.remove(start_node)
         if created_goal_node:
             self.search_graph.remove(goal_node)
-        
+
         return self.current_path
 
     def graph_node_from_entity(self, entity_query, resolution_strategy="nearest"):

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -570,20 +570,18 @@ class World:
             self.current_path = self.robot.path_planner.plan(start, goal)
             if self.current_path is not None:
                 self.current_path[-1].parent = goal_node.parent
-
         elif self.path_planner:
             # Plan with the robot's global planner.
             self.current_path = self.path_planner.plan(start_node, goal_node)
+        else:
+            warnings.warn("No global or local path planners specified.")
+            return None
 
         # If we created temporary nodes for search, remove them
         if created_start_node:
             self.search_graph.remove(start_node)
         if created_goal_node:
             self.search_graph.remove(goal_node)
-
-        else:
-            warnings.warn("No global or local path planners specified.")
-            return None
         
         return self.current_path
 
@@ -605,6 +603,8 @@ class World:
         if isinstance(entity_query, Node):
             return entity_query
         elif isinstance(entity_query, str):
+            # Try resolve an entity based on its name. If that fails, we assume it must be a category,
+            # so try resolve it to a location or to an object by category.
             entity = self.get_entity_by_name(entity_query)
             if entity is None:
                 entity = resolve_to_location(self, category=entity_query,

--- a/pyrobosim/pyrobosim/core/yaml.py
+++ b/pyrobosim/pyrobosim/core/yaml.py
@@ -182,7 +182,7 @@ class WorldYamlLoader:
             max_edge_dist = get_value_or(planning, "max_edge_dist", default=np.inf)
             collision_check_dist = get_value_or(planning, "collision_check_dist", default=0.1)
             self.world.create_search_graph(
-                max_edge_dist=max_edge_dist, collision_check_dist=collision_check_dist)
+                max_edge_dist=max_edge_dist, collision_check_dist=collision_check_dist, create_planner=True)
         else:
             warnings.warn(f"Invalid global planner type specified: {planner_type}")
 

--- a/pyrobosim/pyrobosim/core/yaml.py
+++ b/pyrobosim/pyrobosim/core/yaml.py
@@ -49,8 +49,8 @@ class WorldYamlLoader:
         self.add_hallways()
         self.add_locations()
         self.add_objects()
+        self.add_global_path_planner()
         self.add_robot()
-        self.add_global_planner()
         return self.world
 
 
@@ -158,8 +158,10 @@ class WorldYamlLoader:
             warnings.warn("Multiple robots not supported. Only using the first one.")
         robot_data = self.data["robots"][0]
 
-        from pyrobosim.navigation.execution import ConstantVelocityExecutor
-        robot = Robot(radius=robot_data["radius"], path_executor=ConstantVelocityExecutor())
+        # Create the robot
+        robot = Robot(radius=robot_data["radius"],
+                      path_planner=self.get_local_path_planner(robot_data),
+                      path_executor=self.get_path_executor(robot_data))
         
         loc = robot_data["location"] if "location" in robot_data else None
         if "pose" in robot_data:
@@ -169,12 +171,12 @@ class WorldYamlLoader:
         self.world.add_robot(robot, loc=loc, pose=pose)
 
 
-    def add_global_planner(self):
+    def add_global_path_planner(self):
         """ Adds a global path planner to the world. """
-        if "planning" not in self.data or "planner_type" not in self.data["planning"]:
+        if "global_path_planner" not in self.data or "type" not in self.data["global_path_planner"]:
             return
-        planning = self.data["planning"]
-        planner_type = planning["planner_type"]
+        planning = self.data["global_path_planner"]
+        planner_type = planning["type"]
         
         if planner_type == "search_graph":
             max_edge_dist = get_value_or(planning, "max_edge_dist", default=np.inf)
@@ -182,4 +184,34 @@ class WorldYamlLoader:
             self.world.create_search_graph(
                 max_edge_dist=max_edge_dist, collision_check_dist=collision_check_dist)
         else:
+            warnings.warn(f"Invalid global planner type specified: {planner_type}")
+
+
+    def get_local_path_planner(self, robot_data):
+        """ Gets local planner path planner to a robot. """
+        if "path_planner" not in robot_data:
+            return None
+        planner_data = robot_data["path_planner"]
+        planner_type = planner_data["type"]
+
+        if planner_type == "rrt":
+            from pyrobosim.navigation.rrt import RRTPlanner
+            bidirectional = get_value_or(planner_data, "bidirectional", default=False)
+            rrt_star = get_value_or(planner_data, "rrt_star", default=False)
+            rrt_connect = get_value_or(planner_data, "rrt_connect", default=False)
+            max_connection_dist = get_value_or(planner_data, "max_connection_dist", default=0.5)
+            max_nodes_sampled = get_value_or(planner_data, "max_nodes_sampled", default=1000)
+            max_time = get_value_or(planner_data, "max_time", default=5.0)
+            rewire_radius = get_value_or(planner_data, "rewire_radius", default=1.0)
+            return RRTPlanner(self.world, bidirectional=bidirectional, rrt_star=rrt_star, rrt_connect=rrt_connect,
+                              max_connection_dist=max_connection_dist, max_nodes_sampled=max_nodes_sampled,
+                              max_time=max_time, rewire_radius=rewire_radius)
+        else:
             warnings.warn(f"Invalid planner type specified: {planner_type}")
+            return None
+
+
+    def get_path_executor(self, robot_data):
+        """ Adds a path executor to a robot. """
+        from pyrobosim.navigation.execution import ConstantVelocityExecutor
+        return ConstantVelocityExecutor()

--- a/pyrobosim/pyrobosim/core/yaml.py
+++ b/pyrobosim/pyrobosim/core/yaml.py
@@ -50,7 +50,7 @@ class WorldYamlLoader:
         self.add_locations()
         self.add_objects()
         self.add_robot()
-        self.add_planner()
+        self.add_global_planner()
         return self.world
 
 
@@ -169,7 +169,7 @@ class WorldYamlLoader:
         self.world.add_robot(robot, loc=loc, pose=pose)
 
 
-    def add_planner(self):
+    def add_global_planner(self):
         """ Adds a global path planner to the world. """
         if "planning" not in self.data or "planner_type" not in self.data["planning"]:
             return

--- a/pyrobosim/pyrobosim/data/test_world.yaml
+++ b/pyrobosim/pyrobosim/data/test_world.yaml
@@ -23,7 +23,7 @@ robots:
     pose: [0, 0, 0]
     path_planner:
       type: rrt
-      max_connection_dist: 0.5
+      max_connection_dist: 0.25
       bidirectional: true
       rrt_star: true
       rewire_radius: 1.0
@@ -47,7 +47,7 @@ rooms:
         - [1.5, 1.5]
         - [0.5, 1.5]
     nav_poses:
-      - [0.75, 0.75, 0.0]
+      - [0.75, 0.5, 0.0]
     wall_width: 0.2
     color: [1, 0, 0]
 

--- a/pyrobosim/pyrobosim/data/test_world.yaml
+++ b/pyrobosim/pyrobosim/data/test_world.yaml
@@ -21,19 +21,25 @@ robots:
     radius: 0.1
     location: kitchen
     pose: [0, 0, 0]
-    path_planner:
-      type: rrt
-      max_connection_dist: 0.25
-      bidirectional: true
-      rrt_star: true
-      rewire_radius: 1.0
+    # Rapidly-expanding Random Tree (RRT) planner
+    # path_planner:
+    #   type: rrt
+    #   max_connection_dist: 0.25
+    #   bidirectional: true
+    #   rrt_star: true
+    #   rewire_radius: 1.0
 
 
 # PLANNING: Global planner
 global_path_planner:
-  type: search_graph # The only one for now
+  # Search graph planner from manually specified nodes
+  type: search_graph
   max_edge_dist: 3.0
   collision_check_dist: 0.05
+  # Probabilistic Roadmap (PRM) planner
+  # type: prm
+  # max_connection_dist: 1.5
+  # max_nodes: 100
 
 
 # ROOMS: Polygonal regions that can contain object locations

--- a/pyrobosim/pyrobosim/data/test_world.yaml
+++ b/pyrobosim/pyrobosim/data/test_world.yaml
@@ -21,11 +21,17 @@ robots:
     radius: 0.1
     location: kitchen
     pose: [0, 0, 0]
+    path_planner:
+      type: rrt
+      max_connection_dist: 0.5
+      bidirectional: true
+      rrt_star: true
+      rewire_radius: 1.0
 
 
 # PLANNING: Global planner
-planning:
-  planner_type: search_graph # The only one for now
+global_path_planner:
+  type: search_graph # The only one for now
   max_edge_dist: 3.0
   collision_check_dist: 0.05
 

--- a/pyrobosim/pyrobosim/gui/main.py
+++ b/pyrobosim/pyrobosim/gui/main.py
@@ -143,8 +143,6 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):
         if sampled_pose is not None:
             self.world.robot.set_pose(sampled_pose)
         self.canvas.update_robot_plot()
-        self.world.current_path = None
-        self.canvas.show_path()
         self.canvas.show_world_state(navigating=True)
         self.canvas.draw()
 

--- a/pyrobosim/pyrobosim/gui/main.py
+++ b/pyrobosim/pyrobosim/gui/main.py
@@ -142,6 +142,8 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):
         sampled_pose = self.world.sample_free_robot_pose_uniform()
         if sampled_pose is not None:
             self.world.robot.set_pose(sampled_pose)
+            if self.world.robot.manipulated_object is not None:
+                self.world.robot.manipulated_object.pose = sampled_pose
         self.canvas.update_robot_plot()
         self.canvas.show_world_state(navigating=True)
         self.canvas.draw()

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -125,8 +125,8 @@ class WorldCanvas(FigureCanvasQTAgg):
                 y = (e.n0.pose.y, e.n1.pose.y)
                 graph_edges.append(self.axes.plot(x, y, "k:", linewidth=1))
 
-            # Plot the path if specified
-            self.show_path()
+        # Plot the path if specified
+        self.show_path()
 
         # Update the robot length
         self.robot_length = self.robot_normalized_length * max(

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -51,7 +51,7 @@ class WorldCanvas(FigureCanvasQTAgg):
         self.robot_body = None
         self.robot_dir = None
         self.animated_artists = [self.robot_body, self.robot_dir]
-        self.path_planner_entities = []
+        self.path_planner_artists = []
 
         # Debug displays (TODO: Should be available from GUI)
         self.show_collision_polygons = False
@@ -114,14 +114,8 @@ class WorldCanvas(FigureCanvasQTAgg):
         self.obj_patches = [o.viz_patch for o in (self.world.objects)]
         self.obj_texts = [o.viz_text for o in (self.world.objects)]
 
-        # Plot the path planner and latest path, if specified.
-        # This planner could be global (property of the world) or local (property of the robot).
-        if self.world.path_planner:
-            self.world.path_planner.plot(self.axes)
-        if self.world.robot.path_planner:
-            for e in self.path_planner_entities:
-                self.axes.lines.remove(e)
-            self.path_planner_entities = self.world.robot.path_planner.plot(self.axes)
+        # Path planner and path
+        self.show_planner_and_path()
 
         # Update the robot length
         self.robot_length = self.robot_normalized_length * max(
@@ -157,40 +151,16 @@ class WorldCanvas(FigureCanvasQTAgg):
         adjustText.adjust_text(objs, lim=100,
                                add_objects=self.obj_patches)
 
-    def show_path(self, path=None):
-        """ 
-        Displays a path that the robot will follow for navigation. 
-        
-        :param path: A list of Pose objects defining the path. 
-        :type path: list[:class:`pyrobosim.utils.pose.Pose`], optional
-        """
-        if path is None:
-            path = self.world.current_path
+    def show_planner_and_path(self):
+        # Plot the path planner and latest path, if specified.
+        # This planner could be global (property of the world) or local (property of the robot).
+        for e in self.path_planner_artists:
+            self.axes.lines.remove(e)
 
-        if path is not None:
-            x = [p.pose.x for p in self.world.current_path]
-            y = [p.pose.y for p in self.world.current_path]
-
-            if self.displayed_path is None:
-                self.displayed_path, = self.axes.plot(
-                    x, y, "m-", linewidth=3, zorder=1)
-                self.displayed_path_start, = self.axes.plot(x[0], y[0], "go", zorder=2)
-                self.displayed_path_goal, = self.axes.plot(x[-1], y[-1], "rx", zorder=2)
-            else:
-                self.displayed_path.set_xdata(x)
-                self.displayed_path.set_ydata(y)
-                self.displayed_path.set_visible(True)
-                self.displayed_path_start.set_xdata(x[0])
-                self.displayed_path_start.set_ydata(y[0])
-                self.displayed_path_start.set_visible(True)
-                self.displayed_path_goal.set_xdata(x[-1])
-                self.displayed_path_goal.set_ydata(y[-1])
-                self.displayed_path_goal.set_visible(True)
-        else:
-            if self.displayed_path is not None:
-                self.displayed_path.set_visible(False)
-                self.displayed_path_start.set_visible(False)
-                self.displayed_path_goal.set_visible(False)
+        if self.world.robot.path_planner:
+            self.path_planner_artists = self.world.robot.path_planner.plot(self.axes)
+        elif self.world.path_planner:
+            self.path_planner_artists = self.world.path_planner.plot(self.axes)
 
     def update_robot_plot(self):
         """ Updates the robot visualization graphics objects. """
@@ -255,11 +225,7 @@ class WorldCanvas(FigureCanvasQTAgg):
         """
         # Find a path and kick off the navigation thread
         path = self.world.find_path(goal)
-        if self.world.robot.path_planner:
-            for e in self.path_planner_entities:
-                self.axes.lines.remove(e)
-            self.path_planner_entities = self.world.robot.path_planner.plot(self.axes)
-        self.show_path(path)
+        self.show_planner_and_path()
         self.world.robot.follow_path(
             path, realtime_factor=self.realtime_factor)
 

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -171,6 +171,7 @@ class WorldCanvas(FigureCanvasQTAgg):
             p.x + np.array([0, self.robot_length*np.cos(p.yaw)]))
         self.robot_dir.set_ydata(
             p.y + np.array([0, self.robot_length*np.sin(p.yaw)]))
+        self.update_object_plot(self.world.robot.manipulated_object)
 
     def show_world_state(self, navigating=False):
         """

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -51,6 +51,7 @@ class WorldCanvas(FigureCanvasQTAgg):
         self.robot_body = None
         self.robot_dir = None
         self.animated_artists = [self.robot_body, self.robot_dir]
+        self.path_planner_entities = []
 
         # Debug displays (TODO: Should be available from GUI)
         self.show_collision_polygons = False
@@ -113,20 +114,14 @@ class WorldCanvas(FigureCanvasQTAgg):
         self.obj_patches = [o.viz_patch for o in (self.world.objects)]
         self.obj_texts = [o.viz_text for o in (self.world.objects)]
 
-        # Search graph
-        if self.world.search_graph is not None:
-            x = [n.pose.x for n in self.world.search_graph.nodes]
-            y = [n.pose.y for n in self.world.search_graph.nodes]
-            graph_nodes = self.axes.scatter(x, y, 15, "k")
-
-            graph_edges = []
-            for e in self.world.search_graph.edges:
-                x = (e.n0.pose.x, e.n1.pose.x)
-                y = (e.n0.pose.y, e.n1.pose.y)
-                graph_edges.append(self.axes.plot(x, y, "k:", linewidth=1))
-
-        # Plot the path if specified
-        self.show_path()
+        # Plot the path planner and latest path, if specified.
+        # This planner could be global (property of the world) or local (property of the robot).
+        if self.world.path_planner:
+            self.world.path_planner.plot(self.axes)
+        if self.world.robot.path_planner:
+            for e in self.path_planner_entities:
+                self.axes.lines.remove(e)
+            self.path_planner_entities = self.world.robot.path_planner.plot(self.axes)
 
         # Update the robot length
         self.robot_length = self.robot_normalized_length * max(
@@ -179,17 +174,17 @@ class WorldCanvas(FigureCanvasQTAgg):
             if self.displayed_path is None:
                 self.displayed_path, = self.axes.plot(
                     x, y, "m-", linewidth=3, zorder=1)
-                self.displayed_path_start = self.axes.scatter(
-                    x[0], y[0], 60, "g", "o", zorder=2)
-                self.displayed_path_goal = self.axes.scatter(
-                    x[-1], y[-1], 60, "r", "x", zorder=2)
+                self.displayed_path_start, = self.axes.plot(x[0], y[0], "go", zorder=2)
+                self.displayed_path_goal, = self.axes.plot(x[-1], y[-1], "rx", zorder=2)
             else:
                 self.displayed_path.set_xdata(x)
                 self.displayed_path.set_ydata(y)
-                self.displayed_path_start.set_offsets((x[0], y[0]))
-                self.displayed_path_goal.set_offsets((x[-1], y[-1]))
                 self.displayed_path.set_visible(True)
+                self.displayed_path_start.set_xdata(x[0])
+                self.displayed_path_start.set_ydata(y[0])
                 self.displayed_path_start.set_visible(True)
+                self.displayed_path_goal.set_xdata(x[-1])
+                self.displayed_path_goal.set_ydata(y[-1])
                 self.displayed_path_goal.set_visible(True)
         else:
             if self.displayed_path is not None:
@@ -260,6 +255,10 @@ class WorldCanvas(FigureCanvasQTAgg):
         """
         # Find a path and kick off the navigation thread
         path = self.world.find_path(goal)
+        if self.world.robot.path_planner:
+            for e in self.path_planner_entities:
+                self.axes.lines.remove(e)
+            self.path_planner_entities = self.world.robot.path_planner.plot(self.axes)
         self.show_path(path)
         self.world.robot.follow_path(
             path, realtime_factor=self.realtime_factor)

--- a/pyrobosim/pyrobosim/navigation/prm.py
+++ b/pyrobosim/pyrobosim/navigation/prm.py
@@ -1,16 +1,26 @@
-"""
-Implementation of Probabilistic Roadmaps (PRM) for motion planning.
-"""
-
 import time
 import warnings
 
-from .search_graph import SearchGraph, Node, Edge
+from .search_graph import SearchGraph, Node
 from .trajectory import fill_path_yaws
 from ..utils.pose import Pose
 
+
 class PRMPlanner:
+    """
+    Implementation of Probabilistic Roadmaps (PRM) for motion planning.
+    """
     def __init__(self, world, max_nodes=100, max_connection_dist=2.0):
+        """
+        Creates an instance of a PRM planner.
+
+        :param world: World object to use in the planner.
+        :type world: :class:`pyrobosim.core.world.World`
+        :param max_nodes: Maximum nodes sampled to build the PRM.
+        :type max_nodes: int
+        :param max_connection_dist: Maximum connection distance between two nodes.
+        :type max_connection_dist: float
+        """
         # Parameters
         self.max_connection_dist = max_connection_dist
         self.max_nodes = max_nodes
@@ -24,7 +34,7 @@ class PRMPlanner:
 
 
     def reset(self):
-        """ Resets the search trees and planning metrics. """
+        """ Resamples the PRM and resets planning metrics. """
         self.planning_time = self.sampling_time = 0.0
         self.latest_path = None
 
@@ -42,7 +52,16 @@ class PRMPlanner:
         
 
     def plan(self, start, goal):
-        """ Plan a path from start to goal. """
+        """ 
+        Plans a path from start to goal. 
+        
+        :param start: Start pose or graph node.
+        :type start: :class:`pyrobosim.utils.pose.Pose` / :class:`pyrobosim.navigation.search_graph.Node`
+        :param goal: Goal pose or graph node.
+        :type goal: :class:`pyrobosim.utils.pose.Pose` / :class:`pyrobosim.navigation.search_graph.Node`
+        :return: List of graph Node objects describing the path, or None if not found.
+        :rtype: list[:class:`pyrobosim.navigation.search_graph.Node`] 
+        """
         # Create the start and goal nodes
         if isinstance(start, Pose):
             start = Node(start, parent=None)
@@ -61,13 +80,18 @@ class PRMPlanner:
 
 
     def sample_configuration(self):
-        """ Sample a random configuration from the world. """
+        """ 
+        Samples a random configuration from the world.
+        
+        :return: Collision-free pose if found, else ``None``.
+        :rtype: :class:`pyrobosim.utils.pose.Pose`
+        """
         return self.world.sample_free_robot_pose_uniform()
 
 
     def print_metrics(self):
         """
-        Print metrics about the latest path.
+        Print metrics about the latest path computed
         """
         if self.latest_path is None:
             print("No path.")
@@ -80,9 +104,19 @@ class PRMPlanner:
         print(f"Time to sample nodes: {self.sampling_time} seconds")
         print(f"Time to plan: {self.planning_time} seconds")
 
+
     def plot(self, axes, show_graph=True, show_path=True):
         """
-        Plots the PRM graph on a specified set of axes
+        Plots the PRM and the planned path on a specified set of axes.
+
+        :param axes: The axes on which to draw.
+        :type axes: :class:`matplotlib.axes.Axes`
+        :param show_graph: If True, shows the RRTs used for planning.
+        :type show_graph: bool
+        :param show_path: If True, shows the last planned path.
+        :type show_path: bool
+        :return: List of Matplotlib artists containing what was drawn, used for bookkeeping.
+        :rtype: list[:class:`matplotlib.artist.Artist`]
         """
         artists = []
         if show_graph:
@@ -104,9 +138,15 @@ class PRMPlanner:
 
         return artists
 
+
     def show(self, show_graph=True, show_path=True):
         """
-        Shows the PRM in a new figure.
+        Shows the PRM and the planned path in a new figure.
+
+        :param show_graph: If True, shows the RRTs used for planning.
+        :type show_graph: bool
+        :param show_path: If True, shows the last planned path.
+        :type show_path: bool
         """
         import matplotlib.pyplot as plt
         f = plt.figure()

--- a/pyrobosim/pyrobosim/navigation/prm.py
+++ b/pyrobosim/pyrobosim/navigation/prm.py
@@ -1,0 +1,117 @@
+"""
+Implementation of Probabilistic Roadmaps (PRM) for motion planning.
+"""
+
+import time
+import warnings
+
+from .search_graph import SearchGraph, Node, Edge
+from .trajectory import fill_path_yaws
+from ..utils.pose import Pose
+
+class PRMPlanner:
+    def __init__(self, world, max_nodes=100, max_connection_dist=2.0):
+        # Parameters
+        self.max_connection_dist = max_connection_dist
+        self.max_nodes = max_nodes
+
+        # Visualization
+        self.color = [0, 0.4, 0.8]
+        self.color_alpha = 0.25
+
+        self.world = world
+        self.reset()
+
+
+    def reset(self):
+        """ Resets the search trees and planning metrics. """
+        self.planning_time = self.sampling_time = 0.0
+        self.latest_path = None
+
+        # Create a search graph and sample nodes.
+        self.graph = SearchGraph(
+            world=self.world, max_edge_dist=self.max_connection_dist)
+        t_start = time.time()
+        for i in range(self.max_nodes):
+            n_sample = self.sample_configuration()
+            if not n_sample:
+                warnings.warn(f"Could not sample more than {i} nodes")
+                break
+            self.graph.add(Node(n_sample), autoconnect=True)
+        self.sampling_time = time.time() - t_start
+        
+
+    def plan(self, start, goal):
+        """ Plan a path from start to goal. """
+        # Create the start and goal nodes
+        if isinstance(start, Pose):
+            start = Node(start, parent=None)
+        self.graph.add(start, autoconnect=True)
+        if isinstance(goal, Pose):  
+            goal = Node(goal, parent=None)
+        self.graph.add(goal, autoconnect=True)
+
+        # Find a path from start to goal nodes
+        t_start = time.time()
+        path = self.graph.find_path(start, goal)
+        path = fill_path_yaws(path)
+        self.planning_time = time.time() - t_start
+        self.latest_path = path
+        return self.latest_path       
+
+
+    def sample_configuration(self):
+        """ Sample a random configuration from the world. """
+        return self.world.sample_free_robot_pose_uniform()
+
+
+    def print_metrics(self):
+        """
+        Print metrics about the latest path.
+        """
+        if self.latest_path is None:
+            print("No path.")
+            return
+
+        print("Latest path from PRM:")
+        for n in self.latest_path:
+            print(n.pose)
+        print("")
+        print(f"Time to sample nodes: {self.sampling_time} seconds")
+        print(f"Time to plan: {self.planning_time} seconds")
+
+    def plot(self, axes, show_graph=True, show_path=True):
+        """
+        Plots the PRM graph on a specified set of axes
+        """
+        artists = []
+        if show_graph:
+            for e in self.graph.edges:
+                x = (e.n0.pose.x, e.n1.pose.x)
+                y = (e.n0.pose.y, e.n1.pose.y)
+                edge, = axes.plot(x, y, color=self.color, alpha=self.color_alpha,
+                                  linewidth=0.5, marker="o", markerfacecolor=self.color,
+                                  markeredgecolor=self.color, markersize=3, zorder=1)
+                artists.append(edge)
+        
+        if show_path and self.latest_path is not None:
+            x = [p.pose.x for p in self.latest_path]
+            y = [p.pose.y for p in self.latest_path]
+            path, = axes.plot(x, y, "m-", linewidth=3, zorder=1)
+            start, = axes.plot(x[0], y[0], "go", zorder=2)
+            goal, = axes.plot(x[-1], y[-1], "rx", zorder=2)
+            artists.extend((path, start, goal))
+
+        return artists
+
+    def show(self, show_graph=True, show_path=True):
+        """
+        Shows the PRM in a new figure.
+        """
+        import matplotlib.pyplot as plt
+        f = plt.figure()
+        ax = f.add_subplot(111)
+        self.plot(ax, show_graph=show_graph, show_path=show_path)
+        plt.title("PRM")
+        plt.axis("equal")
+        plt.show()

--- a/pyrobosim/pyrobosim/navigation/rrt.py
+++ b/pyrobosim/pyrobosim/navigation/rrt.py
@@ -10,28 +10,33 @@ from .search_graph import SearchGraph, Node, Edge
 from ..utils.pose import Pose
 
 class RRTPlanner:
-    def __init__(self, world, rrt_star=False):
-        self.max_connection_dist = 1.0
+    def __init__(self, world, bidirectional=False, rrt_star=False):
+        self.max_connection_dist = 0.5
         self.max_nodes_sampled = 1000
         self.max_time = 10
 
         # Algorithm options
+        self.bidirectional = bidirectional
         self.rrt_star = rrt_star
-        self.rewire_radius = 2.0
+        self.rewire_radius = 1.0
 
         self.world = world
         self.reset()
 
     def reset(self):
+        """ Resets the search trees """
         self.graph = SearchGraph(world=self.world)
+        self.graph_goal = SearchGraph(world=self.world)
 
-    def plan(self, start, goal, plot=False):
+    def plan(self, start, goal):
         self.reset()
 
         # Create the start and goal nodes
         n_start = Node(start, parent=None)
         n_goal = Node(goal, parent=None)
         self.graph.nodes = {n_start}
+        if self.bidirectional:
+            self.graph_goal.nodes = {n_goal}
 
         t_start = time.time()
         n_sampled = 0
@@ -40,24 +45,63 @@ class RRTPlanner:
             # Sample a node
             q_sample = self.sample_configuration()
             n_sampled += 1
-            n_near = self.nearest_node(q_sample)
+
+            # Connect aa new node to the parent
+            n_near = self.graph.nearest_node(q_sample)
             n_new = self.new_node(n_near, q_sample)
+            connected_node = self.graph.connect(n_near, n_new)
+            if connected_node:
+                self.graph.nodes.add(n_new)
 
-            # Connect the new node to the parent
-            if not self.graph.connect(n_near, n_new):
-                continue
-            self.graph.nodes.add(n_new)
-
-            # See if the new node can directly connect to the goal
-            goal_dist = n_near.pose.get_linear_distance(n_goal.pose)
-            if goal_dist < self.max_connection_dist and self.graph.connect(n_near, n_goal):
-                n_goal.parent = n_near
-                self.graph.add(n_goal)
-                goal_found = True
+            # If bidirectional, also connect a new node to the parent of the goal graph
+            if self.bidirectional:
+                n_near_goal = self.graph_goal.nearest_node(q_sample)
+                n_new_goal = self.new_node(n_near_goal, q_sample)
+                connected_node_goal = self.graph_goal.connect(n_near_goal, n_new_goal)
+                if connected_node_goal:
+                    self.graph_goal.nodes.add(n_new_goal)
+            else:
+                connected_node_goal = False
 
             # Optional rewire, if RRT* is enabled
             if self.rrt_star:
-                self.rewire_node(n_new)
+                if connected_node:
+                    self.rewire_node(self.graph, n_new)
+                if connected_node_goal:
+                    self.rewire_node(self.graph_goal, n_new_goal)
+
+            # See if the new nodes can directly connect to the goal
+            n_connect_start = None
+            n_connect_goal = None
+            if self.bidirectional:
+                min_dist = self.max_connection_dist
+                if connected_node:
+                    # If we added a node to the start tree, check it against all the goal tree nodes
+                    for n_g in self.graph_goal.nodes:
+                        dist = n_new.pose.get_linear_distance(n_g.pose)
+                        if dist < min_dist and self.graph.check_connectivity(n_new, n_g):
+                            min_dist = dist
+                            n_connect_start = n_new
+                            n_connect_goal = n_g
+                            goal_found = True
+
+                elif connected_node_goal:
+                    # If we added a node to the goal tree, check it against all the start tree nodes
+                    for n_s in self.graph.nodes:
+                        dist = n_new_goal.pose.get_linear_distance(n_s.pose)
+                        if dist < min_dist and self.graph.check_connectivity(n_new_goal, n_s):
+                            min_dist = dist
+                            n_connect_start = n_s
+                            n_connect_goal = n_new_goal
+                            goal_found = True
+
+            elif connected_node:
+                # If not bidirectional, check if the nearest can be added to the goal
+                dist = n_new.pose.get_linear_distance(n_goal.pose)
+                if dist < self.max_connection_dist and self.graph.connect(n_new, n_goal):
+                    n_goal.parent = n_new
+                    self.graph.add(n_goal)
+                    goal_found = True
 
             # Check max nodes samples or max time elapsed
             t_elapsed = time.time() - t_start
@@ -65,7 +109,10 @@ class RRTPlanner:
                 break
             
         # Now back out the path
-        n = n_goal
+        if self.bidirectional:
+            n = n_connect_start
+        else:
+            n = n_goal
         path = [n]
         path_built = False
         while not path_built:
@@ -75,26 +122,20 @@ class RRTPlanner:
                 n = n.parent
                 path.append(n)
         path.reverse()
-        return path        
-        
+        if self.bidirectional:
+            n = n_connect_goal
+            path_built = False
+            while not path_built:
+                if n.parent is None:
+                    path_built = True
+                else:
+                    n = n.parent
+                    path.append(n)
+        return path         
 
     def sample_configuration(self):
         """ Sample a random configuration from the world. """
         return self.world.sample_free_robot_pose_uniform()
-
-    def nearest_node(self, pose):
-        """ Get the nearest node in the graph to a specified pose. """
-        if len(self.graph.nodes) == 0:
-            return None
-        
-        # Find the nearest node
-        min_dist = np.inf
-        for n in self.graph.nodes:
-            dist = pose.get_linear_distance(n.pose)
-            if dist < min_dist:
-                min_dist = dist
-                n_nearest = n
-        return n_nearest
 
     def new_node(self, n_near, q_sample):
         """ Creates a new node based on the nearest """
@@ -111,17 +152,27 @@ class RRTPlanner:
 
         return Node(q_new, parent=n_near, cost=n_near.cost + dist)
 
-    def rewire_node(self, n_new):
+    def rewire_node(self, graph, n_tgt):
         """ 
         Rewires a node by checking vicinity. 
         This is the key modification for RRT*.
         """
-        for n in self.graph.nodes:
-            dist = n.pose.get_linear_distance(n_new.pose)
-            if (n != n_new) and (dist <= self.rewire_radius):
+        did_rewire = False
+        for n in graph.nodes:
+            dist = n.pose.get_linear_distance(n_tgt.pose)
+            if (n != n_tgt) and (dist <= self.rewire_radius):
                 alt_cost = n.cost + dist
-                should_rewire = (alt_cost < n_new.cost) and \
-                    self.graph.check_connectivity(n, n_new)
+                should_rewire = (alt_cost < n_tgt.cost) and \
+                    graph.check_connectivity(n, n_tgt)
                 if should_rewire:
-                    n_new.cost = alt_cost
-                    n_new.parent = n
+                    n_tgt.cost = alt_cost
+                    n_tgt.parent = n
+                    did_rewire = True
+
+        # Uncomment to show the rewired tree
+        # if did_rewire:
+        #     for e in graph.edges.copy():
+        #         if e.n0 == n_tgt or e.n1 == n_tgt:
+        #             graph.edges.remove(e)
+        #     graph.edges.add(Edge(n_tgt, n_tgt.parent))
+                    

--- a/pyrobosim/pyrobosim/navigation/rrt.py
+++ b/pyrobosim/pyrobosim/navigation/rrt.py
@@ -1,0 +1,104 @@
+"""
+Implementation of the Rapidly-exploring Random Tree (RRT) 
+algorithm for motion planning.
+"""
+
+import time
+import numpy as np
+
+from .search_graph import SearchGraph, Node, Edge
+from ..utils.pose import Pose
+
+class RRTPlanner:
+    def __init__(self, world):
+        self.max_connection_dist = 1.0
+        self.max_nodes_sampled = 1000
+        self.max_time = 10
+
+        self.world = world
+        self.reset()
+
+    def reset(self):
+        self.graph = SearchGraph(world=self.world)
+
+    def plan(self, start, goal, plot=False):
+        self.reset()
+
+        # Create the start and goal nodes
+        n_start = Node(start, parent=None)
+        n_goal = Node(goal, parent=None)
+        self.graph.nodes = {n_start}
+
+        t_start = time.time()
+        n_sampled = 0
+        goal_found = False
+        while not goal_found:
+            # Sample a node
+            q_sample = self.sample_configuration()
+            n_sampled += 1
+            n_near = self.nearest_node(q_sample)
+            n_new = self.new_node(n_near, q_sample)
+
+            # Connect the new node to the parent
+            if not self.graph.connect(n_near, n_new):
+                continue
+            self.graph.nodes.add(n_new)
+
+            # See if the new node can directly connect to the goal
+            goal_dist = n_near.pose.get_linear_distance(n_goal.pose)
+            if goal_dist < self.max_connection_dist and self.graph.connect(n_near, n_goal):
+                n_goal.parent = n_near
+                self.graph.add(n_goal)
+                goal_found = True
+
+            # Check max nodes samples or max time elapsed
+            t_elapsed = time.time() - t_start
+            if t_elapsed > self.max_time or n_sampled > self.max_nodes_sampled:
+                break
+            
+        # Now back out the path
+        n = n_goal
+        path = [n]
+        path_built = False
+        while not path_built:
+            if n.parent is None:
+                path_built = True
+            else:
+                n = n.parent
+                path.append(n)
+        path.reverse()
+        return path        
+        
+
+    def sample_configuration(self):
+        """ Sample a random configuration from the world. """
+        return self.world.sample_free_robot_pose_uniform()
+
+    def nearest_node(self, pose):
+        """ Get the nearest node in the graph to a specified pose. """
+        if len(self.graph.nodes) == 0:
+            return None
+        
+        # Find the nearest node
+        min_dist = np.inf
+        for n in self.graph.nodes:
+            dist = pose.get_linear_distance(n.pose)
+            if dist < min_dist:
+                min_dist = dist
+                n_nearest = n
+        return n_nearest
+
+    def new_node(self, n_near, q_sample):
+        """ Creates a new node based on the nearest """
+        q_start = n_near.pose
+        dist = q_start.get_linear_distance(q_sample)
+
+        step_dist = self.max_connection_dist
+        if dist <= step_dist:
+            q_new = q_sample
+        else:
+            theta = q_start.get_angular_distance(q_sample)
+            q_new = Pose(x=q_start.x + step_dist * np.cos(theta),
+                         y=q_start.y + step_dist * np.sin(theta))
+
+        return Node(q_new, parent=n_near)

--- a/pyrobosim/pyrobosim/navigation/rrt.py
+++ b/pyrobosim/pyrobosim/navigation/rrt.py
@@ -3,6 +3,7 @@ Implementation of the Rapidly-exploring Random Tree (RRT)
 algorithm for motion planning.
 """
 
+import copy
 import time
 import numpy as np
 
@@ -10,15 +11,18 @@ from .search_graph import SearchGraph, Node, Edge
 from ..utils.pose import Pose
 
 class RRTPlanner:
-    def __init__(self, world, bidirectional=False, rrt_star=False):
-        self.max_connection_dist = 0.5
-        self.max_nodes_sampled = 1000
-        self.max_time = 10
 
+    # Default params
+    max_connection_dist = 0.5
+    max_nodes_sampled = 1000
+    max_time = 5
+    rewire_radius = 1.0
+
+    def __init__(self, world, bidirectional=False, rrt_connect=False, rrt_star=False):
         # Algorithm options
         self.bidirectional = bidirectional
+        self.rrt_connect = rrt_connect
         self.rrt_star = rrt_star
-        self.rewire_radius = 1.0
 
         self.world = world
         self.reset()
@@ -27,6 +31,9 @@ class RRTPlanner:
         """ Resets the search trees """
         self.graph = SearchGraph(world=self.world)
         self.graph_goal = SearchGraph(world=self.world)
+        self.planning_time = 0.0
+        self.nodes_sampled = 0
+        self.n_rewires = 0
 
     def plan(self, start, goal):
         self.reset()
@@ -39,12 +46,11 @@ class RRTPlanner:
             self.graph_goal.nodes = {n_goal}
 
         t_start = time.time()
-        n_sampled = 0
         goal_found = False
         while not goal_found:
             # Sample a node
             q_sample = self.sample_configuration()
-            n_sampled += 1
+            self.nodes_sampled += 1
 
             # Connect aa new node to the parent
             n_near = self.graph.nearest_node(q_sample)
@@ -70,47 +76,30 @@ class RRTPlanner:
                 if connected_node_goal:
                     self.rewire_node(self.graph_goal, n_new_goal)
 
-            # See if the new nodes can directly connect to the goal
-            n_connect_start = None
-            n_connect_goal = None
+            # See if the new nodes can directly connect to the goal.
+            # This is done either as a single connection within max distance, or using RRT-Connect.
             if self.bidirectional:
-                min_dist = self.max_connection_dist
                 if connected_node:
-                    # If we added a node to the start tree, check it against all the goal tree nodes
-                    for n_g in self.graph_goal.nodes:
-                        dist = n_new.pose.get_linear_distance(n_g.pose)
-                        if dist < min_dist and self.graph.check_connectivity(n_new, n_g):
-                            min_dist = dist
-                            n_connect_start = n_new
-                            n_connect_goal = n_g
-                            goal_found = True
+                    # If we added a node to the start tree, try connect to the goal tree
+                    n_goal_goal_tree = self.graph_goal.nearest_node(n_new.pose)
+                    goal_found, n_goal_start_tree = self.try_connect_until(self.graph, n_new, n_goal_goal_tree)
 
-                elif connected_node_goal:
-                    # If we added a node to the goal tree, check it against all the start tree nodes
-                    for n_s in self.graph.nodes:
-                        dist = n_new_goal.pose.get_linear_distance(n_s.pose)
-                        if dist < min_dist and self.graph.check_connectivity(n_new_goal, n_s):
-                            min_dist = dist
-                            n_connect_start = n_s
-                            n_connect_goal = n_new_goal
-                            goal_found = True
+                if connected_node_goal and not goal_found:
+                    # If we added a node to the goal tree, try connect to the start tree
+                    n_goal_start_tree = self.graph.nearest_node(n_new_goal.pose)
+                    goal_found, n_goal_goal_tree = self.try_connect_until(self.graph_goal, n_new_goal, n_goal_start_tree)
 
             elif connected_node:
-                # If not bidirectional, check if the nearest can be added to the goal
-                dist = n_new.pose.get_linear_distance(n_goal.pose)
-                if dist < self.max_connection_dist and self.graph.connect(n_new, n_goal):
-                    n_goal.parent = n_new
-                    self.graph.add(n_goal)
-                    goal_found = True
+                goal_found, _ = self.try_connect_until(self.graph, n_new, n_goal)
 
             # Check max nodes samples or max time elapsed
-            t_elapsed = time.time() - t_start
-            if t_elapsed > self.max_time or n_sampled > self.max_nodes_sampled:
+            self.planning_time = time.time() - t_start
+            if self.planning_time > self.max_time or self.nodes_sampled > self.max_nodes_sampled:
                 break
             
         # Now back out the path
         if self.bidirectional:
-            n = n_connect_start
+            n = n_goal_start_tree
         else:
             n = n_goal
         path = [n]
@@ -123,7 +112,7 @@ class RRTPlanner:
                 path.append(n)
         path.reverse()
         if self.bidirectional:
-            n = n_connect_goal
+            n = n_goal_goal_tree
             path_built = False
             while not path_built:
                 if n.parent is None:
@@ -157,22 +146,53 @@ class RRTPlanner:
         Rewires a node by checking vicinity. 
         This is the key modification for RRT*.
         """
-        did_rewire = False
+        # First, find the node to rewire, if any
+        n_rewire = None
         for n in graph.nodes:
             dist = n.pose.get_linear_distance(n_tgt.pose)
             if (n != n_tgt) and (dist <= self.rewire_radius):
                 alt_cost = n.cost + dist
-                should_rewire = (alt_cost < n_tgt.cost) and \
-                    graph.check_connectivity(n, n_tgt)
-                if should_rewire:
+                if (alt_cost < n_tgt.cost) and \
+                    graph.check_connectivity(n, n_tgt):
+                    n_rewire = n
                     n_tgt.cost = alt_cost
-                    n_tgt.parent = n
-                    did_rewire = True
 
-        # Uncomment to show the rewired tree
-        # if did_rewire:
-        #     for e in graph.edges.copy():
-        #         if e.n0 == n_tgt or e.n1 == n_tgt:
-        #             graph.edges.remove(e)
-        #     graph.edges.add(Edge(n_tgt, n_tgt.parent))
-                    
+        # If we found a rewire node, do the rewire
+        if n_rewire is not None:
+            n_tgt.parent = n_rewire
+            for e in graph.edges.copy():
+                if e.n0 == n_tgt or e.n1 == n_tgt:
+                    graph.edges.remove(e)
+            graph.edges.add(Edge(n_tgt, n_tgt.parent))
+            self.n_rewires += 1
+
+    def try_connect_until(self, graph, n_curr, n_tgt):
+        """
+        Try to connect a node "n_curr" to a target node "n_tgt".
+        This will keep extending the current node towards the target if 
+        RRT-Connect is enabled, or else will just try once.
+        """
+        # Needed for bidirectional RRT so the connection node can be in both trees.
+        if self.bidirectional:
+            n_tgt = copy.deepcopy(n_tgt)
+
+        while True:
+            dist = n_curr.pose.get_linear_distance(n_tgt.pose)
+
+            # First, try directly connecting to the goal
+            if dist < self.max_connection_dist and self.graph.connect(n_curr, n_tgt):
+                n_tgt.parent = n_curr
+                graph.nodes.add(n_tgt)
+                return True, n_tgt
+
+            if self.rrt_connect:
+                # If using RRT-Connect, keep trying to connect until we succeed or fail.
+                n_new = self.new_node(n_curr, n_tgt.pose)
+                if graph.connect(n_curr, n_new):
+                    graph.nodes.add(n_new)
+                    n_curr = n_new
+                else:
+                    return False, n_curr
+            else:
+                # If not using RRT-Connect, we only get one chance to connect to the target.
+                return False, n_curr

--- a/pyrobosim/pyrobosim/navigation/rrt.py
+++ b/pyrobosim/pyrobosim/navigation/rrt.py
@@ -45,6 +45,11 @@ class RRTPlanner:
         self.max_time = max_time
         self.rewire_radius = rewire_radius
 
+        # Visualization
+        self.color_start = [0, 0, 0]
+        self.color_goal = [0, 0.4, 0.8]
+        self.color_alpha = 0.5
+
         self.world = world
         self.reset()
 
@@ -309,13 +314,15 @@ class RRTPlanner:
             for e in self.graph.edges:
                 x = (e.n0.pose.x, e.n1.pose.x)
                 y = (e.n0.pose.y, e.n1.pose.y)
-                edge, = axes.plot(x, y, "k:", linewidth=1)
+                edge, = axes.plot(x, y, linestyle=":", linewidth=1,
+                                  color=self.color_start, alpha=self.color_alpha)
                 artists.append(edge)
             if self.bidirectional:
                 for e in self.graph_goal.edges:
                     x = (e.n0.pose.x, e.n1.pose.x)
                     y = (e.n0.pose.y, e.n1.pose.y)
-                    edge, = axes.plot(x, y, "b--", linewidth=1)
+                    edge, = axes.plot(x, y, linestyle="--", linewidth=1,
+                                      color=self.color_goal, alpha=self.color_alpha)
                     artists.append(edge)
         
         if show_path and self.latest_path is not None:

--- a/pyrobosim/pyrobosim/navigation/rrt.py
+++ b/pyrobosim/pyrobosim/navigation/rrt.py
@@ -11,18 +11,18 @@ from .search_graph import SearchGraph, Node, Edge
 from ..utils.pose import Pose
 
 class RRTPlanner:
-
-    # Default params
-    max_connection_dist = 0.5
-    max_nodes_sampled = 1000
-    max_time = 5
-    rewire_radius = 1.0
-
-    def __init__(self, world, bidirectional=False, rrt_connect=False, rrt_star=False):
+    def __init__(self, world, bidirectional=False, rrt_connect=False, rrt_star=False,
+                 max_connection_dist=0.5, max_nodes_sampled=1000, max_time=5.0, rewire_radius=1.0):
         # Algorithm options
         self.bidirectional = bidirectional
         self.rrt_connect = rrt_connect
         self.rrt_star = rrt_star
+
+        # Parameters
+        self.max_connection_dist = max_connection_dist
+        self.max_nodes_sampled = max_nodes_sampled
+        self.max_time = max_time
+        self.rewire_radius = rewire_radius
 
         self.world = world
         self.reset()

--- a/pyrobosim/pyrobosim/navigation/rrt.py
+++ b/pyrobosim/pyrobosim/navigation/rrt.py
@@ -13,7 +13,7 @@ from ..utils.pose import Pose
 
 class RRTPlanner:
     def __init__(self, world, bidirectional=False, rrt_connect=False, rrt_star=False,
-                 max_connection_dist=0.5, max_nodes_sampled=1000, max_time=5.0, rewire_radius=1.0):
+                 max_connection_dist=0.25, max_nodes_sampled=1000, max_time=5.0, rewire_radius=1.0):
         # Algorithm options
         self.bidirectional = bidirectional
         self.rrt_connect = rrt_connect
@@ -202,6 +202,22 @@ class RRTPlanner:
             else:
                 # If not using RRT-Connect, we only get one chance to connect to the target.
                 return False, n_curr
+
+    def print_metrics(self):
+        """
+        Print metrics about the latest path.
+        """
+        if self.latest_path is None:
+            print("No path.")
+            return
+
+        print("Latest path from RRT:")
+        for n in self.latest_path:
+            print(n.pose)
+        print("")
+        print(f"Nodes sampled: {self.nodes_sampled}")
+        print(f"Time to plan: {self.planning_time} seconds")
+        print(f"Number of rewires: {self.n_rewires}")
 
     def plot(self, axes, show_graph=True, show_path=True):
         """

--- a/pyrobosim/pyrobosim/navigation/rrt.py
+++ b/pyrobosim/pyrobosim/navigation/rrt.py
@@ -8,6 +8,7 @@ import time
 import numpy as np
 
 from .search_graph import SearchGraph, Node, Edge
+from .trajectory import fill_path_yaws
 from ..utils.pose import Pose
 
 class RRTPlanner:
@@ -28,7 +29,7 @@ class RRTPlanner:
         self.reset()
 
     def reset(self):
-        """ Resets the search trees """
+        """ Resets the search trees and planning metrics. """
         self.graph = SearchGraph(world=self.world)
         self.graph_goal = SearchGraph(world=self.world)
         self.latest_path = None
@@ -37,6 +38,7 @@ class RRTPlanner:
         self.n_rewires = 0
 
     def plan(self, start, goal):
+        """ Plan a path from start to goal. """
         self.reset()
 
         # Create the start and goal nodes
@@ -121,6 +123,8 @@ class RRTPlanner:
                 else:
                     n = n.parent
                     path.append(n)
+
+        path = fill_path_yaws(path)
         self.latest_path = path
         return path         
 
@@ -229,7 +233,7 @@ class RRTPlanner:
 
     def show(self, show_graph=True, show_path=True):
         """
-        Shows the RRT in a new figure
+        Shows the RRT in a new figure.
         """
         import matplotlib.pyplot as plt
         f = plt.figure()

--- a/pyrobosim/pyrobosim/navigation/search_graph.py
+++ b/pyrobosim/pyrobosim/navigation/search_graph.py
@@ -30,6 +30,7 @@ class SearchGraph:
         self.distance_dict = {}
 
         self.solver = GraphSolver()
+        self.latest_path = None
 
     def add(self, n, autoconnect=False):
         """ 
@@ -145,7 +146,8 @@ class SearchGraph:
             warnings.warn("Did not find a path from start to goal.")
             return []
         else:
-            return list(path)
+            self.latest_path = list(path)
+            return self.latest_path
 
     def nearest_node(self, pose):
         """ 
@@ -167,6 +169,28 @@ class SearchGraph:
                 min_dist = dist
                 n_nearest = n
         return n_nearest
+
+    def plot(self, axes, show_graph=True, show_path=True):
+        """ 
+        Plots the search graph on a specified set of axes.
+        """
+        if show_graph:
+            x = [n.pose.x for n in self.nodes]
+            y = [n.pose.y for n in self.nodes]
+            axes.scatter(x, y, 15, "k")
+
+            for e in self.edges:
+                x = (e.n0.pose.x, e.n1.pose.x)
+                y = (e.n0.pose.y, e.n1.pose.y)
+                axes.plot(x, y, "k:", linewidth=1)
+
+        if show_path and self.latest_path is not None:
+            x = [p.pose.x for p in self.latest_path]
+            y = [p.pose.y for p in self.latest_path]
+            axes.plot(x, y, "m-", linewidth=3, zorder=1)
+            axes.scatter(x[0], y[0], 60, "g", "o", zorder=2)
+            axes.scatter(x[-1], y[-1], 60, "r", "x", zorder=2)
+
 
 
 class Node:

--- a/pyrobosim/pyrobosim/navigation/search_graph.py
+++ b/pyrobosim/pyrobosim/navigation/search_graph.py
@@ -145,10 +145,14 @@ class SearchGraph:
         if (self.world is None) or (start == goal):
             return True
 
-        # Build up the array of test X and Y coordinates for sampling between
-        # the start and goal points.
+        # Check against the max edge distance.
         dist = start.pose.get_linear_distance(goal.pose, ignore_z=True)
         angle = start.pose.get_angular_distance(goal.pose)
+        if dist > self.max_edge_dist:
+            return False
+
+        # Build up the array of test X and Y coordinates for sampling between
+        # the start and goal points.
         dist_array = np.arange(0, dist, self.collision_check_dist)
         # If the nodes are coincident, connect them by default.
         if dist_array.size == 0:

--- a/pyrobosim/pyrobosim/navigation/search_graph.py
+++ b/pyrobosim/pyrobosim/navigation/search_graph.py
@@ -152,7 +152,7 @@ class SearchGraph:
 class Node:
     """ Graph node representation. """
 
-    def __init__(self, pose, parent=None):
+    def __init__(self, pose, parent=None, cost=0.0):
         """
         Creates a graph node. 
         
@@ -160,9 +160,12 @@ class Node:
         :type pose: :class:`pyrobosim.utils.pose.Pose`
         :param parent: Parent node, if any.
         :type parent: :class:`Node`, optional
+        :param cost: Cose of the node, defaults to zero
+        :type cost: float, optional
         """
         self.pose = pose
         self.parent = parent
+        self.cost = cost
         self.neighbors = set()
 
 

--- a/pyrobosim/pyrobosim/navigation/search_graph.py
+++ b/pyrobosim/pyrobosim/navigation/search_graph.py
@@ -148,6 +148,27 @@ class SearchGraph:
         else:
             return list(path)
 
+    def nearest_node(self, pose):
+        """ 
+        Get the nearest node in the graph to a specified pose. 
+        
+        :param pose: Query pose
+        :type pose: :class:`pyrobosim.utils.pose.Pose`
+        :return: The nearest node to the query pose, or None if the graph is empty
+        :rtype: :class:`Node`
+        """
+        if len(self.nodes) == 0:
+            return None
+        
+        # Find the nearest node
+        min_dist = np.inf
+        for n in self.nodes:
+            dist = pose.get_linear_distance(n.pose)
+            if dist < min_dist:
+                min_dist = dist
+                n_nearest = n
+        return n_nearest
+
 
 class Node:
     """ Graph node representation. """

--- a/pyrobosim/pyrobosim/navigation/search_graph.py
+++ b/pyrobosim/pyrobosim/navigation/search_graph.py
@@ -121,8 +121,7 @@ class SearchGraph:
         y_pts = start.pose.y + dist_array * np.sin(angle)
 
         # Check the occupancy of all the test points.
-        # Since we know the nodes already were sampled in free space, use a reduced inflation radius.
-        for x_check, y_check in zip(x_pts[1:-1], y_pts[1:-1]):
+        for x_check, y_check in zip(x_pts, y_pts):
             if self.world.check_occupancy(Pose(x=x_check, y=y_check)):
                 return False
 

--- a/pyrobosim/pyrobosim/navigation/search_graph.py
+++ b/pyrobosim/pyrobosim/navigation/search_graph.py
@@ -174,23 +174,28 @@ class SearchGraph:
         """ 
         Plots the search graph on a specified set of axes.
         """
+        artists = []
         if show_graph:
             x = [n.pose.x for n in self.nodes]
             y = [n.pose.y for n in self.nodes]
-            axes.scatter(x, y, 15, "k")
+            nodes, = axes.plot(x, y, "k.", linestyle="None", markersize=10)
+            artists.append(nodes)
 
             for e in self.edges:
                 x = (e.n0.pose.x, e.n1.pose.x)
                 y = (e.n0.pose.y, e.n1.pose.y)
-                axes.plot(x, y, "k:", linewidth=1)
+                edge, = axes.plot(x, y, "k:", linewidth=1)
+                artists.append(edge)
 
         if show_path and self.latest_path is not None:
             x = [p.pose.x for p in self.latest_path]
             y = [p.pose.y for p in self.latest_path]
-            axes.plot(x, y, "m-", linewidth=3, zorder=1)
-            axes.scatter(x[0], y[0], 60, "g", "o", zorder=2)
-            axes.scatter(x[-1], y[-1], 60, "r", "x", zorder=2)
+            path, = axes.plot(x, y, "m-", linewidth=3, zorder=1)
+            start, = axes.plot(x[0], y[0], "go", zorder=2)
+            goal, = axes.plot(x[-1], y[-1], "rx", zorder=2)
+            artists.extend((path, start, goal))
 
+        return artists
 
 
 class Node:

--- a/pyrobosim/pyrobosim/navigation/search_graph.py
+++ b/pyrobosim/pyrobosim/navigation/search_graph.py
@@ -240,7 +240,7 @@ class Node:
         :type pose: :class:`pyrobosim.utils.pose.Pose`
         :param parent: Parent node, if any.
         :type parent: :class:`Node`, optional
-        :param cost: Cose of the node, defaults to zero
+        :param cost: Cost of the node, defaults to zero.
         :type cost: float, optional
         """
         self.pose = pose

--- a/pyrobosim/pyrobosim/navigation/search_graph.py
+++ b/pyrobosim/pyrobosim/navigation/search_graph.py
@@ -57,11 +57,15 @@ class SearchGraph:
         :type n0: :class:`Node`
         :param n1: Second node to connect
         :type n1: :class:`Node`
+        :return: True if nodes were, else False.
+        :rtype: bool
         """
         if (n0 != n1) and self.check_connectivity(n0, n1):
             n0.neighbors.add(n1)
             n1.neighbors.add(n0)
             self.edges.add(Edge(n0, n1))
+            return True
+        return False
 
     def remove(self, ndel):
         """ 

--- a/pyrobosim/pyrobosim/navigation/trajectory.py
+++ b/pyrobosim/pyrobosim/navigation/trajectory.py
@@ -15,6 +15,9 @@ def fill_path_yaws(path):
     :return: Path with filled-in yaw angle values.
     :rtype: list[:class:`pyrobosim.utils.pose.Pose`]
     """
+    if path is None:
+        return path
+
     for idx in range(1, len(path)-1):
         path[idx].pose.yaw = np.arctan2(path[idx].pose.y - path[idx-1].pose.y,
                                         path[idx].pose.x - path[idx-1].pose.x)

--- a/pyrobosim_ros/CMakeLists.txt
+++ b/pyrobosim_ros/CMakeLists.txt
@@ -18,6 +18,7 @@ ament_python_install_package(
 install(PROGRAMS
   examples/demo.py
   examples/demo_commands.py
+  ../pyrobosim/examples/test_prm.py
   ../pyrobosim/examples/test_rrt.py
   ../pyrobosim/examples/demo_world_save.py
   DESTINATION lib/${PROJECT_NAME}

--- a/pyrobosim_ros/CMakeLists.txt
+++ b/pyrobosim_ros/CMakeLists.txt
@@ -18,6 +18,7 @@ ament_python_install_package(
 install(PROGRAMS
   examples/demo.py
   examples/demo_commands.py
+  ../pyrobosim/examples/test_rrt.py
   ../pyrobosim/examples/demo_world_save.py
   DESTINATION lib/${PROJECT_NAME}
 )

--- a/pyrobosim_ros/examples/demo.py
+++ b/pyrobosim_ros/examples/demo.py
@@ -66,7 +66,8 @@ def create_world():
     w.add_robot(r, loc="kitchen")
 
     # Create a search graph
-    w.create_search_graph(max_edge_dist=3.0, collision_check_dist=0.05)
+    w.create_search_graph(
+        max_edge_dist=3.0, collision_check_dist=0.05, create_planner=True)
     return w
 
 

--- a/pyrobosim_ros/examples/demo.py
+++ b/pyrobosim_ros/examples/demo.py
@@ -67,9 +67,6 @@ def create_world():
 
     # Create a search graph
     w.create_search_graph(max_edge_dist=3.0, collision_check_dist=0.05)
-    # w.path_planner = None
-    # from pyrobosim.navigation.rrt import RRTPlanner
-    # r.set_path_planner(RRTPlanner(w, bidirectional=True, rrt_connect=False, rrt_star=True))
     return w
 
 

--- a/pyrobosim_ros/examples/demo.py
+++ b/pyrobosim_ros/examples/demo.py
@@ -67,6 +67,9 @@ def create_world():
 
     # Create a search graph
     w.create_search_graph(max_edge_dist=3.0, collision_check_dist=0.05)
+    # w.path_planner = None
+    # from pyrobosim.navigation.rrt import RRTPlanner
+    # r.set_path_planner(RRTPlanner(w, bidirectional=True, rrt_connect=False, rrt_star=True))
     return w
 
 


### PR DESCRIPTION
This PR adds two main things: some infrastructure to create global vs. local path planners, and then actual sampling-based planner implementations.

## Infrastructure

* **Global path planners** represent multi-query things such as roadmaps (probabilistic or otherwise) and are properties of the world.
* **Local path planners** represent single-query things such as RRTs and are properties of the robot.

I've arbitrarily picked the robot's local path planner to take precedence if all are specified. Additionally, the existing search graph, which was a hard-coded set of nodes for all rooms/hallways/locations/etc. now still exists as a `SearchGraph` but has a thin wrapper called `SearchGraphPlanner` around it if you want to use it as a planner.

Admittedly, there is still an awkward dependency on the `SearchGraph` which exists no matter what the planner is to give us graph nodes pertaining to entities such as locations. There's definitely a better solution and I'd love feedback on that.

## Planners

This PR implements two additional sampling-based planners: PRM as an example of a global path planner, and RRT as an example of a local path planner.

* PRM is just a standard implementation with a max number of nodes and connection distance.
* RRT has the standard implementation, but with additional optional algorithmic tweaks -- specifically bidirectional RRT, RRT*, and RRT-Connect. All 3 can be enabled/disabled individually.

There are super basic tests added for these planners, which can be run as:

```
ros2 run pyrobosim_ros test_rrt.py
```

PRM:
![image](https://user-images.githubusercontent.com/4603398/168505331-21b0ca4a-0e58-4f4c-86a7-05dfae11684e.png)

RRT:
![image](https://user-images.githubusercontent.com/4603398/168505371-ebe3d7a1-7fda-4e6f-879b-73b063b837eb.png)

Bidirectional RRT*:
![image](https://user-images.githubusercontent.com/4603398/170898035-4b38614e-94bb-4fae-b552-542e0f9da9aa.png)

Closes #1.