### PR TITLE
Pin Shapely version to 1.8

### DIFF
--- a/pyrobosim/setup.py
+++ b/pyrobosim/setup.py
@@ -20,7 +20,7 @@ install_requires = [
     "pycollada",
     "PyQt5",
     "PyYAML",   
-    "shapely",
+    "shapely==1.8",
     "scipy",
     "transforms3d",
     "trimesh"]


### PR DESCRIPTION
Turns out today a Shapely 2.0 was release which broke passing polygons into `descartes.patch.PolygonPatch`.

Pinning the version until a longer-term solution is found (either an update to Descartes or removing the dependency altogether).