### PR TITLE
Fix matplotlib artist removal for later versions

### DIFF
--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -281,8 +281,8 @@ class WorldCanvas(FigureCanvasQTAgg):
         :param path: The path to display.
         :type path: :class:`pyrobosim.utils.motion.Path`
         """
-        for e in self.path_planner_artists:
-            self.axes.lines.remove(e)
+        for artist in self.path_planner_artists:
+            artist.remove()
         self.path_planner_artists = []
         x = [p.x for p in path.poses]
         y = [p.y for p in path.poses]
@@ -308,8 +308,8 @@ class WorldCanvas(FigureCanvasQTAgg):
         while self.draw_lock:
             time.sleep(0.001)
         self.draw_lock = True
-        for e in self.path_planner_artists:
-            self.axes.lines.remove(e)
+        for artist in self.path_planner_artists:
+            artist.remove()
 
         color = robot.color if robot is not None else "m"
 

--- a/pyrobosim/setup.py
+++ b/pyrobosim/setup.py
@@ -17,6 +17,7 @@ def get_files_in_folder(directory):
 install_requires = [
     "adjustText",
     "astar",
+    "matplotlib",
     "numpy",
     "pycollada",
     "PyQt5",


### PR DESCRIPTION
This addresses the matplotlib issue we found related to https://github.com/matplotlib/matplotlib/issues/22093, without having to pin down to an older version.

I tried with version 3.4 and 3.7.1 (the latest available right now).

Try it out? Best way is to remove any virtual environment you may have, or at least manually upgrade your matplotlib to the latest.