### PR TITLE
Pin to Matplotlib 3.4.3

### DIFF
--- a/pyrobosim/setup.py
+++ b/pyrobosim/setup.py
@@ -17,6 +17,7 @@ def get_files_in_folder(directory):
 install_requires = [
     "adjustText",
     "astar",
+    "matplotlib==3.4.3",
     "numpy",
     "pycollada",
     "PyQt5",


### PR DESCRIPTION
There is a [bug](https://github.com/matplotlib/matplotlib/issues/22093) with newer matplotlib versions (3.5.0 and up) where deleting the artists before redrawing a path yields this:

```
 in show_planner_and_path
    self.axes.lines.remove(e)
AttributeError: 'ArtistList' object has no attribute 'remove'
```

For now, I will pin down the version and then do a longer-term fix when I can.