### PR TITLE
Use dict get() method in YAML loading utilities

### DIFF
--- a/pyrobosim/pyrobosim/navigation/trajectory.py
+++ b/pyrobosim/pyrobosim/navigation/trajectory.py
@@ -29,7 +29,7 @@ def get_constant_speed_trajectory(path, linear_velocity=0.2, max_angular_velocit
 
     # Calculate the time points for the path at constant velocity, also 
     # accounting for the maximum angular velocity if specified.
-    t_pts = np.zeros_like(path.poses, dtype=np.float)
+    t_pts = np.zeros_like(path.poses, dtype=np.float64)
     for idx in range(path.num_poses - 1):
         start_pose = path.poses[idx]
         end_pose = path.poses[idx + 1]


### PR DESCRIPTION
For some reason, I had written a `get_value_or()` function to get data from a dict, but fall back to a default value if that key doesn't exist... when actually Python dicts already have a `get()` method that does just this.

I also found a small issue in another file while testing in Python 3.8 so sneaking in that fix.