### PR TITLE
Fix PDDLStream planner retry logic

### DIFF
--- a/pyrobosim/pyrobosim/planning/pddlstream/planner.py
+++ b/pyrobosim/pyrobosim/planning/pddlstream/planner.py
@@ -118,11 +118,11 @@ class PDDLStreamPlanner:
             # If the solution is valid, no need to try again
             # TODO: Could later consider an option to execute all the attempts
             # and take the minimum-cost plan from that batch.
-            if solution is not None and len(solution) > 0:
+            plan_out = pddlstream_solution_to_plan(solution, robot.name)
+            if plan_out is not None:
                 break
 
         # Convert the solution to a TaskPlan object.
-        plan_out = pddlstream_solution_to_plan(solution, robot.name)
         self.latest_plan = plan_out
         if verbose:
             print("\nInitial conditions:")

--- a/pyrobosim/pyrobosim/planning/pddlstream/planner.py
+++ b/pyrobosim/pyrobosim/planning/pddlstream/planner.py
@@ -118,7 +118,7 @@ class PDDLStreamPlanner:
             # If the solution is valid, no need to try again
             # TODO: Could later consider an option to execute all the attempts
             # and take the minimum-cost plan from that batch.
-            if solution is not None:
+            if solution is not None and len(solution) > 0:
                 break
 
         # Convert the solution to a TaskPlan object.

--- a/test/planning/test_pddlstream_manip.py
+++ b/test/planning/test_pddlstream_manip.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
     import threading
 
     domain_name = "04_nav_manip_stream"
-    t = threading.Thread(target=start_planner, args=(w, domain_name, True))
+    t = threading.Thread(target=start_planner, args=(w, domain_name, True, 3))
     t.start()
 
     from pyrobosim.gui.main import PyRoboSimGUI


### PR DESCRIPTION
In https://github.com/sea-bass/pyrobosim/pull/40, we added some logic to retry plans; however, the check needed to be done on the plan which is only the first element of the solution tuple.