### PR TITLE
Ensure Docker display works without xhost command

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -3,10 +3,6 @@ name: tests
 on:
   # Run action every time branch is pushed to
   push:
-
-  # Job on certain pull request events
-  pull_request:
-    types: [opened, ready_for_review, review_requested]
   
   # Nightly job on default (main) branch
   schedule:

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,2 @@
+# Temporary folder containing installed artifacts to share across containers
+tmp/

--- a/docker/Dockerfile.foxy
+++ b/docker/Dockerfile.foxy
@@ -1,28 +1,19 @@
 # pyrobosim Dockerfile for Ubuntu 20.04 / ROS2 Foxy
-FROM ubuntu:20.04
-
+FROM osrf/ros:foxy-desktop
 SHELL ["/bin/bash", "-c"]
-ARG DEBIAN_FRONTEND=noninteractive
 
-# Install ROS2 Foxy according to the official instructions
-# https://docs.ros.org/en/foxy/Installation/Ubuntu-Install-Debians.html
-RUN apt-get update && \ 
-    apt-get install -y apt-utils curl gnupg2 locales lsb-release python3-pip
-RUN dpkg-reconfigure locales && locale-gen en_US en_US.UTF-8
-RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
-RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(source /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
-RUN apt-get update && apt-get upgrade -y && \ 
-    apt-get install -y ros-foxy-desktop
-RUN apt-get install -y python3-colcon-common-extensions
-RUN echo "source /opt/ros/foxy/setup.bash" >> ~/.bashrc
+# Install dependencies
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get upgrade -y 
+RUN apt-get install -y \ 
+    apt-utils python3-pip python3-tk
 
 # Create a colcon workspace
 RUN mkdir -p /pyrobosim_ws/src
 
 # Install pyrobosim and testing dependencies
 COPY pyrobosim /temp/pyrobosim
-RUN cd /temp/pyrobosim && \ 
-    pip3 install .
+RUN cd /temp/pyrobosim && pip3 install .
 RUN pip3 install lark pytest pytest-html
 
 # Setup an entrypoint and working folder

--- a/docker/Dockerfile.humble
+++ b/docker/Dockerfile.humble
@@ -1,28 +1,19 @@
 # pyrobosim Dockerfile for Ubuntu 22.04 / ROS2 Humble
-FROM ubuntu:22.04
-
+FROM osrf/ros:humble-desktop
 SHELL ["/bin/bash", "-c"]
-ARG DEBIAN_FRONTEND=noninteractive
 
-# Install ROS2 Humble according to the official instructions
-# https://docs.ros.org/en/foxy/Installation/Ubuntu-Install-Debians.html
-RUN apt-get update && \ 
-    apt-get install -y apt-utils curl gnupg locales lsb-release python3-pip
-RUN dpkg-reconfigure locales && locale-gen en_US en_US.UTF-8
-RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
-RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(source /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
-RUN apt-get update && apt-get upgrade -y && \ 
-    apt-get install -y ros-humble-desktop
-RUN apt-get install -y python3-colcon-common-extensions
-RUN echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
+# Install dependencies
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get upgrade -y 
+RUN apt-get install -y \ 
+    apt-utils python3-pip python3-tk
 
 # Create a colcon workspace
 RUN mkdir -p /pyrobosim_ws/src
 
 # Install pyrobosim and testing dependencies
 COPY pyrobosim /temp/pyrobosim
-RUN cd /temp/pyrobosim && \ 
-    pip3 install .
+RUN cd /temp/pyrobosim && pip3 install .
 RUN pip3 install lark pytest pytest-html
 
 # Setup an entrypoint and working folder

--- a/docker/Dockerfile.humble
+++ b/docker/Dockerfile.humble
@@ -1,6 +1,6 @@
 # pyrobosim Dockerfile for Ubuntu 22.04 / ROS2 Humble
 FROM osrf/ros:humble-desktop
-SHELL ["/bin/bash", "-c"]
+# SHELL ["/bin/bash", "-c"]
 
 # Install dependencies
 ARG DEBIAN_FRONTEND=noninteractive

--- a/docker/build_docker.bash
+++ b/docker/build_docker.bash
@@ -8,6 +8,8 @@ fi
 IMAGE_NAME=pyrobosim_$ROS_DISTRO
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
+rm -rf $SCRIPT_DIR/tmp
+
 pushd $SCRIPT_DIR/..
 docker build -f $SCRIPT_DIR/Dockerfile.$ROS_DISTRO \
              -t $IMAGE_NAME .

--- a/docker/build_docker.bash
+++ b/docker/build_docker.bash
@@ -9,5 +9,6 @@ IMAGE_NAME=pyrobosim_$ROS_DISTRO
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 pushd $SCRIPT_DIR/..
-docker build -f $SCRIPT_DIR/Dockerfile.$ROS_DISTRO -t $IMAGE_NAME .
+docker build -f $SCRIPT_DIR/Dockerfile.$ROS_DISTRO \
+             -t $IMAGE_NAME .
 popd

--- a/docker/entrypoint_foxy.sh
+++ b/docker/entrypoint_foxy.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
-# Source ROS
+# Source ROS and the Colcon workspace
 source /opt/ros/foxy/setup.bash
+if [ ! -f /pyrobosim_ws/install/setup.bash ]
+then
+  colcon build
+fi
+. /pyrobosim_ws/install/setup.bash
 
 # Execute the command passed into this entrypoint
 exec "$@"

--- a/docker/entrypoint_humble.sh
+++ b/docker/entrypoint_humble.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
-# Source ROS
+# Source ROS and the Colcon workspace
 source /opt/ros/humble/setup.bash
+if [ ! -f /pyrobosim_ws/install/setup.bash ]
+then
+  colcon build
+fi
+. /pyrobosim_ws/install/setup.bash
 
 # Execute the command passed into this entrypoint
 exec "$@"

--- a/docker/run_docker.bash
+++ b/docker/run_docker.bash
@@ -19,7 +19,7 @@ IMAGE_NAME=pyrobosim_$ROS_DISTRO
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # If no command is specified, just open a Bash terminal.
-CMD=${1:-bash}
+CMD="${1:-bash}"
 
 # If running as part of CI, do not use displays and interactive mode.
 if [ "$2" == "ci_mode" ]
@@ -38,9 +38,11 @@ else
     --volume="$XAUTH:$XAUTH" \
 "
 fi
+NETWORK_ARGS="--ipc=host --net=host"
 
 # Finally, run the command in Docker
-echo "Running image $IMAGE_NAME..."
-docker run --net=host --rm $DISPLAY_ARGS \
+docker run --rm $NETWORK_ARGS $DISPLAY_ARGS \
     --volume=$SCRIPT_DIR/..:/pyrobosim_ws/src/pyrobosim:rw \
+    --volume=$SCRIPT_DIR/tmp:/pyrobosim_ws/build:rw \
+    --volume=$SCRIPT_DIR/tmp:/pyrobosim_ws/install:rw \
     $IMAGE_NAME $CMD

--- a/docker/run_docker.bash
+++ b/docker/run_docker.bash
@@ -1,7 +1,13 @@
 # Run docker container
 #
-# To get display, first run the following command in your Terminal: 
-#   xhost + local:docker
+# To get a specific ROS2 distro, specify the ROS_DISTRO environment variable as follows:
+#   ROS_DISTRO=humble ./run_docker.bash
+#
+# To run a specific command, you can enter additional arguments:
+#   ./run_docker.bash src/pyrobosim/docker/test_docker.bash
+#
+# To run without display for use in continuous integration, use the `ci_mode` argument:
+#   ./run_docker.bash src/pyrobosim/docker/test_docker.bash ci_mode
 
 if [ "$ROS_DISTRO" == "" ]
 then
@@ -12,27 +18,29 @@ fi
 IMAGE_NAME=pyrobosim_$ROS_DISTRO
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-# If no command is specified, just open a terminal
+# If no command is specified, just open a Bash terminal.
 CMD=${1:-bash}
 
-DISPLAY_ARGS="
---gpus all \
---env="NVIDIA_DRIVER_CAPABILITIES=all" \
---env="DISPLAY" \
---env="QT_X11_NO_MITSHM=1" \
---volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
-"
-
-# If running as part of CI, disable displays and interactive mode.
-INTERACT_FLAGS=-it
+# If running as part of CI, do not use displays and interactive mode.
 if [ "$2" == "ci_mode" ]
 then 
-  INTERACT_FLAGS=""
   DISPLAY_ARGS=""
+else
+  source $SCRIPT_DIR/setup_xauth.bash
+  DISPLAY_ARGS="
+    -it --gpus all \
+    --env="NVIDIA_DRIVER_CAPABILITIES=all" \
+    --env="DISPLAY" \
+    --env="QT_X11_NO_MITSHM=1" \
+    --env="XAUTHORITY=$XAUTH" \
+    --volume="/dev/input:/dev/input" \
+    --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
+    --volume="$XAUTH:$XAUTH" \
+"
 fi
 
 # Finally, run the command in Docker
 echo "Running image $IMAGE_NAME..."
-docker run $INTERACT_FLAGS --net=host $DISPLAY_ARGS \
-    --volume=$SCRIPT_DIR/..:/pyrobosim_ws/src/pyrobosim \
+docker run --net=host --rm $DISPLAY_ARGS \
+    --volume=$SCRIPT_DIR/..:/pyrobosim_ws/src/pyrobosim:rw \
     $IMAGE_NAME $CMD

--- a/docker/run_docker.bash
+++ b/docker/run_docker.bash
@@ -38,11 +38,15 @@ else
     --volume="$XAUTH:$XAUTH" \
 "
 fi
-NETWORK_ARGS="--ipc=host --net=host"
 
+# Setup other Docker arguments
+NETWORK_ARGS="--ipc=host --net=host"
+VOLUMES="
+  --volume=$SCRIPT_DIR/..:/pyrobosim_ws/src/pyrobosim:rw \
+  --volume=$SCRIPT_DIR/tmp/build:/pyrobosim_ws/build:rw \
+  --volume=$SCRIPT_DIR/tmp/install:/pyrobosim_ws/install:rw \
+  --volume=$SCRIPT_DIR/tmp/log:/pyrobosim_ws/install/log:rw \
+"
 # Finally, run the command in Docker
-docker run --rm $NETWORK_ARGS $DISPLAY_ARGS \
-    --volume=$SCRIPT_DIR/..:/pyrobosim_ws/src/pyrobosim:rw \
-    --volume=$SCRIPT_DIR/tmp:/pyrobosim_ws/build:rw \
-    --volume=$SCRIPT_DIR/tmp:/pyrobosim_ws/install:rw \
+docker run --rm $NETWORK_ARGS $DISPLAY_ARGS $VOLUMES \
     $IMAGE_NAME $CMD

--- a/docker/setup_xauth.bash
+++ b/docker/setup_xauth.bash
@@ -1,0 +1,14 @@
+# Make sure processes in the container can connect to the X server
+XAUTH=/tmp/.docker.xauth
+if [ ! -f $XAUTH ]
+then
+    xauth_list=$(xauth nlist $DISPLAY)
+    xauth_list=$(sed -e 's/^..../ffff/' <<< "$xauth_list")
+    if [ ! -z "$xauth_list" ]
+    then
+        echo "$xauth_list" | xauth -f $XAUTH nmerge -
+    else
+        touch $XAUTH
+    fi
+    chmod a+r $XAUTH
+fi

--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -6,6 +6,9 @@ This package is being tested with:
 * Python 3.8 in Ubuntu 20.04, optionally with ROS2 Foxy
 * Python 3.10 in Ubuntu 22.04, optionally with ROS2 Humble
 
+Local Setup
+-----------
+
 If using ROS2, clone this repo in a valid `colcon workspace <https://docs.ros.org/en/foxy/Tutorials/Workspace/Creating-A-Workspace.html>`_.
 Otherwise, if running standalone, clone it wherever you would like.
 
@@ -38,3 +41,25 @@ If you plan to use ROS2, you can similarly create a bash function like this:
     pyrobosim_ros() {
        source /path/to/pyrobosim/setup/setup_pyrobosim.bash humble
     }
+
+
+Docker Setup
+------------
+
+We also provide Docker images compatible with ROS2 Foxy and Humble releases.
+
+If you already have sourced ROS2 in your system (e.g., `source /opt/ros/humble/setup.bash`),
+then you should have a `ROS_DISTRO` environment variable set. Otherwise,
+
+::
+
+    export ROS_DISTRO=humble
+    ./docker/build_docker.bash
+    ./docker/run_docker.bash
+
+Alternatively, you can directly a command from Docker:
+
+::
+
+    ./docker/run_docker.bash "ros2 run pyrobosim_ros demo.py"
+

--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -48,8 +48,8 @@ Docker Setup
 
 We also provide Docker images compatible with ROS2 Foxy and Humble releases.
 
-If you already have sourced ROS2 in your system (e.g., `source /opt/ros/humble/setup.bash`),
-then you should have a `ROS_DISTRO` environment variable set. Otherwise,
+If you already have sourced ROS2 in your system (e.g., ``source /opt/ros/humble/setup.bash``),
+then you should have a ``ROS_DISTRO`` environment variable set. Otherwise,
 
 ::
 
@@ -57,9 +57,15 @@ then you should have a `ROS_DISTRO` environment variable set. Otherwise,
     ./docker/build_docker.bash
     ./docker/run_docker.bash
 
-Alternatively, you can directly a command from Docker:
+Alternatively, you can directly run a command in a Docker container:
 
 ::
 
     ./docker/run_docker.bash "ros2 run pyrobosim_ros demo.py"
 
+Colcon workspace build artifacts are shared across containers by mounting volumes, so you
+can run a different command in a new Terminal without rebuilding. For example,
+
+::
+
+    ./docker/run_docker.bash "ros2 run pyrobosim_ros demo_commands.py"

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -36,7 +36,7 @@ click the **Navigate** button. Once at the destination, click **Pick**.
 With ROS2
 ---------
 
-First, build and setup the colcon workspace.
+First, build and setup the ``colcon`` workspace (or use one of our provided Docker containers).
 
 ::
 


### PR DESCRIPTION
This PR takes the great updates from @ibrahiminfinite to get display inside a Docker container working without having to run the `xhost` command.

To test:

```
export ROS_DISTRO=foxy #or humble
docker/build_docker.bash
docker/run_docker.bash "ros2 run pyrobosim_ros demo.py"
```

... I additionally added in a little hack that uses a host mounted volume so you don't have to rebuild the colcon workspace across containers by stashing the `install`/`build`/`log` folders in `docker/tmp` on the host. After doing the above, try this:

```
docker/run_docker.bash "ros2 run pyrobosim_ros demo_commands.py"
```

Closes #3  