### PR TITLE
Use grasp generator in robot model and `pick_object()` action

### DIFF
--- a/docs/source/yaml/world_schema.rst
+++ b/docs/source/yaml/world_schema.rst
@@ -24,15 +24,20 @@ The world schema looks as follows, where ``<angle brackets>`` are placeholders:
       locations: </path/to/location_data_file.yaml>
       objects: </path/to/object_data_file.yaml>
 
-   # Robots: For now, we only support a single robot
+   # Robots: Each robot contains basic properties, plus other add-ons such as path planners and grasp generators
    robots: 
-     - id: <value>
+     - name: <name>
        radius: <value> # Robot radius
-       location: <name> # Initial location
+       location: <loc_name> # Initial location
        pose: [<x>, <y>, <z>, <yaw>] # Initial pose, if not specified will sample
        path_planner: # Local robot path planner -- generally refers to single-query planners
          type: rrt # Supported types -- rrt
          <property>: <planner_property>
+       grasp_generator: # For object grasp generation
+         type: parallel_grasp # Supported types -- parallel_grasp
+         <property>: <grasp_generator_property>
+     - ...
+     - ...
 
    # Global path planner -- generally refers to multi-query planners
    global_path_planner:

--- a/pyrobosim/examples/demo.py
+++ b/pyrobosim/examples/demo.py
@@ -11,6 +11,7 @@ import numpy as np
 from pyrobosim.core.robot import Robot
 from pyrobosim.core.room import Room
 from pyrobosim.core.world import World
+from pyrobosim.manipulation.grasping import GraspGenerator, ParallelGraspProperties
 from pyrobosim.navigation.execution import ConstantVelocityExecutor
 from pyrobosim.utils.general import get_data_folder
 from pyrobosim.utils.pose import Pose
@@ -62,16 +63,23 @@ def create_world(multirobot=False):
     w.add_object("water", desk)
 
     # Add robots
+    grasp_props = ParallelGraspProperties(
+        max_width=0.15, depth=0.1, height=0.04,
+        width_clearance=0.01, depth_clearance=0.01
+    )
     r = Robot(name="robot", radius=0.1,
-              path_executor=ConstantVelocityExecutor())
+              path_executor=ConstantVelocityExecutor(),
+              grasp_generator=GraspGenerator(grasp_props))
     w.add_robot(r, loc="kitchen")
     if multirobot:
         robot1 = Robot(name="robot1", radius=0.08, color=(0.8, 0.8, 0),
-                path_executor=ConstantVelocityExecutor())
+                       path_executor=ConstantVelocityExecutor(),
+                       grasp_generator=GraspGenerator(grasp_props))
         w.add_robot(robot1, loc="bathroom")
 
         robby = Robot(name="robby", radius=0.06, color=(0, 0.8, 0.8),
-                    path_executor=ConstantVelocityExecutor())
+                      path_executor=ConstantVelocityExecutor(),
+                      grasp_generator=GraspGenerator(grasp_props))
         w.add_robot(robby, loc="bedroom")
         from pyrobosim.navigation.rrt import RRTPlanner
         robby.set_path_planner(

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -221,7 +221,11 @@ class Robot:
         # generate grasps here.
         # TODO: Specify allowed grasp types
         if grasp_pose is not None:
-            self.latest_grasp = Grasp(origin=grasp_pose)
+            if self.grasp_generator is not None:
+                grasp_properties = self.grasp_generator.properties
+            else:
+                grasp_properties = None
+            self.latest_grasp = Grasp(origin=grasp_pose, properties=grasp_properties)
         elif self.grasp_generator is not None:
             cuboid_pose = obj.get_grasp_cuboid_pose()
             grasps = self.grasp_generator.generate(

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -349,7 +349,7 @@ class Robot:
 
         elif action.type == "pick":
             if self.world.has_gui:
-                success = self.world.gui.canvas.pick_object(self, action.object)
+                success = self.world.gui.canvas.pick_object(self, action.object, action.pose)
             else:
                 success = self.pick_object(action.object, action.pose)
 

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -223,11 +223,7 @@ class Robot:
         if grasp_pose is not None:
             self.latest_grasp = Grasp(origin=grasp_pose)
         elif self.grasp_generator is not None:
-            cuboid_pose = Pose.from_transform(
-                np.matmul(obj.cuboid_pose.get_transform_matrix(),
-                          obj.pose.get_transform_matrix(),      
-                )
-            )
+            cuboid_pose = obj.get_grasp_cuboid_pose()
             grasps = self.grasp_generator.generate(
                 obj.cuboid_dims, cuboid_pose, self.pose,
                 front_grasps=True, top_grasps=True, side_grasps=False

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -233,18 +233,11 @@ class Robot:
                 front_grasps=True, top_grasps=True, side_grasps=False
             )
 
-            # DEBUG DISPLAY
-            # obj_footprint = np.array(list(obj.raw_polygon.exterior.coords))
-            # self.grasp_generator.show_grasps(
-            #     obj.cuboid_dims, grasps, cuboid_pose,
-            #     self.pose, obj_footprint)
-            # END DEBUG DISPLAY
-
             if len(grasps) == 0:
                 warnings.warn(f"Could not generate valid grasps. Cannot pick.")
                 return False
             else:
-                # TODO: For now, just pick a random grasp. Logic could be improved.
+                # TODO: For now, just pick a random grasp.
                 self.latest_grasp = np.random.choice(grasps)
                 print(self.latest_grasp)
 

--- a/pyrobosim/pyrobosim/data/pddlstream_simple_world.yaml
+++ b/pyrobosim/pyrobosim/data/pddlstream_simple_world.yaml
@@ -27,6 +27,16 @@ robots:
       bidirectional: false
       rrt_star: true
       rewire_radius: 1.5
+    grasping:
+      generator: parallel_grasp
+      max_width: 0.15
+      depth: 0.1
+      height: 0.04
+      width_clearance: 0.01
+      depth_clearance: 0.01
+      front_grasps: true
+      top_grasps: true
+      side_grasps: false
 
 
 # PLANNING: Global planner

--- a/pyrobosim/pyrobosim/data/pddlstream_simple_world.yaml
+++ b/pyrobosim/pyrobosim/data/pddlstream_simple_world.yaml
@@ -34,9 +34,6 @@ robots:
       height: 0.04
       width_clearance: 0.01
       depth_clearance: 0.01
-      front_grasps: true
-      top_grasps: true
-      side_grasps: false
 
 
 # PLANNING: Global planner

--- a/pyrobosim/pyrobosim/data/test_world.yaml
+++ b/pyrobosim/pyrobosim/data/test_world.yaml
@@ -15,7 +15,7 @@ metadata:
   objects: $DATA/example_object_data.yaml
 
 
-# ROBOTS: For now, we only support a single robot
+# ROBOTS
 robots:
   - name: robot
     radius: 0.1
@@ -28,7 +28,14 @@ robots:
     #   bidirectional: true
     #   rrt_star: true
     #   rewire_radius: 1.0
-
+    # Grasp generation
+    grasping:
+      generator: parallel_grasp
+      max_width: 0.15
+      depth: 0.1
+      height: 0.04
+      width_clearance: 0.01
+      depth_clearance: 0.01
 
 # PLANNING: Global planner
 global_path_planner:

--- a/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
+++ b/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
@@ -33,9 +33,6 @@ robots:
       height: 0.04
       width_clearance: 0.01
       depth_clearance: 0.01
-      front_grasps: true
-      top_grasps: true
-      side_grasps: false
 
   - name: "robby"
     radius: 0.06

--- a/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
+++ b/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
@@ -15,16 +15,28 @@ metadata:
   objects: $DATA/example_object_data.yaml
 
 
-# ROBOTS: For now, we only support a single robot
+# ROBOTS
 robots:
   - name: "robot"
     radius: 0.1
     color: [0.8, 0.0, 0.8]
     location: kitchen
     pose: [0, 0, 0]
+
   - radius: 0.08
     color: [0.8, 0.8, 0.0]
     location: bathroom
+    grasping:
+      generator: parallel_grasp
+      max_width: 0.15
+      depth: 0.1
+      height: 0.04
+      width_clearance: 0.01
+      depth_clearance: 0.01
+      front_grasps: true
+      top_grasps: true
+      side_grasps: false
+
   - name: "robby"
     radius: 0.06
     color: [0.0, 0.8, 0.8]

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -401,7 +401,7 @@ class WorldCanvas(FigureCanvasQTAgg):
             time.sleep(0.1)
         return True
 
-    def pick_object(self, robot, obj_name):
+    def pick_object(self, robot, obj_name, grasp_pose=None):
         """
         Picks an object with a specified robot.
 
@@ -409,11 +409,13 @@ class WorldCanvas(FigureCanvasQTAgg):
         :type robot: :class:`pyrobosim.core.robot.Robot`
         :param obj_name: The name of the object.
         :type obj_name: str
+        :param grasp_pose: A pose describing how to manipulate the object.
+        :type grasp_pose: :class:`pyrobosim.utils.pose.Pose`, optional
         :return: True if picking succeeds, else False
         :rtype: bool
         """
         if robot is not None:
-            success = robot.pick_object(obj_name)
+            success = robot.pick_object(obj_name, grasp_pose)
             if success:
                 self.update_object_plot(robot.manipulated_object)
                 self.show_world_state(robot)

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -439,7 +439,6 @@ class WorldCanvas(FigureCanvasQTAgg):
             obj.viz_patch.remove()
             success = robot.place_object(pose=pose)
             self.axes.add_patch(obj.viz_patch)
-            self.update_object_plot(obj)
             self.show_world_state(robot)
             self.draw_and_sleep()
             return success


### PR DESCRIPTION
This PR builds on https://github.com/sea-bass/pyrobosim/pull/44 and adds the ability to configure a grasp generator for a robot, as well as use it as part of a robot's `pick_object()` action with some basic logic.

The idea is that for a "real" task and motion planner, the grasp generator will be used elsewhere and the pose will directly be passed into the action interface.

Makes progress towards #45.