### PR TITLE
Add max attempts to PDDLStream planning

### DIFF
--- a/test/planning/test_pddlstream_manip.py
+++ b/test/planning/test_pddlstream_manip.py
@@ -72,8 +72,7 @@ def start_planner(world, domain_name="04_nav_manip_stream",
                         max_attempts=max_attempts, verbose=interactive)
     if interactive:
         robot.execute_plan(plan, blocking=True)
-    if plan is not None:
-        return plan
+    return plan
 
 #####################
 # ACTUAL UNIT TESTS #

--- a/test/planning/test_pddlstream_manip.py
+++ b/test/planning/test_pddlstream_manip.py
@@ -58,7 +58,8 @@ def create_test_world(add_alt_desk=True):
     return w
 
 
-def start_planner(world, domain_name="04_nav_manip_stream", interactive=False):
+def start_planner(world, domain_name="04_nav_manip_stream",
+                  interactive=False, max_attempts=1):
     domain_folder = os.path.join(get_default_domains_folder(), domain_name)
     planner = PDDLStreamPlanner(world, domain_folder)
 
@@ -67,24 +68,25 @@ def start_planner(world, domain_name="04_nav_manip_stream", interactive=False):
     if interactive:
         input("Press Enter to start planning.")
     robot = world.robots[0]
-    plan = planner.plan(robot, goal_literals, focused=True, verbose=interactive)
+    plan = planner.plan(robot, goal_literals, focused=True,
+                        max_attempts=max_attempts, verbose=interactive)
     if interactive:
         robot.execute_plan(plan, blocking=True)
-    return plan
-
+    if plan is not None:
+        return plan
 
 #####################
 # ACTUAL UNIT TESTS #
 #####################
 def test_plan_single_desk():
     w = create_test_world(add_alt_desk=False)
-    plan = start_planner(w)
+    plan = start_planner(w, max_attempts=3)
     assert plan is not None
 
 
 def test_plan_double_desk():
     w = create_test_world(add_alt_desk=True)
-    plan = start_planner(w)
+    plan = start_planner(w, max_attempts=3)
     assert plan is not None
 
 


### PR DESCRIPTION
This PR adds a `max_attempts` argument to the `PDDLStreamPlanner.plan()` method to allow retries if task and motion planning fails.

While this was originally intended to address a flaky test which sometimes fails, I realized this utility is generally useful.