### PR TITLE
Use `QThread` instead of regular threads so closing the GUI exits the program

### DIFF
--- a/pyrobosim/examples/demo_prm.py
+++ b/pyrobosim/examples/demo_prm.py
@@ -29,7 +29,6 @@ if __name__ == "__main__":
     test_prm()
 
     import sys
-    from pyrobosim.gui.main import PyRoboSimGUI
+    from pyrobosim.gui.main import start_gui
 
-    app = PyRoboSimGUI(w, sys.argv)
-    sys.exit(app.exec_())
+    start_gui(w, sys.argv)

--- a/pyrobosim/examples/demo_rrt.py
+++ b/pyrobosim/examples/demo_rrt.py
@@ -29,7 +29,6 @@ if __name__ == "__main__":
     test_rrt()
 
     import sys
-    from pyrobosim.gui.main import PyRoboSimGUI
+    from pyrobosim.gui.main import start_gui
 
-    app = PyRoboSimGUI(w, sys.argv)
-    sys.exit(app.exec_())
+    start_gui(w, sys.argv)

--- a/pyrobosim/pyrobosim/core/ros_interface.py
+++ b/pyrobosim/pyrobosim/core/ros_interface.py
@@ -11,7 +11,6 @@ from pyrobosim_msgs.msg import (
     RobotState,
     LocationState,
     ObjectState,
-    WorldState,
     TaskAction,
     TaskPlan,
 )

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -8,7 +8,27 @@ from matplotlib.figure import Figure
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 from matplotlib.pyplot import Circle
 from matplotlib.transforms import Affine2D
-from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtCore import pyqtSignal, QThread
+
+
+class NavMonitor(QThread):
+    """
+    Helper class that monitors navigation animation in a QThread
+    """
+
+    def __init__(self, canvas):
+        """
+        Creates a navigation monitor thread.
+
+        :param canvas: A world canvas object linked to this thread.
+        :type canvas: :class:`pyrobosim.gui.world_canvas.WorldCanvas`
+        """
+        super(NavMonitor, self).__init__()
+        self.canvas = canvas
+
+    def run(self):
+        """Runs the navigation monitor thread."""
+        self.canvas.monitor_nav_animation()
 
 
 class WorldCanvas(FigureCanvasQTAgg):
@@ -68,7 +88,7 @@ class WorldCanvas(FigureCanvasQTAgg):
         self.draw_lock = False
 
         # Start thread for monitoring robot navigation state.
-        self.nav_animator = threading.Thread(target=self.monitor_nav_animation)
+        self.nav_animator = NavMonitor(self)
         self.nav_animator.start()
 
     def show_robots(self):

--- a/pyrobosim_ros/examples/demo.py
+++ b/pyrobosim_ros/examples/demo.py
@@ -6,6 +6,7 @@ additionally starting up a ROS interface.
 """
 import os
 import sys
+import threading
 import numpy as np
 
 from pyrobosim.core.robot import Robot
@@ -119,8 +120,6 @@ if __name__ == "__main__":
     n = create_ros_node()
 
     # Start ROS node in separate thread
-    import threading
-
     t = threading.Thread(target=n.start)
     t.start()
 

--- a/pyrobosim_ros/examples/demo_pddl_world.py
+++ b/pyrobosim_ros/examples/demo_pddl_world.py
@@ -40,8 +40,6 @@ if __name__ == "__main__":
     n = create_ros_node()
 
     # Start ROS Node in separate thread
-    import threading
-
     t = threading.Thread(target=n.start)
     t.start()
 

--- a/test/planning/test_pddlstream_manip.py
+++ b/test/planning/test_pddlstream_manip.py
@@ -135,7 +135,6 @@ if __name__ == "__main__":
     )
     t.start()
 
-    from pyrobosim.gui.main import PyRoboSimGUI
+    from pyrobosim.gui.main import start_gui
 
-    app = PyRoboSimGUI(w, sys.argv)
-    sys.exit(app.exec_())
+    start_gui(w, sys.argv)

--- a/test/planning/test_pddlstream_nav.py
+++ b/test/planning/test_pddlstream_nav.py
@@ -9,6 +9,7 @@ import sys
 from pyrobosim.core.robot import Robot
 from pyrobosim.core.room import Room
 from pyrobosim.core.world import World
+from pyrobosim.gui.main import start_gui
 from pyrobosim.navigation.execution import ConstantVelocityExecutor
 from pyrobosim.navigation.rrt import RRTPlanner
 from pyrobosim.planning.pddlstream.planner import PDDLStreamPlanner
@@ -119,7 +120,4 @@ if __name__ == "__main__":
     t = threading.Thread(target=start_planner, args=(w, domain_name, True))
     t.start()
 
-    from pyrobosim.gui.main import PyRoboSimGUI
-
-    app = PyRoboSimGUI(w, sys.argv)
-    sys.exit(app.exec_())
+    start_gui(w, sys.argv)


### PR DESCRIPTION
I realized that closing the `pyrobosim` GUI makes the program just... never exit, so I found a solution using `QThread` instead of the regular `threading.Thread`. Seems to fix the issue for me!