### PR TITLE
Find and replace entity names with objects in planning goal specifications

### DIFF
--- a/pyrobosim/examples/demo_pddl.py
+++ b/pyrobosim/examples/demo_pddl.py
@@ -49,21 +49,20 @@ def start_planner(world, args):
         get_default_domains_folder(), args.example)
     planner = PDDLStreamPlanner(world, domain_folder)
 
-    get = lambda entity : world.get_entity_by_name(entity)
     if args.example == "01_simple":
         # Task specification for simple example.
         goal_literals = [
-            ("At", get("robot"), get("bedroom")),
-            ("At", get("apple0"), get("table0_tabletop")),
-            ("At", get("banana0"), get("counter0_left")),
-            ("Holding", get("robot"), get("water0"))
+            ("At", "robot", "bedroom"),
+            ("At", "apple0", "table0_tabletop"),
+            ("At", "banana0", "counter0_left"),
+            ("Holding", "robot", "water0")
         ]
     elif args.example in ["02_derived", "03_nav_stream", "04_nav_manip_stream"]:
         # Task specification for derived predicate example.
         goal_literals = [
-            ("Has", get("desk0_desktop"), get("banana0")),
-            ("Has", "counter", get("apple1")),
-            ("HasNone", get("bathroom"), "banana"),
+            ("Has", "desk0_desktop", "banana0"),
+            ("Has", "counter", "apple1"),
+            ("HasNone", "bathroom", "banana"),
             ("HasAll", "table", "water"),
         ]
     else:

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -885,6 +885,36 @@ class World:
                     return spawn
         return None
 
+    def get_object_spawns(self, category_list=None):
+        """ 
+        Gets all object spawn locations, optionally filtered by category.
+        
+        :param category_list: Optional list of categories to filter by.
+        :type category_list: list[str]
+        :return: List of object spawn locations that match the input category
+            list, if specified.
+        :rtype: list[:class:`pyrobosim.core.locations.ObjectSpawn`]
+        """
+        spawn_list = []
+        for loc in self.locations:
+            if not category_list or loc.category in category_list:
+                spawn_list.extend(loc.children)
+
+    def get_object_spawn_names(self, category_list=None):
+        """ 
+        Gets all object spawn location names, optionally filtered by category.
+        
+        :param category_list: Optional list of categories to filter by.
+        :type category_list: list[str]
+        :return: List of object spawn location names that match the input
+            category list, if specified.
+        :rtype: list[str]
+        """
+        spawn_name_list = []
+        for loc in self.locations:
+            if not category_list or loc.category in category_list:
+                spawn_name_list.extend([spawn.name for spawn in loc.children])
+
     def get_objects(self, category_list=None):
         """ 
         Gets all objects in the world, optionally filtered by category. 

--- a/pyrobosim/pyrobosim/planning/pddlstream/planner.py
+++ b/pyrobosim/pyrobosim/planning/pddlstream/planner.py
@@ -7,7 +7,8 @@ from pddlstream.language.constants import And, PDDLProblem
 from pddlstream.utils import read
 
 from .mappings import get_stream_info, get_stream_map
-from .utils import world_to_pddlstream_init, pddlstream_solution_to_plan
+from .utils import process_goal_specification, world_to_pddlstream_init, \
+    pddlstream_solution_to_plan
 
 
 class PDDLStreamPlanner:
@@ -68,6 +69,7 @@ class PDDLStreamPlanner:
         """
         # Set the initial and goal states for PDDLStream
         init = world_to_pddlstream_init(self.world)
+        process_goal_specification(goal_literals, self.world)
         goal = And(*goal_literals)
         self.latest_specification = goal
 

--- a/pyrobosim/pyrobosim/planning/pddlstream/utils.py
+++ b/pyrobosim/pyrobosim/planning/pddlstream/utils.py
@@ -81,6 +81,41 @@ def world_to_pddlstream_init(world):
     return init
 
 
+def process_goal_specification(goal_literals, world):
+    """
+    Processes and validates a goal specification for planning.
+
+    :param goal_literals: List of literals describing a goal specification.
+    :type goal_literals: list[tuple]
+    """
+    for i, literal in enumerate(goal_literals):
+        # If any predicate has a string argument, check whether it corresponds
+        # to a named entity in the world. If it does, replace it.
+        for j, elem in enumerate(literal):
+            if j > 0 and isinstance(elem, str):
+                entity = world.get_entity_by_name(elem)
+                if entity:
+                    replace_goal_literal_tuple(goal_literals, i, j, entity)
+
+
+def replace_goal_literal_tuple(goal_literals, literal_idx, arg_idx, new_val):
+    """
+    Utility function to replace the element of a goal literal tuple in place.
+    
+    :param goal_literals: List of literals describing a goal specification.
+    :type goal_literals: list[tuple]   
+    :param literal_idx: Index of goal literal in list to replace.
+    :type literal_idx: int
+    :param arg_idx: Index of argument in goal literal to replace.
+    :type arg_idx: int
+    :param new_val: New value to replace inside the goal literal tuple.
+    :type new_val: Any
+    """
+    literal_copy = list(goal_literals[literal_idx])
+    literal_copy[arg_idx] = new_val
+    goal_literals[literal_idx] = tuple(literal_copy)
+
+
 def pddlstream_solution_to_plan(solution):
     """
     Converts the output plan of a PDDLStream solution to a plan

--- a/pyrobosim_ros/examples/demo_pddl_planner.py
+++ b/pyrobosim_ros/examples/demo_pddl_planner.py
@@ -66,21 +66,20 @@ class PlannerNode(Node):
             self.goalspec_sub = self.create_subscription(
                 GoalSpecification, "goal_specification", self.goalspec_callback, 10)
         else:
-            get = lambda entity : self.world.get_entity_by_name(entity)
             if example == "01_simple":
                 # Task specification for simple example.
                 self.latest_goal = [
-                    ("At", get("robot"), get("bedroom")),
-                    ("At", get("apple0"), get("table0_tabletop")),
-                    ("At", get("banana0"), get("counter0_left")),
-                    ("Holding", get("robot"), get("water0"))
+                    ("At", "robot", "bedroom"),
+                    ("At", "apple0", "table0_tabletop"),
+                    ("At", "banana0", "counter0_left"),
+                    ("Holding", "robot", "water0")
                 ]
             elif example in ["02_derived", "03_nav_stream", "04_nav_manip_stream"]:
                 # Task specification for derived predicate example.
                 self.latest_goal = [
-                    ("Has", get("desk0_desktop"), get("banana0")),
-                    ("Has", "counter", get("apple1")),
-                    ("HasNone", get("bathroom"), "banana"),
+                    ("Has", "desk0_desktop", "banana0"),
+                    ("Has", "counter", "apple1"),
+                    ("HasNone", "bathroom", "banana"),
                     ("HasAll", "table", "water")
                 ]
             else:

--- a/test/planning/test_pddlstream_nav.py
+++ b/test/planning/test_pddlstream_nav.py
@@ -70,9 +70,7 @@ def create_test_world(add_hallway=True):
 def start_planner(world, domain_name="03_nav_stream", interactive=False):
     domain_folder = os.path.join(get_default_domains_folder(), domain_name)
     planner = PDDLStreamPlanner(world, domain_folder)
-
-    get = lambda entity: world.get_entity_by_name(entity)
-    goal_literals = [("Has", get("robot"), "apple")]
+    goal_literals = [("Has", "robot", "apple")]
 
     if interactive:
         input("Press Enter to start planning.")


### PR DESCRIPTION
This PR uses the world model utilities to parse through a planning goal specification so you can simply enter the name of an entity as a string instead of having to manually get the entity object by its name. Basically, the call to `get_entity_by_name()` is stuck inside the planning code.

Before:
```
get = lambda entity : world.get_entity_by_name(entity)
goal_literals = [
    ("At", get("robot"), get("bedroom")),
    ("At", get("apple0"), get("table0_tabletop"))
]
```

After:
```
goal_literals = [
    ("At", "robot", "bedroom"),
    ("At", "apple0", "table0_tabletop"),
]
```

Closes https://github.com/sea-bass/pyrobosim/issues/23.