### PR TITLE
Use launch files in ROS examples

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,9 +1,6 @@
 name: tests
 
 on:
-  # Run action every time branch is pushed to
-  push:
-
   # Run action on certain pull request events
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]

--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -68,11 +68,7 @@ Alternatively, you can directly run a command in a Docker container:
 
 ::
 
-    ./docker/run_docker.bash "ros2 run pyrobosim_ros demo.py"
+    ./docker/run_docker.bash "ros2 launch pyrobosim_ros demo.py"
 
-Colcon workspace build artifacts are shared across containers by mounting volumes, so you
-can run a different command in a new Terminal without rebuilding. For example,
-
-::
-
-    ./docker/run_docker.bash "ros2 run pyrobosim_ros demo_commands.py"
+Colcon workspace build artifacts are shared across containers by mounting volumes,
+so you can run a different command in a new Terminal without rebuilding.

--- a/docs/source/usage/basic_usage.rst
+++ b/docs/source/usage/basic_usage.rst
@@ -48,11 +48,12 @@ You can run a ROS2 enabled demo and interact with the GUI:
     ros2 run pyrobosim_ros demo.py 
 
 
-In a separate Terminal, you can publish a list of commands as follows:
+In a separate node, you can publish a list of commands:
 
 ::
 
-    ros2 run pyrobosim_ros demo_commands.py
+    ros2 launch pyrobosim_ros demo_commands.py
+
 
 The first command will start a world as a ROS2 node, and the second one will publish a plan (or set of actions) to the node.
 
@@ -67,12 +68,12 @@ Creating Worlds
 ---------------
 Worlds can be created either with the pyrobosim API, or loaded from a YAML file using the :doc:`WorldYamlLoader </generated/pyrobosim.core.yaml.WorldYamlLoader>` utility:
 
-By default, ``demo.py`` creates a world using the API, but you can alternative try a demo YAML file using the ``--from-file`` argument. For example:
+By default, ``demo.py`` creates a world using the API, but you can alternatively try a demo YAML file using the ``--world-file`` argument. For example:
 
 ::
 
-    python examples/demo.py --from-file
-    ros2 run pyrobosim_ros demo.py --from-file
+    python examples/demo.py --world-file test_world.yaml
+    ros2 launch pyrobosim_ros demo.py world_file:=test_world.yaml
 
 Refer to the :doc:`YAML Schemas </yaml/index>` documentation for more information.
 

--- a/docs/source/usage/basic_usage.rst
+++ b/docs/source/usage/basic_usage.rst
@@ -45,14 +45,15 @@ You can run a ROS2 enabled demo and interact with the GUI:
 
 ::
 
-    ros2 run pyrobosim_ros demo.py 
+    ros2 run pyrobosim_ros demo.py
 
 
-In a separate Terminal, you can publish a single action or a plan (list of commands):
+In a separate Terminal, you can publish a plan or a single action:
 
 ::
 
-    ros2 run pyrobosim_ros demo_commands.py
+    ros2 run pyrobosim_ros demo_commands.py --ros-args -p mode:=action
+    ros2 run pyrobosim_ros demo_commands.py --ros-args -p mode:=plan
 
 
 Or, you can run both of these nodes together using a provided launch file:
@@ -60,7 +61,7 @@ Or, you can run both of these nodes together using a provided launch file:
 ::
 
     ros2 launch pyrobosim_ros demo_commands.py mode:=plan
-    ros2 launch pyrobosim_ros demo_commands.py mode:=plan
+    ros2 launch pyrobosim_ros demo_commands.py mode:=action
 
 
 The first command will start a world as a ROS2 node, and the second one will publish a plan (or set of actions) to the node.

--- a/docs/source/usage/basic_usage.rst
+++ b/docs/source/usage/basic_usage.rst
@@ -48,11 +48,19 @@ You can run a ROS2 enabled demo and interact with the GUI:
     ros2 run pyrobosim_ros demo.py 
 
 
-In a separate node, you can publish a list of commands:
+In a separate Terminal, you can publish a single action or a plan (list of commands):
 
 ::
 
-    ros2 launch pyrobosim_ros demo_commands.py
+    ros2 run pyrobosim_ros demo_commands.py
+
+
+Or, you can run both of these nodes together using a provided launch file:
+
+::
+
+    ros2 launch pyrobosim_ros demo_commands.py mode:=plan
+    ros2 launch pyrobosim_ros demo_commands.py mode:=plan
 
 
 The first command will start a world as a ROS2 node, and the second one will publish a plan (or set of actions) to the node.

--- a/docs/source/usage/tamp.rst
+++ b/docs/source/usage/tamp.rst
@@ -62,16 +62,23 @@ To start a world and then a planner with a hard-coded goal specification:
 
 ::
 
-    ros2 run pyrobosim_ros demo_pddl_world.py --example 01_simple
-    ros2 run pyrobosim_ros demo_pddl_planner.py --example 01_simple --verbose
+    ros2 run pyrobosim_ros demo_pddl_world.py
+    ros2 run pyrobosim_ros demo_pddl_planner.py --ros-args -p example:=01_simple -p subscribe:=false
 
 To start a world, a planner, and a separate node that publishes a goal specification:
 
 ::
 
-    ros2 run pyrobosim_ros demo_pddl_world.py --example 01_simple
-    ros2 run pyrobosim_ros demo_pddl_planner.py --example 01_simple --verbose --subscribe
-    ros2 run pyrobosim_ros demo_pddl_goal_publisher.py --example 01_simple
+    ros2 run pyrobosim_ros demo_pddl_world.py
+    ros2 run pyrobosim_ros demo_pddl_planner.py --ros-args -p example:=01_simple -p subscribe:=true
+    ros2 run pyrobosim_ros demo_pddl_goal_publisher.py --ros-args -p example:=01_simple
+
+Alternatively, you can use a single launch file to run the full example and configure it:
+
+::
+
+    ros2 launch pyrobosim_ros demo_pddl.py example:=01_simple
+    ros2 launch pyrobosim_ros demo_pddl.py example:=04_nav_manip_stream subscribe:=true verbose:=true
 
 The output should look as follows:
 

--- a/pyrobosim/examples/demo.py
+++ b/pyrobosim/examples/demo.py
@@ -85,11 +85,9 @@ def start_gui(world, args):
 def parse_args():
     """ Parse command-line arguments """
     parser = argparse.ArgumentParser(description="Main pyrobosim demo.")
-    parser.add_argument("--from-file", action="store_true",
-                        help="Load from YAML file")
-    parser.add_argument("--world-file", default="test_world.yaml",
+    parser.add_argument("--world-file", default="",
                         help="YAML file name (should be in the pyrobosim/data folder). " +
-                             "Defaults to test_world.yaml")
+                             "If not specified, a world will be created programmatically.")
     return parser.parse_args()
 
 
@@ -97,10 +95,10 @@ if __name__ == "__main__":
     args = parse_args()
 
     # Create a world or load it from file.
-    if args.from_file:
-        w = create_world_from_yaml(args.world_file)
-    else:
+    if args.world_file == "":
         w = create_world()
+    else:
+        w = create_world_from_yaml(args.world_file)        
 
     # Start the program either as ROS2 node or standalone.
     start_gui(w, sys.argv)

--- a/pyrobosim/pyrobosim/core/locations.py
+++ b/pyrobosim/pyrobosim/core/locations.py
@@ -194,6 +194,10 @@ class ObjectSpawn:
         else:
             self.viz_color = self.parent.viz_color
 
+        self.set_pose_from_parent()
+
+    def set_pose_from_parent(self):
+        """ Updates the object spawn's pose from its parent's pose. """
         # Get the footprint and height data
         if "footprint" not in self.metadata:
             self.metadata["footprint"] = {"type": "parent"}

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -353,7 +353,8 @@ class World:
         new_polygon = transform_polygon(loc.raw_polygon, pose)
         is_valid_pose = new_polygon.within(room.polygon)
         for other_loc in room.locations:
-            is_valid_pose = is_valid_pose and not new_polygon.intersects(other_loc.polygon)
+            if loc != other_loc:
+                is_valid_pose = is_valid_pose and not new_polygon.intersects(other_loc.polygon)
         if not is_valid_pose:
             warnings.warn(f"Location {loc.name} in collision. Cannot add to world.")
             return False
@@ -364,7 +365,8 @@ class World:
         room.locations.append(loc)
         loc.set_pose(pose)
         loc.create_polygons(self.inflation_radius)
-        loc.create_spawn_locations()
+        for spawn in loc.children:
+            spawn.set_pose_from_parent()
         return True
 
     def remove_location(self, loc):

--- a/pyrobosim/pyrobosim/data/pddlstream/domains/04_nav_manip_stream/streams.pddl
+++ b/pyrobosim/pyrobosim/data/pddlstream/domains/04_nav_manip_stream/streams.pddl
@@ -40,7 +40,7 @@
     :certified (and (Pose ?p) (Placeable ?l ?o ?p))
   )
 
-  ; T-COLLISION-FREE: Check if a pose pose is collision free
+  ; T-COLLISION-FREE: Check if a placement pose is collision free
   (:stream t-collision-free
     :inputs (?o1 ?p1 ?o2 ?p2)
     :domain (and (Obj ?o1) (Pose ?p1)

--- a/pyrobosim_ros/CMakeLists.txt
+++ b/pyrobosim_ros/CMakeLists.txt
@@ -34,4 +34,10 @@ install(DIRECTORY
   DESTINATION share/${PROJECT_NAME}
 )
 
+# Install launch files
+install(DIRECTORY
+  launch
+  DESTINATION share/${PROJECT_NAME}
+)
+
 ament_package()

--- a/pyrobosim_ros/examples/demo.py
+++ b/pyrobosim_ros/examples/demo.py
@@ -84,40 +84,36 @@ def start_gui(world, args):
     sys.exit(app.exec_())
 
 
-def start_ros_node(world):
+def create_ros_node():
     """ Initializes ROS node """
     import rclpy
     from pyrobosim.core.ros_interface import WorldROSWrapper
 
     rclpy.init()
-    world_node = WorldROSWrapper(world, name="test_world", state_pub_rate=0.1)
-    world_node.start()
+    node = WorldROSWrapper(state_pub_rate=0.1)
+    node.declare_parameter("world_file", value="")
+    
+    # Set the world
+    world_file = node.get_parameter("world_file").value
+    if world_file == "":
+        node.get_logger().info("Creating demo world programmatically.")
+        w = create_world()
+    else:
+        node.get_logger().info(f"Using world file {world_file}.")
+        w = create_world_from_yaml(world_file)
+        
+    node.set_world(w)
 
-
-def parse_args():
-    """ Parse command-line arguments """
-    parser = argparse.ArgumentParser(description="Main pyrobosim ROS2 demo.")
-    parser.add_argument("--from-file", action="store_true",
-                        help="Load from YAML file")
-    parser.add_argument("--world-file", default="test_world.yaml",
-                        help="YAML file name (should be in the pyrobosim/data folder). " +
-                             "Defaults to test_world.yaml")
-    return parser.parse_args()
+    return node
 
 
 if __name__ == "__main__":
-    args = parse_args()
+    n = create_ros_node()
 
-    # Create a world or load it from file.
-    if args.from_file:
-        w = create_world_from_yaml(args.world_file)
-    else:
-        w = create_world()
-
-    # Start ROS Node in separate thread
+    # Start ROS node in separate thread
     import threading
-    t = threading.Thread(target=start_ros_node, args=(w,))
+    t = threading.Thread(target=n.start)
     t.start()
 
     # Start GUI in main thread
-    start_gui(w, sys.argv)
+    start_gui(n.world, sys.argv)

--- a/pyrobosim_ros/examples/demo.py
+++ b/pyrobosim_ros/examples/demo.py
@@ -6,7 +6,6 @@ additionally starting up a ROS interface.
 """
 import os
 import sys
-import argparse
 import numpy as np
 
 from pyrobosim.core.robot import Robot

--- a/pyrobosim_ros/examples/demo_commands.py
+++ b/pyrobosim_ros/examples/demo_commands.py
@@ -32,18 +32,22 @@ def main():
     rclpy.init()
     cmd = Commander()
 
-    # Add delay to ensure publishers and the world are ready.
-    # TODO: Wait for the world node to be running instead of hard-coded delay.
-    time.sleep(3.0)
-
     # Choose between action or plan command, based on input parameter.
     mode = cmd.get_parameter("mode").value
     if mode == "action":
+        cmd.get_logger().info("Waiting for subscription")
+        while cmd.action_pub.get_subscription_count() < 1:
+            time.sleep(2.0)
+
         cmd.get_logger().info("Publishing sample task action...")
         action_msg = TaskAction(type="navigate", target_location="desk")
         cmd.action_pub.publish(action_msg)
 
     elif mode == "plan":
+        cmd.get_logger().info("Waiting for subscription")
+        while cmd.plan_pub.get_subscription_count() < 1:
+            time.sleep(2.0)
+
         cmd.get_logger().info("Publishing sample task plan...")
         task_actions = [
             TaskAction(type="navigate", target_location="desk"),

--- a/pyrobosim_ros/examples/demo_commands.py
+++ b/pyrobosim_ros/examples/demo_commands.py
@@ -4,7 +4,6 @@
 Test script showing how to publish actions and plans
 """
 
-import argparse
 import rclpy
 from rclpy.node import Node
 import time
@@ -13,9 +12,8 @@ from pyrobosim_msgs.msg import TaskAction, TaskPlan
 
 
 class Commander(Node):
-    def __init__(self, name="pyrobosim"):
-        self.name = name
-        super().__init__(self.name + "_command_publisher", namespace=self.name)
+    def __init__(self):
+        super().__init__("demo_command_publisher")
 
         self.declare_parameter("mode", value="plan")
 
@@ -27,6 +25,9 @@ class Commander(Node):
         self.plan_pub = self.create_publisher(
             TaskPlan, "commanded_plan", 10)
 
+        # Delay to ensure world is loaded.
+        time.sleep(2.0)
+
 
 def main():
     rclpy.init()
@@ -35,19 +36,11 @@ def main():
     # Choose between action or plan command, based on input parameter.
     mode = cmd.get_parameter("mode").value
     if mode == "action":
-        cmd.get_logger().info("Waiting for subscription")
-        while cmd.action_pub.get_subscription_count() < 1:
-            time.sleep(2.0)
-
         cmd.get_logger().info("Publishing sample task action...")
         action_msg = TaskAction(type="navigate", target_location="desk")
         cmd.action_pub.publish(action_msg)
 
     elif mode == "plan":
-        cmd.get_logger().info("Waiting for subscription")
-        while cmd.plan_pub.get_subscription_count() < 1:
-            time.sleep(2.0)
-
         cmd.get_logger().info("Publishing sample task plan...")
         task_actions = [
             TaskAction(type="navigate", target_location="desk"),

--- a/pyrobosim_ros/examples/demo_pddl_world.py
+++ b/pyrobosim_ros/examples/demo_pddl_world.py
@@ -7,19 +7,10 @@ Task and Motion Planner such as PDDLStream.
 
 import os
 import sys
-import argparse
 import threading
 
 from pyrobosim.core.yaml import WorldYamlLoader
 from pyrobosim.utils.general import get_data_folder
-
-
-def parse_args():
-    """ Parse command-line arguments """
-    parser = argparse.ArgumentParser(description="PDDLStream demo world node.")
-    parser.add_argument("--example", default="01_simple",
-                        help="Example name (01_simple, 02_derived, 03_nav_stream, 04_nav_manip_stream)")
-    return parser.parse_args()
 
 
 def load_world():
@@ -38,24 +29,24 @@ def start_gui(world, args):
     sys.exit(app.exec_())
 
 
-def start_ros_node(world):
+def create_ros_node():
     """ Initializes ROS node """
     import rclpy
-    from pyrobosim.core.ros_interface import WorldROSWrapper
-
     rclpy.init()
-    world_node = WorldROSWrapper(world, name="pddl_demo", state_pub_rate=0.1)
-    world_node.start()
+
+    from pyrobosim.core.ros_interface import WorldROSWrapper
+    w = load_world()
+    node = WorldROSWrapper(world=w, name="pddl_demo", state_pub_rate=0.1)
+    return node
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    w = load_world()
+    n = create_ros_node()
 
     # Start ROS Node in separate thread
     import threading
-    t = threading.Thread(target=start_ros_node, args=(w,))
+    t = threading.Thread(target=n.start)
     t.start()
 
     # Start GUI in main thread
-    start_gui(w, sys.argv)
+    start_gui(n.world, sys.argv)

--- a/pyrobosim_ros/launch/demo.py
+++ b/pyrobosim_ros/launch/demo.py
@@ -1,0 +1,29 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch.substitutions import TextSubstitution
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+
+    # Arguments
+    world_file_arg = DeclareLaunchArgument(
+        "world_file",
+        default_value=TextSubstitution(text="")
+        description="YAML file name (should be in the pyrobosim/data folder). " +
+                    "If not specified, a world will be created programmatically."
+    )
+
+    # Nodes
+    demo_node = Node(
+        package="pyrobosim_ros",
+        executable="demo.py",
+        name="demo",
+        namespace="pyrobosim",
+        parameters=[{
+            "world_file": LaunchConfiguration("world_file")
+        }]
+    )
+
+    return LaunchDescription([world_file_arg, demo_node])

--- a/pyrobosim_ros/launch/demo_commands.py
+++ b/pyrobosim_ros/launch/demo_commands.py
@@ -1,0 +1,48 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch.substitutions import TextSubstitution
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+
+    # Arguments
+    world_file_arg = DeclareLaunchArgument(
+        "world_file",
+        default_value=TextSubstitution(text=""),
+        description="YAML file name (should be in the pyrobosim/data folder). " +
+                    "If not specified, a world will be created programmatically."
+    )
+    mode_arg = DeclareLaunchArgument(
+        "mode",
+        default_value=TextSubstitution(text="plan"),
+        description="Command mode (action or plan)"
+    )
+
+    # Nodes
+    world_node = Node(
+        package="pyrobosim_ros",
+        executable="demo.py",
+        name="demo",
+        namespace="pyrobosim",
+        parameters=[{
+            "world_file": LaunchConfiguration("world_file")
+        }]
+    )
+    command_node = Node(
+        package="pyrobosim_ros",
+        executable="demo_commands.py",
+        name="demo",
+        namespace="pyrobosim",
+        parameters=[{
+            "mode": LaunchConfiguration("mode")
+        }]
+    )
+
+    return LaunchDescription([
+        world_file_arg,
+        mode_arg, 
+        world_node,
+        command_node]
+    )

--- a/pyrobosim_ros/launch/demo_commands.py
+++ b/pyrobosim_ros/launch/demo_commands.py
@@ -24,7 +24,7 @@ def generate_launch_description():
     world_node = Node(
         package="pyrobosim_ros",
         executable="demo.py",
-        name="demo",
+        name="demo_world",
         namespace="pyrobosim",
         parameters=[{
             "world_file": LaunchConfiguration("world_file")
@@ -33,7 +33,7 @@ def generate_launch_description():
     command_node = Node(
         package="pyrobosim_ros",
         executable="demo_commands.py",
-        name="demo",
+        name="demo_commands",
         namespace="pyrobosim",
         parameters=[{
             "mode": LaunchConfiguration("mode")
@@ -44,5 +44,5 @@ def generate_launch_description():
         world_file_arg,
         mode_arg, 
         world_node,
-        command_node]
-    )
+        command_node
+    ])

--- a/pyrobosim_ros/launch/demo_pddl.py
+++ b/pyrobosim_ros/launch/demo_pddl.py
@@ -1,0 +1,73 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.conditions import IfCondition
+from launch.substitutions import LaunchConfiguration
+from launch.substitutions import TextSubstitution
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+
+    # Arguments
+    example_arg = DeclareLaunchArgument(
+        "example",
+        default_value=TextSubstitution(text="01_simple"),
+        description="Example name, must be one of " +
+                    "(01_simple, 02_derived, 03_nav_stream, 04_nav_manip_stream)"
+    )
+    verbose_arg = DeclareLaunchArgument(
+        "verbose",
+        default_value=TextSubstitution(text="true"),
+        description="Print planner output (true/false)"
+    )
+    subscribe_arg = DeclareLaunchArgument(
+        "subscribe",
+        default_value=TextSubstitution(text="true"),
+        description="If true, waits to receive goal on a subscriber."
+    )
+    search_sample_ratio_arg = DeclareLaunchArgument(
+        "search_sample_ratio",
+        default_value=TextSubstitution(text="1.0"),
+        description="Search to sample ratio for planner"
+    )
+
+    # Nodes
+    world_node = Node(
+        package="pyrobosim_ros",
+        executable="demo_pddl_world.py",
+        name="pddl_demo",
+        namespace="pyrobosim"
+    )
+    planner_node = Node(
+        package="pyrobosim_ros",
+        executable="demo_pddl_planner.py",
+        name="pddl_demo_planner",
+        namespace="pyrobosim",
+        parameters=[{
+            "example": LaunchConfiguration("example"),
+            "subscribe": LaunchConfiguration("subscribe"),
+            "verbose": LaunchConfiguration("verbose"),
+            "search_sample_ratio": LaunchConfiguration("search_sample_ratio"),
+        }]
+    )
+    goalspec_node = Node(
+        package="pyrobosim_ros",
+        executable="demo_pddl_goal_publisher.py",
+        name="pddl_demo_goal_publisher",
+        namespace="pyrobosim",
+        parameters=[{
+            "example": LaunchConfiguration("example"),
+            "verbose": LaunchConfiguration("verbose")
+        }],
+        condition=IfCondition(LaunchConfiguration("subscribe"))
+    )
+
+    return LaunchDescription([
+        example_arg,
+        verbose_arg,
+        subscribe_arg,
+        search_sample_ratio_arg,
+        world_node,
+        planner_node,
+        goalspec_node
+    ])

--- a/pyrobosim_ros/package.xml
+++ b/pyrobosim_ros/package.xml
@@ -16,6 +16,7 @@
   <!-- Execution dependencies -->
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclpy</exec_depend>
+  <exec_depend>ros2launch</exec_depend>
   <exec_depend>pyrobosim_msgs</exec_depend>
 
   <!-- Test dependencies -->


### PR DESCRIPTION
This PR aims to switch ROS examples to have parameters specified via launch files.

This will make things easier to run with a single `ros2 launch` command instead of multiple `ros2 run` commands that have to manually match certain arguments to work correctly. 