### PR TITLE
Unify world entity creation arguments

### DIFF
--- a/docs/source/yaml/location_schema.rst
+++ b/docs/source/yaml/location_schema.rst
@@ -37,15 +37,15 @@ A simple object with a box footprint and one object spawn that inherits parent g
        type: box
        dims: [0.9, 1.2]
        height: 0.5              # 0.5 m off the ground
-  nav_poses:                    # List of navigation poses around the location origin
-    - [-0.75, 0, 0]             # (the children below will inherit the parent's poses)
-    - [0.75, 0, 0.0, 3.14]
-  locations:                    # List of locations
-    - name: "tabletop"          # The location name will be "<loc_name>_tabletop"
-      footprint:
-        type: parent            # "parent" footprint means we inherit parent's box geometry
-        padding: 0.1            # 10 cm padding relative to the parent geometry
-  color: [0.2, 0, 0]            # Dark red
+     nav_poses:                 # List of navigation poses around the location origin
+       - [-0.75, 0, 0]          # (the children below will inherit the parent's poses)
+       - [0.75, 0, 0.0, 3.14]
+     locations:                 # List of locations
+       - name: "tabletop"       # The location name will be "<loc_name>_tabletop"
+         footprint:
+           type: parent         # "parent" footprint means we inherit parent's box geometry
+           padding: 0.1         # 10 cm padding relative to the parent geometry
+     color: [0.2, 0, 0]         # Dark red
 
 A more complex object with a box footprint and two separate object spawns.
 

--- a/docs/source/yaml/world_schema.rst
+++ b/docs/source/yaml/world_schema.rst
@@ -81,6 +81,6 @@ The world schema looks as follows, where ``<angle brackets>`` are placeholders:
    # Objects
    objects:
      - name: <obj_name>  # If not specified, will be automatic
-       type: <obj_category>  # From object YAML file
-       location: <loc_name>
+       category: <obj_category>  # From object YAML file
+       parent: <loc_name>
        pose: [<x>, <y>, <z>, <yaw>]  # If not specified, will sample

--- a/docs/source/yaml/world_schema.rst
+++ b/docs/source/yaml/world_schema.rst
@@ -71,16 +71,16 @@ The world schema looks as follows, where ``<angle brackets>`` are placeholders:
 
    # Locations
    locations:
-     - name: <loc_name> # If not specified, will be automatic
-       type: <loc_category> # From location YAML file
-       room: <room_name>
-       pose: [<x>, <y>, <z>, <yaw>] # If not specified, will sample
+     - name: <loc_name>  # If not specified, will be automatic
+       category: <loc_category>  # From location YAML file
+       parent: <room_name>
+       pose: [<x>, <y>, <z>, <yaw>]  # If not specified, will sample
      - ...
      - ...
 
    # Objects
    objects:
-     - name: <obj_name> # If not specified, will be automatic
-       type: <obj_category> # From object YAML file
+     - name: <obj_name>  # If not specified, will be automatic
+       type: <obj_category>  # From object YAML file
        location: <loc_name>
-       pose: [<x>, <y>, <z>, <yaw>] # If not specified, will sample
+       pose: [<x>, <y>, <z>, <yaw>]  # If not specified, will sample

--- a/docs/source/yaml/world_schema.rst
+++ b/docs/source/yaml/world_schema.rst
@@ -61,8 +61,8 @@ The world schema looks as follows, where ``<angle brackets>`` are placeholders:
 
    # Hallways (refer to Hallways API)
    hallways:
-     - from: <room1>
-       to: <room2>
+     - room_start: <room1>
+       room_end: <room2>
        width: <value>
        conn_method: <type>
        <conn_property>: <value>

--- a/pyrobosim/examples/demo.py
+++ b/pyrobosim/examples/demo.py
@@ -42,13 +42,18 @@ def create_world(multirobot=False):
     world.add_room(name="bathroom", footprint=r3coords, color=[0, 0, 0.6])
 
     # Add hallways between the rooms
-    world.add_hallway("kitchen", "bathroom", width=0.7)
+    world.add_hallway(room_start="kitchen", room_end="bathroom", width=0.7)
     world.add_hallway(
-        "bathroom", "bedroom", width=0.5, conn_method="angle", conn_angle=0, offset=0.8
+        room_start="bathroom",
+        room_end="bedroom",
+        width=0.5,
+        conn_method="angle",
+        conn_angle=0,
+        offset=0.8,
     )
     world.add_hallway(
-        "kitchen",
-        "bedroom",
+        room_start="kitchen",
+        room_end="bedroom",
         width=0.6,
         conn_method="points",
         conn_points=[(1.0, 0.5), (2.5, 0.5), (2.5, 3.0)],

--- a/pyrobosim/examples/demo.py
+++ b/pyrobosim/examples/demo.py
@@ -61,13 +61,17 @@ def create_world(multirobot=False):
 
     # Add locations
     table = world.add_location(
-        "table", "kitchen", Pose(x=0.85, y=-0.5, z=0.0, yaw=-np.pi / 2)
+        category="table",
+        parent="kitchen",
+        pose=Pose(x=0.85, y=-0.5, z=0.0, yaw=-np.pi / 2.0),
     )
-    desk = world.add_location("desk", "bedroom", Pose(x=3.15, y=3.65, z=0.0, yaw=0.0))
+    desk = world.add_location(
+        category="desk", parent="bedroom", pose=Pose(x=3.15, y=3.65, z=0.0, yaw=0.0)
+    )
     counter = world.add_location(
-        "counter",
-        "bathroom",
-        Pose(x=-2.45, y=2.5, z=0.0, q=[0.634411, 0.0, 0.0, 0.7729959]),
+        category="counter",
+        parent="bathroom",
+        pose=Pose(x=-2.45, y=2.5, z=0.0, q=[0.634411, 0.0, 0.0, 0.7729959]),
     )
 
     # Add objects

--- a/pyrobosim/examples/demo.py
+++ b/pyrobosim/examples/demo.py
@@ -7,7 +7,7 @@ import os
 import argparse
 import numpy as np
 
-from pyrobosim.core import Robot, Room, World, WorldYamlLoader
+from pyrobosim.core import Robot, World, WorldYamlLoader
 from pyrobosim.gui import start_gui
 from pyrobosim.manipulation import GraspGenerator, ParallelGraspProperties
 from pyrobosim.navigation import ConstantVelocityExecutor, RRTPlanner
@@ -31,17 +31,15 @@ def create_world(multirobot=False):
     # Add rooms
     r1coords = [(-1, -1), (1.5, -1), (1.5, 1.5), (0.5, 1.5)]
     world.add_room(
-        Room(
-            r1coords,
-            name="kitchen",
-            color=[1, 0, 0],
-            nav_poses=[Pose(x=0.75, y=0.75, z=0.0, yaw=0.0)],
-        )
+        name="kitchen",
+        footprint=r1coords,
+        color=[1, 0, 0],
+        nav_poses=[Pose(x=0.75, y=0.75, z=0.0, yaw=0.0)],
     )
     r2coords = [(1.75, 2.5), (3.5, 2.5), (3.5, 4), (1.75, 4)]
-    world.add_room(Room(r2coords, name="bedroom", color=[0, 0.6, 0]))
+    world.add_room(name="bedroom", footprint=r2coords, color=[0, 0.6, 0])
     r3coords = [(-1, 1), (-1, 3.5), (-3.0, 3.5), (-2.5, 1)]
-    world.add_room(Room(r3coords, name="bathroom", color=[0, 0, 0.6]))
+    world.add_room(name="bathroom", footprint=r3coords, color=[0, 0, 0.6])
 
     # Add hallways between the rooms
     world.add_hallway("kitchen", "bathroom", width=0.7)

--- a/pyrobosim/examples/demo.py
+++ b/pyrobosim/examples/demo.py
@@ -76,16 +76,18 @@ def create_world(multirobot=False):
 
     # Add objects
     world.add_object(
-        "banana",
-        table,
+        category="banana",
+        parent=table,
         pose=Pose(x=1.0, y=-0.5, z=0.0, q=[0.9238811, 0.0, 0.0, 0.3826797]),
     )
-    world.add_object("apple", desk, pose=Pose(x=3.2, y=3.5, z=0.0, yaw=0.0))
-    world.add_object("apple", table)
-    world.add_object("apple", table)
-    world.add_object("water", counter)
-    world.add_object("banana", counter)
-    world.add_object("water", desk)
+    world.add_object(
+        category="apple", parent=desk, pose=Pose(x=3.2, y=3.5, z=0.0, yaw=0.0)
+    )
+    world.add_object(category="apple", parent=table)
+    world.add_object(category="apple", parent=table)
+    world.add_object(category="water", parent=counter)
+    world.add_object(category="banana", parent=counter)
+    world.add_object(category="water", parent=desk)
 
     # Add robots
     grasp_props = ParallelGraspProperties(

--- a/pyrobosim/examples/test_world.py
+++ b/pyrobosim/examples/test_world.py
@@ -60,7 +60,11 @@ class TestWorldModeling:
         """Tests the creation of a hallway between 2 rooms"""
 
         TestWorldModeling.world.add_hallway(
-            "kitchen", "bedroom", offset=0.5, conn_method="auto", width=0.5
+            room_start="kitchen",
+            room_start="bedroom",
+            offset=0.5,
+            conn_method="auto",
+            width=0.5,
         )
         assert len(TestWorldModeling.world.hallways) == 1
 

--- a/pyrobosim/examples/test_world.py
+++ b/pyrobosim/examples/test_world.py
@@ -61,7 +61,7 @@ class TestWorldModeling:
 
         TestWorldModeling.world.add_hallway(
             room_start="kitchen",
-            room_start="bedroom",
+            room_end="bedroom",
             offset=0.5,
             conn_method="auto",
             width=0.5,

--- a/pyrobosim/examples/test_world.py
+++ b/pyrobosim/examples/test_world.py
@@ -79,7 +79,9 @@ class TestWorldModeling:
     def test_create_location():
         """Tests the creation of locations"""
         table = TestWorldModeling.world.add_location(
-            "table", "kitchen", Pose(x=0.85, y=-0.5, z=0.0, yaw=-np.pi / 2)
+            category="table",
+            parent="kitchen",
+            pose=Pose(x=0.85, y=-0.5, z=0.0, yaw=-np.pi / 2.0),
         )
 
         assert len(TestWorldModeling.world.locations) == 1
@@ -88,8 +90,8 @@ class TestWorldModeling:
         )  # automatic naming check
 
         desk = TestWorldModeling.world.add_location(
-            "desk",
-            "bedroom",
+            category="desk",
+            parent="bedroom",
             name="study_desk",
             pose=Pose(x=3.15, y=3.65, z=0.0, yaw=0.0),
         )

--- a/pyrobosim/examples/test_world.py
+++ b/pyrobosim/examples/test_world.py
@@ -110,8 +110,8 @@ class TestWorldModeling:
     def test_create_object():
         """Tests adding objects to a location"""
 
-        TestWorldModeling.world.add_object("apple", "table0")
-        TestWorldModeling.world.add_object("apple", "study_desk")
+        TestWorldModeling.world.add_object(category="apple", parent="table0")
+        TestWorldModeling.world.add_object(category="apple", parent="study_desk")
         assert len(TestWorldModeling.world.objects) == 2
 
         # second apple
@@ -176,7 +176,7 @@ class TestWorldModeling:
     def test_hierarchical_cleanup():
         """Tests if an entity is automatically deleted on parent deletion"""
 
-        TestWorldModeling.world.add_object("apple", "table0")
+        TestWorldModeling.world.add_object(category="apple", parent="table0")
         loc = TestWorldModeling.world.get_location_by_name("table0")
         assert len(loc.children[0].children) == 2
         assert TestWorldModeling.world.remove_room("kitchen") is True

--- a/pyrobosim/examples/test_world.py
+++ b/pyrobosim/examples/test_world.py
@@ -5,7 +5,7 @@ import os
 import pytest
 import numpy as np
 
-from pyrobosim.core import Hallway, Object, Room, World
+from pyrobosim.core import Hallway, Object, World
 from pyrobosim.utils.pose import Pose
 
 from pyrobosim.utils.general import get_data_folder
@@ -33,19 +33,21 @@ class TestWorldModeling:
 
         room1_name = "kitchen"
         room1_coords = [(-1, -1), (1.5, -1), (1.5, 1.5), (0.5, 1.5)]
-        room1 = Room(room1_coords, name=room1_name, color=[1, 0, 0])
-        TestWorldModeling.world.add_room(room1)
+        TestWorldModeling.world.add_room(
+            name=room1_name, footprint=room1_coords, color=[1, 0, 0]
+        )
 
         assert len(TestWorldModeling.world.rooms) == 1
-        assert TestWorldModeling.world.get_room_by_name(room1_name) == room1
+        assert TestWorldModeling.world.get_room_by_name(room1_name) is not None
 
         room2_name = "bedroom"
         room2_coords = [(1.75, 2.5), (3.5, 2.5), (3.5, 4), (1.75, 4)]
-        room2 = Room(room2_coords, name=room2_name, color=[1, 0, 0])
-        TestWorldModeling.world.add_room(room2)
+        TestWorldModeling.world.add_room(
+            name=room2_name, footprint=room2_coords, color=[1, 0, 0]
+        )
 
         assert len(TestWorldModeling.world.rooms) == 2
-        assert TestWorldModeling.world.get_room_by_name(room2_name) == room2
+        assert TestWorldModeling.world.get_room_by_name(room2_name) is not None
 
     @staticmethod
     @pytest.mark.dependency(

--- a/pyrobosim/pyrobosim/core/hallway.py
+++ b/pyrobosim/pyrobosim/core/hallway.py
@@ -15,9 +15,9 @@ class Hallway:
 
     def __init__(
         self,
-        room_start,
-        room_end,
-        hall_width,
+        room_start=None,
+        room_end=None,
+        width=0.0,
         conn_method="auto",
         offset=0,
         conn_angle=0,
@@ -37,8 +37,8 @@ class Hallway:
         :type room_start: :class:`pyrobosim.core.room.Room`
         :param room_end: Room object for the end of the hallway.
         :type room_end: :class:`pyrobosim.core.room.Room`
-        :param hall_width: Width of the hallway, in meters
-        :type hall_width: float
+        :param width: Width of the hallway, in meters
+        :type width: float
         :param conn_method: Connection method (see above)
         :type conn_method: str, optional
         :param offset: Perpendicular offset from centroid of start point
@@ -54,10 +54,19 @@ class Hallway:
         :param wall_width: Width of hallway walls, in meters.
         :type wall_width: float, optional
         """
+        # Validate input
+        if room_start is None:
+            raise Exception("room_start must be a valid Room object.")
+        if room_end is None:
+            raise Exception("room_end must be a valid Room object.")
+        if width <= 0.0:
+            raise Exception("width must be a positibe value.")
+
+        # Unpack input
         self.room_start = room_start
         self.room_end = room_end
         self.name = f"hall_{room_start.name}_{room_end.name}"
-        self.hall_width = hall_width
+        self.width = width
         self.wall_width = wall_width
         self.offset = offset
         self.viz_color = color
@@ -88,7 +97,7 @@ class Hallway:
 
         # Create the hallway polygon
         self.polygon = LineString(self.points)
-        self.polygon = inflate_polygon(self.polygon, hall_width / 2.0)
+        self.polygon = inflate_polygon(self.polygon, width / 2.0)
 
         # Get the collision and visualization polygons
         self.update_collision_polygons()

--- a/pyrobosim/pyrobosim/core/hallway.py
+++ b/pyrobosim/pyrobosim/core/hallway.py
@@ -33,13 +33,13 @@ class Hallway:
             - ``"angle"`` : Directly specifies an angle leaving the centroid of the start room.
             - ``"points"`` : Specify an explicit list of points defining the hallway.
 
-        :param room_start: Room object for the start of the hallway.
+        :param room_start: Room object for the start of the hallway (required).
         :type room_start: :class:`pyrobosim.core.room.Room`
-        :param room_end: Room object for the end of the hallway.
+        :param room_end: Room object for the end of the hallway (required).
         :type room_end: :class:`pyrobosim.core.room.Room`
-        :param width: Width of the hallway, in meters
+        :param width: Width of the hallway, in meters (required).
         :type width: float
-        :param conn_method: Connection method (see above)
+        :param conn_method: Connection method (see description above).
         :type conn_method: str, optional
         :param offset: Perpendicular offset from centroid of start point
             (valid if using ``"auto"`` or ``"angle"`` connection methods)

--- a/pyrobosim/pyrobosim/core/locations.py
+++ b/pyrobosim/pyrobosim/core/locations.py
@@ -32,26 +32,37 @@ class Location:
         """
         cls.metadata = EntityMetadata(filename)
 
-    def __init__(self, category, pose, name=None, parent=None):
+    def __init__(self, name=None, category=None, pose=None, parent=None, color=None):
         """
         Creates a location instance.
 
-        :param category: Location category (e.g., ``"table"``).
-        :type category: str
-        :param pose: Pose of the location.
-        :type pose: :class:`pyrobosim.utils.pose.Pose`
         :param name: Name of the location.
         :type name: str, optional
+        :param category: Location category (e.g., ``"table"``).
+        :type category: str
+        :param pose: Pose of the location (required).
+        :type pose: :class:`pyrobosim.utils.pose.Pose`
         :param parent: Parent of the location (typically a :class:`pyrobosim.core.room.Room`)
         :type parent: Entity
+        :param color: Visualization color as an (R, G, B) tuple in the range (0.0, 1.0).
+            If using a category with a defined color, this parameter overrides the category color.
+        :type color: (float, float, float), optional
         """
+        # Validate input
+        if parent is None:
+            raise Exception("Location parent must be specified.")
+        if pose is None:
+            raise Exception("Location pose must be specified.")
+
         # Extract the model information from the model list
         self.name = name
         self.category = category
         self.parent = parent
 
         self.metadata = Location.metadata.get(self.category)
-        if "color" in self.metadata:
+        if color is not None:
+            self.viz_color = color
+        elif "color" in self.metadata:
             self.viz_color = self.metadata["color"]
 
         self.set_pose(pose)
@@ -90,7 +101,7 @@ class Location:
         Sets the pose of a location, accounting for its navigation poses and object spawns.
         Use this instead of directly assigning the ``pose`` attribute.
 
-        :param pose: New pose for the object.
+        :param pose: New pose for the location.
         :type pose: :class:`pyrobosim.utils.pose.Pose`
         """
         # Update the actual pose

--- a/pyrobosim/pyrobosim/core/objects.py
+++ b/pyrobosim/pyrobosim/core/objects.py
@@ -19,7 +19,7 @@ class Object:
 
     # Default class attributes
     height = 0.1
-    """ Vertical height of location. """
+    """ Vertical height of object. """
     viz_color = (0, 0, 1)
     """ Visualization color (RGB tuple). """
 
@@ -34,21 +34,30 @@ class Object:
         cls.metadata = EntityMetadata(filename)
 
     def __init__(
-        self, category=None, name=None, parent=None, pose=None, inflation_radius=0.0
+        self,
+        name=None,
+        category=None,
+        parent=None,
+        pose=None,
+        inflation_radius=0.0,
+        color=None,
     ):
         """
         Creates an object instance.
 
+        :param name: Name of the object.
+        :type name: str, optional
         :param category: Object category (e.g., ``"apple"``).
         :type category: str
-        :param name: Name of the location.
-        :type name: str, optional
-        :param parent: Parent of the location (typically a :class:`pyrobosim.core.room.Room`)
+        :param parent: Parent of the object (typically a :class:`pyrobosim.core.locations.ObjectSpawn`)
         :type parent: Entity
-        :param pose: Pose of the location.
+        :param pose: Pose of the object.
         :type pose: :class:`pyrobosim.utils.pose.Pose`
         :param inflation_radius: Inflation radius for polygon collision checks.
         :type inflation_radius: float, optional
+        :param color: Visualization color as an (R, G, B) tuple in the range (0.0, 1.0).
+            If using a category with a defined color, this parameter overrides the category color.
+        :type color: (float, float, float), optional
         """
         self.category = category
         self.name = name
@@ -60,8 +69,11 @@ class Object:
         self.viz_text = None
 
         self.metadata = Object.metadata.get(self.category)
-        if "color" in self.metadata:
+        if color is not None:
+            self.viz_color = color
+        elif "color" in self.metadata:
             self.viz_color = self.metadata["color"]
+
         self.set_pose(pose)
         self.create_polygons()
         self.create_grasp_cuboid()

--- a/pyrobosim/pyrobosim/core/room.py
+++ b/pyrobosim/pyrobosim/core/room.py
@@ -16,8 +16,8 @@ class Room:
 
     def __init__(
         self,
-        footprint,
         name=None,
+        footprint=[],
         color=[0.4, 0.4, 0.4],
         wall_width=0.2,
         nav_poses=None,
@@ -26,10 +26,10 @@ class Room:
         """
         Creates a Room instance.
 
-        :param footprint: Point list or Shapely polygon describing the room 2D footprint.
-        :type footprint: :class:`shapely.geometry.Polygon`/list[:class:`pyrobosim.utils.pose.Pose`]
-        :param name: Room name
+        :param name: Room name.
         :type name: str, optional
+        :param footprint: Point list or Shapely polygon describing the room 2D footprint.
+        :type footprint: :class:`shapely.geometry.Polygon`/list[:class:`pyrobosim.utils.pose.Pose`], optional
         :param color: Visualization color as an (R, G, B) tuple in the range (0.0, 1.0)
         :type color: (float, float, float), optional
         :param wall_width: Width of room walls, in meters.
@@ -49,10 +49,13 @@ class Room:
         self.graph_nodes = []
 
         # Create the room polygon
+        self.height = height
         if isinstance(footprint, list):
             self.polygon = Polygon(footprint)
         else:
             self.polygon, _ = polygon_and_height_from_footprint(footprint)
+        if self.polygon.is_empty:
+            return
         self.centroid = list(self.polygon.centroid.coords)[0]
         self.update_collision_polygons()
         self.update_visualization_polygon()
@@ -62,7 +65,6 @@ class Room:
             self.nav_poses = nav_poses
         else:
             self.nav_poses = [Pose.from_list(self.centroid)]
-        self.height = height
 
     def update_collision_polygons(self, inflation_radius=0):
         """

--- a/pyrobosim/pyrobosim/core/room.py
+++ b/pyrobosim/pyrobosim/core/room.py
@@ -28,8 +28,8 @@ class Room:
 
         :param name: Room name.
         :type name: str, optional
-        :param footprint: Point list or Shapely polygon describing the room 2D footprint.
-        :type footprint: :class:`shapely.geometry.Polygon`/list[:class:`pyrobosim.utils.pose.Pose`], optional
+        :param footprint: Point list or Shapely polygon describing the room 2D footprint (required).
+        :type footprint: :class:`shapely.geometry.Polygon`/list[:class:`pyrobosim.utils.pose.Pose`]
         :param color: Visualization color as an (R, G, B) tuple in the range (0.0, 1.0)
         :type color: (float, float, float), optional
         :param wall_width: Width of room walls, in meters.
@@ -55,7 +55,8 @@ class Room:
         else:
             self.polygon, _ = polygon_and_height_from_footprint(footprint)
         if self.polygon.is_empty:
-            return
+            raise Exception("Room footprint cannot be empty.")
+
         self.centroid = list(self.polygon.centroid.coords)[0]
         self.update_collision_polygons()
         self.update_visualization_polygon()

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -1168,7 +1168,7 @@ class World:
         else:
             return None
 
-    def add_robot(self, robot, loc=None, pose=None, use_robot_pose=False):
+    def add_robot(self, robot, loc=None, pose=None):
         """
         Adds a robot to the world given either a world entity and/or pose.
 
@@ -1178,8 +1178,6 @@ class World:
         :type loc: Entity, optional
         :param pose: Pose at which to add the robot. If not specified, will be sampled.
         :type pose: :class:`pyrobosim.utils.pose.Pose`
-        :param use_robot_pose: If True, uses the pose already specified in the robot instance.
-        :type use_robot_pose: bool, optional
         """
         # Check that the robot name doesn't already exist.
         if robot.name in self.get_robot_names():
@@ -1194,14 +1192,7 @@ class World:
             self.set_inflation_radius(new_inflation_radius)
 
         valid_pose = True
-        if use_robot_pose:
-            # If using the robot pose, simply add the robot and we're done!
-            robot_pose = robot.pose
-            if self.check_occupancy((pose.x, pose.y)):
-                warnings.warn(f"{pose} is occupied.")
-                valid_pose = False
-
-        elif loc is None:
+        if loc is None:
             if pose is None:
                 # If nothing is specified, sample any valid location in the world
                 robot_pose = self.sample_free_robot_pose_uniform(
@@ -1219,7 +1210,7 @@ class World:
             # If we have a valid pose, extract its location
             loc = self.get_location_from_pose(robot_pose)
 
-        elif loc is not None:
+        else:
             # First, validate that the location is valid for a robot
             if isinstance(loc, str):
                 loc = self.get_entity_by_name(loc)

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -111,7 +111,7 @@ class World:
     ##########################
     # World Building Methods #
     ##########################
-    def add_room(self, **kwargs):
+    def add_room(self, **room_config):
         """
         Adds a room to the world.
 
@@ -121,7 +121,7 @@ class World:
         If the room has an empty footprint or would cause a collision with another entity in the world,
         it will not be added to the world model.
 
-        :param \*\*kwargs: Keyword arguments describing the room.
+        :param \*\*room_config: Keyword arguments describing the room.
 
             You can use ``room=Room(...)`` to directly pass in a :class:`pyrobosim.core.room.Room` object,
             or alternatively use the same keyword arguments you would use to create a Room object.
@@ -131,10 +131,10 @@ class World:
 
         # If it's a room object, get it from the "room" named argument.
         # Else, create a room directly from the specified arguments.
-        if "room" in kwargs:
-            room = kwargs["room"]
+        if "room" in room_config:
+            room = room_config["room"]
         else:
-            room = Room(**kwargs)
+            room = Room(**room_config)
 
         # If the room name is empty, automatically name it.
         if room.name is None:
@@ -206,11 +206,11 @@ class World:
             self.search_graph.remove(room.graph_nodes)
         return True
 
-    def add_hallway(self, **kwargs):
+    def add_hallway(self, **hallway_config):
         """
         Adds a hallway from with specified parameters related to the :class:`pyrobosim.core.hallway.Hallway` class.
 
-        :param \*\*kwargs: Keyword arguments describing the hallway.
+        :param \*\*hallway_config: Keyword arguments describing the hallway.
 
             You can use ``hallway=Hallway(...)`` to directly pass in a :class:`pyrobosim.core.hallway.Hallway`
             object, or alternatively use the same keyword arguments you would use to create a Hallway object.
@@ -223,15 +223,19 @@ class World:
         """
         # If it's a hallway object, get it from the "hallway" named argument.
         # Else, create a hallway directly from the specified arguments.
-        if "hallway" in kwargs:
-            hallway = kwargs["hallway"]
+        if "hallway" in hallway_config:
+            hallway = hallway_config["hallway"]
         else:
-            if isinstance(kwargs["room_start"], str):
-                kwargs["room_start"] = self.get_room_by_name(kwargs["room_start"])
-            if isinstance(kwargs["room_end"], str):
-                kwargs["room_end"] = self.get_room_by_name(kwargs["room_end"])
+            if isinstance(hallway_config["room_start"], str):
+                hallway_config["room_start"] = self.get_room_by_name(
+                    hallway_config["room_start"]
+                )
+            if isinstance(hallway_config["room_end"], str):
+                hallway_config["room_end"] = self.get_room_by_name(
+                    hallway_config["room_end"]
+                )
 
-            hallway = Hallway(**kwargs)
+            hallway = Hallway(**hallway_config)
 
         # Check if the hallway collides with any other rooms or hallways
         is_valid_pose = True
@@ -291,14 +295,14 @@ class World:
             self.update_bounds(entity=hallway, remove=True)
         return True
 
-    def add_location(self, **kwargs):
+    def add_location(self, **location_config):
         """
         Adds a location at the specified parent entity, usually a room.
 
         If the location does not have a specified name, it will be given an
         automatic name using its category, e.g., ``"table0"``.
 
-        :param \*\*kwargs: Keyword arguments describing the location.
+        :param \*\*location_config: Keyword arguments describing the location.
 
             You can use ``location=Location(...)`` to directly pass in a :class:`pyrobosim.core.location.Location`
             object, or alternatively use the same keyword arguments you would use to create a Location object.
@@ -310,13 +314,15 @@ class World:
         """
         # If it's a location object, get it from the "location" named argument.
         # Else, create a location directly from the specified arguments.
-        if "location" in kwargs:
-            loc = kwargs["location"]
+        if "location" in location_config:
+            loc = location_config["location"]
         else:
-            if isinstance(kwargs["parent"], str):
-                kwargs["parent"] = self.get_room_by_name(kwargs["parent"])
+            if isinstance(location_config["parent"], str):
+                location_config["parent"] = self.get_room_by_name(
+                    location_config["parent"]
+                )
 
-            loc = Location(**kwargs)
+            loc = Location(**location_config)
 
         # If the category name is empty, use "location" as the base name.
         category = loc.category
@@ -442,7 +448,7 @@ class World:
             return True
         return False
 
-    def add_object(self, **kwargs):
+    def add_object(self, **object_config):
         """
         Adds an object to a specific location.
 
@@ -451,7 +457,7 @@ class World:
 
         If the location contains multiple object spawns, one will be selected at random.
 
-        :param \*\*kwargs: Keyword arguments describing the object.
+        :param \*\*object_config: Keyword arguments describing the object.
 
             You can use ``object=Object(...)`` to directly pass in a :class:`pyrobosim.core.objects.Object`
             object, or alternatively use the same keyword arguments you would use to create an Object instance.
@@ -463,10 +469,10 @@ class World:
         """
         # If it's on Object instance, get it from the "location" named argument.
         # Else, create a location directly from the specified arguments.
-        if "object" in kwargs:
-            obj = kwargs["object"]
+        if "object" in object_config:
+            obj = object_config["object"]
         else:
-            parent = kwargs.get("parent", None)
+            parent = object_config.get("parent", None)
             if isinstance(parent, str):
                 parent = self.get_entity_by_name(parent)
 
@@ -476,15 +482,15 @@ class World:
                 parent = np.random.choice(parent.children)
 
             if not isinstance(parent, ObjectSpawn):
-                parent_arg = kwargs.get("parent", None)
+                parent_arg = object_config.get("parent", None)
                 warnings.warn(
                     f"Parent location {parent_arg} did not resolve to a valid location for an object."
                 )
                 return None
 
-            kwargs["parent"] = parent
-            kwargs["inflation_radius"] = self.object_radius
-            obj = Object(**kwargs)
+            object_config["parent"] = parent
+            object_config["inflation_radius"] = self.object_radius
+            obj = Object(**object_config)
 
         # If the category name is empty, use "object" as the base name.
         category = obj.category

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -111,23 +111,38 @@ class World:
     ##########################
     # World Building Methods #
     ##########################
-    def add_room(self, room):
+    def add_room(self, **kwargs):
         """
         Adds a room to the world.
 
         If the room does not have a specified name, it will be given an automatic
-        name of the form ``"room0"``, ``"room1"``, etc.
+        name of the form ``"room_0"``, ``"room_1"``, etc.
 
-        If the room would cause a collision with another entity in the world,
+        If the room has an empty footprint or would cause a collision with another entity in the world,
         it will not be added to the world model.
 
-        :param room: Room object to add to the world.
-        :type room: :class:`pyrobosim.core.room.Room`
+        :param \*\*kwargs: Keyword arguments describing the room.
+            You can use ``room=Room(...)`` to directly pass in a :class:`pyrobosim.core.room.Room` object,
+            or alternatively use the same keyword arguments you would use to create a Room object.
         :return: True if the room was successfully added, else False.
         :rtype: bool
         """
+
+        # If it's a room object, get it from the "room" named argument.
+        # Else, create a room directly from the specified arguments.
+        if "room" in kwargs:
+            room = kwargs["room"]
+        else:
+            room = Room(**kwargs)
+
+        # If the room name is empty, automatically name it.
         if room.name is None:
             room.name = f"room_{self.num_rooms}"
+
+        # If the room geometry is empty, do not allow it
+        if room.polygon.is_empty:
+            warnings.warn(f"Room {room.name} has empty geometry. Cannot add to world.")
+            return False
 
         # Check if the room collides with any other rooms or hallways
         is_valid_pose = True

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -148,12 +148,11 @@ class World:
         # Check if the room collides with any other rooms or hallways
         is_valid_pose = True
         for other_loc in self.rooms + self.hallways:
-            is_valid_pose = (
-                is_valid_pose
-                and not room.external_collision_polygon.intersects(
-                    other_loc.external_collision_polygon
-                )
-            )
+            if room.external_collision_polygon.intersects(
+                other_loc.external_collision_polygon
+            ):
+                is_valid_pose = False
+                break
         if not is_valid_pose:
             warnings.warn(f"Room {room.name} in collision. Cannot add to world.")
             return None
@@ -242,12 +241,11 @@ class World:
         for other_loc in self.rooms + self.hallways:
             if (other_loc == hallway.room_start) or (other_loc == hallway.room_end):
                 continue
-            is_valid_pose = (
-                is_valid_pose
-                and not hallway.external_collision_polygon.intersects(
-                    other_loc.external_collision_polygon
-                )
-            )
+            if hallway.external_collision_polygon.intersects(
+                other_loc.external_collision_polygon
+            ):
+                is_valid_pose = False
+                break
         if not is_valid_pose:
             warnings.warn(f"Hallway {hallway.name} in collision. Cannot add to world.")
             return None
@@ -338,10 +336,11 @@ class World:
         # Check that the location fits within the room and is not in collision with
         # other locations already in the room. Else, warn and do not add it.
         is_valid_pose = loc.polygon.within(loc.parent.polygon)
-        for other_loc in loc.parent.locations:
-            is_valid_pose = is_valid_pose and not loc.polygon.intersects(
-                other_loc.polygon
-            )
+        if is_valid_pose:
+            for other_loc in loc.parent.locations:
+                if loc.polygon.intersects(other_loc.polygon):
+                    is_valid_pose = False
+                    break
         if not is_valid_pose:
             warnings.warn(f"Location {loc.name} in collision. Cannot add to world.")
             return None

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -284,10 +284,10 @@ class World:
         # Remove the hallways from the world and relevant rooms.
         self.hallways.remove(hallway)
         self.name_to_entity.pop(hallway.name)
-        for r in [hallway.room_start, hallway.room_end]:
-            r.hallways.remove(hallway)
-            r.update_collision_polygons()
-            r.update_visualization_polygon()
+        for room in [hallway.room_start, hallway.room_end]:
+            room.hallways.remove(hallway)
+            room.update_collision_polygons()
+            room.update_visualization_polygon()
             self.update_bounds(entity=hallway, remove=True)
         return True
 

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -122,6 +122,7 @@ class World:
         it will not be added to the world model.
 
         :param \*\*kwargs: Keyword arguments describing the room.
+
             You can use ``room=Room(...)`` to directly pass in a :class:`pyrobosim.core.room.Room` object,
             or alternatively use the same keyword arguments you would use to create a Room object.
         :return: room object if successfully created, else None.
@@ -210,6 +211,7 @@ class World:
         Adds a hallway from with specified parameters related to the :class:`pyrobosim.core.hallway.Hallway` class.
 
         :param \*\*kwargs: Keyword arguments describing the hallway.
+
             You can use ``hallway=Hallway(...)`` to directly pass in a :class:`pyrobosim.core.room.Room` object,
             or alternatively use the same keyword arguments you would use to create a Room object.
 

--- a/pyrobosim/pyrobosim/core/yaml_utils.py
+++ b/pyrobosim/pyrobosim/core/yaml_utils.py
@@ -69,10 +69,7 @@ class WorldYamlLoader:
 
     def add_rooms(self):
         """Add rooms to the world."""
-        if "rooms" not in self.data:
-            return
-
-        for room_data in self.data["rooms"]:
+        for room_data in self.data.get("rooms", []):
             # TODO: Find a way to parse poses as YAML.
             if "nav_poses" in room_data:
                 room_data["nav_poses"] = [
@@ -83,23 +80,16 @@ class WorldYamlLoader:
 
     def add_hallways(self):
         """Add hallways connecting rooms to the world."""
-        if "hallways" not in self.data:
-            return
-
-        for hall_data in self.data["hallways"]:
+        for hall_data in self.data.get("hallways", []):
             self.world.add_hallway(**hall_data)
 
     def add_locations(self):
         """Add locations for object spawning to the world."""
-        if "locations" not in self.data:
-            return
+        for loc_data in self.data.get("locations", []):
+            # TODO: Find a way to parse poses as YAML.
+            loc_data["pose"] = Pose.from_list(loc_data["pose"])
 
-        for loc in self.data["locations"]:
-            category = loc["type"]
-            room = loc["room"]
-            pose = Pose.from_list(loc["pose"])
-            name = loc.get("name", None)
-            self.world.add_location(category, room, pose, name=name)
+            self.world.add_location(**loc_data)
 
     def add_objects(self):
         """Add objects to the world."""

--- a/pyrobosim/pyrobosim/core/yaml_utils.py
+++ b/pyrobosim/pyrobosim/core/yaml_utils.py
@@ -96,15 +96,11 @@ class WorldYamlLoader:
         if "objects" not in self.data:
             return
 
-        for obj in self.data["objects"]:
-            category = obj["type"]
-            loc = obj["location"]
-            if "pose" in obj:
-                pose = Pose.from_list(obj["pose"])
-            else:
-                pose = None
-            name = obj.get("name", None)
-            self.world.add_object(category, loc, pose=pose, name=name)
+        for obj_data in self.data.get("objects", []):
+            # TODO: Find a way to parse poses as YAML.
+            if "pose" in obj_data:
+                obj_data["pose"] = Pose.from_list(obj_data["pose"])
+            self.world.add_object(**obj_data)
 
     def add_robots(self):
         """Add robots to the world."""

--- a/pyrobosim/pyrobosim/core/yaml_utils.py
+++ b/pyrobosim/pyrobosim/core/yaml_utils.py
@@ -6,7 +6,6 @@ import warnings
 import yaml
 
 from .robot import Robot
-from .room import Room
 from .world import World
 from ..utils.general import replace_special_yaml_tokens
 from ..utils.pose import Pose
@@ -74,22 +73,13 @@ class WorldYamlLoader:
             return
 
         for room_data in self.data["rooms"]:
-            name = room_data.get("name", None)
-            color = room_data.get("color", [0.4, 0.4, 0.4])
-            wall_width = room_data.get("wall_width", 0.2)
+            # TODO: Find a way to parse poses as YAML.
             if "nav_poses" in room_data:
-                nav_poses = [Pose.from_list(p) for p in room_data["nav_poses"]]
-            else:
-                nav_poses = None
+                room_data["nav_poses"] = [
+                    Pose.from_list(p) for p in room_data["nav_poses"]
+                ]
 
-            room = Room(
-                room_data["footprint"],
-                name=name,
-                color=color,
-                wall_width=wall_width,
-                nav_poses=nav_poses,
-            )
-            self.world.add_room(room)
+            self.world.add_room(**room_data)
 
     def add_hallways(self):
         """Add hallways connecting rooms to the world."""

--- a/pyrobosim/pyrobosim/core/yaml_utils.py
+++ b/pyrobosim/pyrobosim/core/yaml_utils.py
@@ -86,25 +86,8 @@ class WorldYamlLoader:
         if "hallways" not in self.data:
             return
 
-        for hall in self.data["hallways"]:
-            conn_method = hall.get("conn_method", "auto")
-            offset = hall.get("offset", 0.0)
-            conn_angle = hall.get("conn_angle", 0.0)
-            conn_points = hall.get("conn_points", [])
-            color = hall.get("color", [0.4, 0.4, 0.4])
-            wall_width = hall.get("wall_width", 0.2)
-
-            self.world.add_hallway(
-                hall["from"],
-                hall["to"],
-                hall["width"],
-                conn_method=conn_method,
-                offset=offset,
-                conn_angle=conn_angle,
-                conn_points=conn_points,
-                color=color,
-                wall_width=wall_width,
-            )
+        for hall_data in self.data["hallways"]:
+            self.world.add_hallway(**hall_data)
 
     def add_locations(self):
         """Add locations for object spawning to the world."""

--- a/pyrobosim/pyrobosim/data/pddlstream_simple_world.yaml
+++ b/pyrobosim/pyrobosim/data/pddlstream_simple_world.yaml
@@ -81,20 +81,20 @@ rooms:
 
 # HALLWAYS: Connect rooms
 hallways:
-  - from: kitchen
-    to: bathroom
+  - room_start: kitchen
+    room_end: bathroom
     width: 0.7
     conn_method: auto
 
-  - from: bathroom
-    to: bedroom
+  - room_start: bathroom
+    room_end: bedroom
     width: 0.5
     conn_method: angle
     conn_angle: 0.0
     offset: 0.8
 
-  - from: kitchen
-    to: bedroom
+  - room_start: kitchen
+    room_end: bedroom
     width: 0.6
     conn_method: points
     conn_points:

--- a/pyrobosim/pyrobosim/data/pddlstream_simple_world.yaml
+++ b/pyrobosim/pyrobosim/data/pddlstream_simple_world.yaml
@@ -105,16 +105,16 @@ hallways:
 
 # LOCATIONS: Can contain objects
 locations:
-  - type: table
-    room: kitchen
+  - category: table
+    parent: kitchen
     pose: [0.85, -0.5, 0.0, -1.57]
 
-  - type: desk
-    room: bedroom
+  - category: desk
+    parent: bedroom
     pose: [3.15, 3.65, 0.0, 0.0]
 
-  - type: counter
-    room: bathroom
+  - category: counter
+    parent: bathroom
     pose: [-2.45, 2.5, 0.0, 1.767]
 
 

--- a/pyrobosim/pyrobosim/data/pddlstream_simple_world.yaml
+++ b/pyrobosim/pyrobosim/data/pddlstream_simple_world.yaml
@@ -120,25 +120,25 @@ locations:
 
 # OBJECTS: Can be picked, placed, and move by robot
 objects:
-  - type: banana
-    location: table0
+  - category: banana
+    parent: table0
     pose: [1.0, -0.5, 0.0, 0.707]
 
-  - type: apple
-    location: desk0
+  - category: apple
+    parent: desk0
     pose: [3.2, 3.5, 0.0, 0.0]
 
-  - type: apple
-    location: table0
+  - category: apple
+    parent: table0
 
-  - type: apple
-    location: table0
+  - category: apple
+    parent: table0
 
-  - type: water
-    location: counter0
+  - category: water
+    parent: counter0
 
-  - type: banana
-    location: counter0
+  - category: banana
+    parent: counter0
 
-  - type: water
-    location: desk0
+  - category: water
+    parent: desk0

--- a/pyrobosim/pyrobosim/data/test_world.yaml
+++ b/pyrobosim/pyrobosim/data/test_world.yaml
@@ -119,23 +119,23 @@ hallways:
 # # LOCATIONS: Can contain objects
 locations:
   - name: table0
-    type: table
-    room: kitchen
+    category: table
+    parent: kitchen
     pose: [0.85, -0.5, 0.0, -1.57]
 
   - name: my_desk
-    type: desk
-    room: bedroom
+    category: desk
+    parent: bedroom
     pose: [3.15, 3.65, 0.0, 0.0]
 
   - name: counter0
-    type: counter
-    room: bathroom
+    category: counter
+    parent: bathroom
     pose: [-2.45, 2.5, 0.0, 1.767]
 
   - name: trash
-    type: trash_can
-    room: kitchen
+    category: trash_can
+    parent: kitchen
     pose: [0.9, 1.1, 0.0, 1.57]
 
 

--- a/pyrobosim/pyrobosim/data/test_world.yaml
+++ b/pyrobosim/pyrobosim/data/test_world.yaml
@@ -141,31 +141,31 @@ locations:
 
 # # OBJECTS: Can be picked, placed, and move by robot
 objects:
-  - type: banana
-    location: table0
+  - category: banana
+    parent: table0
     pose: [1.0, -0.5, 0.0, 0.707]
 
-  - type: apple
-    location: my_desk
+  - category: apple
+    parent: my_desk
     pose: [3.2, 3.5, 0.0, 0.0]
 
   - name: gala
-    type: apple
-    location: table0
+    category: apple
+    parent: table0
 
   - name: fuji
-    type: apple
-    location: trash
+    category: apple
+    parent: trash
 
-  - type: water
-    location: counter0
+  - category: water
+    parent: counter0
 
-  - type: banana
-    location: counter0
+  - category: banana
+    parent: counter0
 
-  - type: water
-    location: my_desk
+  - category: water
+    parent: my_desk
 
   - name: soda
-    type: coke
-    location: my_desk
+    category: coke
+    parent: my_desk

--- a/pyrobosim/pyrobosim/data/test_world.yaml
+++ b/pyrobosim/pyrobosim/data/test_world.yaml
@@ -94,20 +94,20 @@ rooms:
 
 # # HALLWAYS: Connect rooms
 hallways:
-  - from: kitchen
-    to: bathroom
+  - room_start: kitchen
+    room_end: bathroom
     width: 0.7
     conn_method: auto
 
-  - from: bathroom
-    to: bedroom
+  - room_start: bathroom
+    room_end: bedroom
     width: 0.5
     conn_method: angle
     conn_angle: 0.0
     offset: 0.8
 
-  - from: kitchen
-    to: bedroom
+  - room_start: kitchen
+    room_end: bedroom
     width: 0.6
     conn_method: points
     conn_points:

--- a/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
+++ b/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
@@ -95,20 +95,20 @@ rooms:
 
 # HALLWAYS: Connect rooms
 hallways:
-  - from: kitchen
-    to: bathroom
+  - room_start: kitchen
+    room_end: bathroom
     width: 0.7
     conn_method: auto
 
-  - from: bathroom
-    to: bedroom
+  - room_start: bathroom
+    room_end: bedroom
     width: 0.5
     conn_method: angle
     conn_angle: 0.0
     offset: 0.8
 
-  - from: kitchen
-    to: bedroom
+  - room_start: kitchen
+    room_end: bedroom
     width: 0.6
     conn_method: points
     conn_points:

--- a/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
+++ b/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
@@ -120,23 +120,23 @@ hallways:
 # LOCATIONS: Can contain objects
 locations:
   - name: table0
-    type: table
-    room: kitchen
+    category: table
+    parent: kitchen
     pose: [0.85, -0.5, 0.0, -1.57]
 
   - name: my_desk
-    type: desk
-    room: bedroom
+    category: desk
+    parent: bedroom
     pose: [3.15, 3.65, 0.0, 0.0]
 
   - name: counter0
-    type: counter
-    room: bathroom
+    category: counter
+    parent: bathroom
     pose: [-2.45, 2.5, 0.0, 1.767]
 
   - name: trash
-    type: trash_can
-    room: kitchen
+    category: trash_can
+    parent: kitchen
     pose: [0.9, 1.1, 0.0, 1.57]
 
 

--- a/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
+++ b/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
@@ -142,31 +142,31 @@ locations:
 
 # OBJECTS: Can be picked, placed, and move by robot
 objects:
-  - type: banana
-    location: table0
+  - category: banana
+    parent: table0
     pose: [1.0, -0.5, 0.0, 0.707]
 
-  - type: apple
-    location: my_desk
+  - category: apple
+    parent: my_desk
     pose: [3.2, 3.5, 0.0, 0.0]
 
   - name: gala
-    type: apple
-    location: table0
+    category: apple
+    parent: table0
 
   - name: fuji
-    type: apple
-    location: trash
+    category: apple
+    parent: trash
 
-  - type: water
-    location: counter0_left
+  - category: water
+    parent: counter0_left
 
-  - type: banana
-    location: counter0_right
+  - category: banana
+    parent: counter0_right
 
-  - type: water
-    location: my_desk
+  - category: water
+    parent: my_desk
 
   - name: soda
-    type: coke
-    location: my_desk
+    category: coke
+    parent: my_desk

--- a/pyrobosim/pyrobosim/planning/__init__.py
+++ b/pyrobosim/pyrobosim/planning/__init__.py
@@ -6,4 +6,8 @@ a plan, as well as infrastructure to come up with such a plan given the
 current and desired state of the world.
 """
 
-from .pddlstream.planner import *
+import importlib
+
+# Only import PDDLStream planner if the module is available.
+if importlib.util.find_spec("pddlstream") is not None:
+    from .pddlstream.planner import *

--- a/pyrobosim/pyrobosim/planning/pddlstream/planner.py
+++ b/pyrobosim/pyrobosim/planning/pddlstream/planner.py
@@ -57,7 +57,7 @@ class PDDLStreamPlanner:
         goal_literals,
         max_attempts=1,
         verbose=False,
-        **kwargs,
+        **planner_config,
     ):
         """
         Searches for a set of actions that completes a goal specification
@@ -73,7 +73,7 @@ class PDDLStreamPlanner:
         :type max_attempts: int, optional
         :param verbose: If True, prints additional information. Defaults to False.
         :type verbose: bool, optional
-        :param \*\*kwargs: Additional keyword arguments to pass to the PDDLStream planner.
+        :param \*\*planner_config: Additional keyword arguments to pass to the PDDLStream planner.
         :return: A task plan object ready to use with ``pyrobosim``.
         :rtype: :class:`pyrobosim.planning.actions.TaskPlan`
         """
@@ -100,7 +100,10 @@ class PDDLStreamPlanner:
         for i in range(max_attempts):
             # Solve the problem using the "adaptive" PDDLStream algorithm.
             solution = solve_adaptive(
-                prob, stream_info=self.stream_info_fn(), verbose=verbose, **kwargs
+                prob,
+                stream_info=self.stream_info_fn(),
+                verbose=verbose,
+                **planner_config,
             )
 
             # If the solution is valid, no need to try again

--- a/pyrobosim/pyrobosim/utils/general.py
+++ b/pyrobosim/pyrobosim/utils/general.py
@@ -64,10 +64,7 @@ class EntityMetadata:
         :return: Category metadata dictionary if it exists, else None.
         :rtype: dict
         """
-        if self.has_category(category):
-            return self.data[category]
-        else:
-            return None
+        return self.data.get(category, None)
 
 
 def replace_special_yaml_tokens(in_text, root_dir=None):

--- a/pyrobosim_ros/examples/demo.py
+++ b/pyrobosim_ros/examples/demo.py
@@ -39,13 +39,18 @@ def create_world():
     world.add_room(name="bathroom", footprint=r3coords, color=[0, 0, 0.6])
 
     # Add hallways between the rooms
-    world.add_hallway("kitchen", "bathroom", width=0.7)
+    world.add_hallway(room_start="kitchen", room_end="bathroom", width=0.7)
     world.add_hallway(
-        "bathroom", "bedroom", width=0.5, conn_method="angle", conn_angle=0, offset=0.8
+        room_start="bathroom",
+        room_end="bedroom",
+        width=0.5,
+        conn_method="angle",
+        conn_angle=0,
+        offset=0.8,
     )
     world.add_hallway(
-        "kitchen",
-        "bedroom",
+        room_start="kitchen",
+        room_end="bedroom",
         width=0.6,
         conn_method="points",
         conn_points=[(1.0, 0.5), (2.5, 0.5), (2.5, 3.0)],

--- a/pyrobosim_ros/examples/demo.py
+++ b/pyrobosim_ros/examples/demo.py
@@ -70,13 +70,15 @@ def create_world():
     )
 
     # Add objects
-    world.add_object("banana", table, pose=Pose(x=1.0, y=-0.5, yaw=np.pi / 4))
-    world.add_object("apple", desk, pose=Pose(x=3.2, y=3.5, yaw=0))
-    world.add_object("apple", table)
-    world.add_object("apple", table)
-    world.add_object("water", counter)
-    world.add_object("banana", counter)
-    world.add_object("water", desk)
+    world.add_object(
+        category="banana", parent=table, pose=Pose(x=1.0, y=-0.5, yaw=np.pi / 4.0)
+    )
+    world.add_object(category="apple", parent=desk, pose=Pose(x=3.2, y=3.5, yaw=0.0))
+    world.add_object(category="apple", parent=table)
+    world.add_object(category="apple", parent=table)
+    world.add_object(category="water", parent=counter)
+    world.add_object(category="banana", parent=counter)
+    world.add_object(category="water", parent=desk)
 
     # Add a robot
     robot = Robot(name="robot", radius=0.1, path_executor=ConstantVelocityExecutor())

--- a/pyrobosim_ros/examples/demo.py
+++ b/pyrobosim_ros/examples/demo.py
@@ -57,10 +57,16 @@ def create_world():
     )
 
     # Add locations
-    table = world.add_location("table", "kitchen", Pose(x=0.85, y=-0.5, yaw=-np.pi / 2))
-    desk = world.add_location("desk", "bedroom", Pose(x=3.15, y=3.65, yaw=0))
+    table = world.add_location(
+        category="table", parent="kitchen", pose=Pose(x=0.85, y=-0.5, yaw=-np.pi / 2.0)
+    )
+    desk = world.add_location(
+        category="desk", parent="bedroom", pose=Pose(x=3.15, y=3.65, yaw=0.0)
+    )
     counter = world.add_location(
-        "counter", "bathroom", Pose(x=-2.45, y=2.5, yaw=np.pi / 2 + np.pi / 16)
+        category="counter",
+        parent="bathroom",
+        pose=Pose(x=-2.45, y=2.5, yaw=np.pi / 2.0 + np.pi / 16.0),
     )
 
     # Add objects

--- a/pyrobosim_ros/examples/demo.py
+++ b/pyrobosim_ros/examples/demo.py
@@ -9,7 +9,7 @@ import rclpy
 import threading
 import numpy as np
 
-from pyrobosim.core import Robot, Room, World, WorldYamlLoader
+from pyrobosim.core import Robot, World, WorldYamlLoader
 from pyrobosim.gui import start_gui
 from pyrobosim.navigation import ConstantVelocityExecutor
 from pyrobosim.utils.general import get_data_folder
@@ -32,18 +32,11 @@ def create_world():
 
     # Add rooms
     r1coords = [(-1, -1), (1.5, -1), (1.5, 1.5), (0.5, 1.5)]
-    world.add_room(
-        Room(
-            r1coords,
-            name="kitchen",
-            color=[1, 0, 0],
-            nav_poses=[Pose(x=0.75, y=0.75, yaw=0)],
-        )
-    )
+    world.add_room(name="kitchen", footprint=r1coords, color=[1, 0, 0])
     r2coords = [(1.75, 2.5), (3.5, 2.5), (3.5, 4), (1.75, 4)]
-    world.add_room(Room(r2coords, name="bedroom", color=[0, 0.6, 0]))
+    world.add_room(name="bedroom", footprint=r2coords, color=[0, 0.6, 0])
     r3coords = [(-1, 1), (-1, 3.5), (-3.0, 3.5), (-2.5, 1)]
-    world.add_room(Room(r3coords, name="bathroom", color=[0, 0, 0.6]))
+    world.add_room(name="bathroom", footprint=r3coords, color=[0, 0, 0.6])
 
     # Add hallways between the rooms
     world.add_hallway("kitchen", "bathroom", width=0.7)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --ignore=dependencies

--- a/test/planning/test_pddlstream_manip.py
+++ b/test/planning/test_pddlstream_manip.py
@@ -38,11 +38,15 @@ def create_test_world(add_alt_desk=True):
     )
 
     # Add locations and objects
-    table0 = world.add_location("table", "home", Pose(x=0.0, y=0.5, z=0, yaw=np.pi / 2))
-    desk0 = world.add_location("desk", "storage", Pose(x=2.5, y=-1.5, z=0.0, yaw=0.0))
+    table0 = world.add_location(
+        category="table", parent="home", pose=Pose(x=0.0, y=0.5, z=0.0, yaw=np.pi / 2.0)
+    )
+    desk0 = world.add_location(
+        category="desk", parent="storage", pose=Pose(x=2.5, y=-1.5, z=0.0, yaw=0.0)
+    )
     if add_alt_desk:
         desk1 = world.add_location(
-            "desk", "storage", Pose(x=4.5, y=1.5, z=0.0, yaw=0.0)
+            category="desk", parent="storage", pose=Pose(x=4.5, y=1.5, z=0.0, yaw=0.0)
         )
     world.add_object("banana", table0)
     world.add_object("water", desk0, pose=Pose(x=2.375, y=-1.375, z=0, yaw=np.pi / 4))

--- a/test/planning/test_pddlstream_manip.py
+++ b/test/planning/test_pddlstream_manip.py
@@ -48,9 +48,17 @@ def create_test_world(add_alt_desk=True):
         desk1 = world.add_location(
             category="desk", parent="storage", pose=Pose(x=4.5, y=1.5, z=0.0, yaw=0.0)
         )
-    world.add_object("banana", table0)
-    world.add_object("water", desk0, pose=Pose(x=2.375, y=-1.375, z=0, yaw=np.pi / 4))
-    world.add_object("water", desk0, pose=Pose(x=2.575, y=-1.6, z=0, yaw=-np.pi / 4))
+    world.add_object(category="banana", parent=table0)
+    world.add_object(
+        category="water",
+        parent=desk0,
+        pose=Pose(x=2.375, y=-1.375, z=0, yaw=np.pi / 4.0),
+    )
+    world.add_object(
+        category="water",
+        parent=desk0,
+        pose=Pose(x=2.575, y=-1.6, z=0, yaw=-np.pi / 4.0),
+    )
 
     # Add a robot
     grasp_props = ParallelGraspProperties(

--- a/test/planning/test_pddlstream_manip.py
+++ b/test/planning/test_pddlstream_manip.py
@@ -33,7 +33,9 @@ def create_test_world(add_alt_desk=True):
     world.add_room(name="home", footprint=home_coords, color=[1, 0, 0])
     storage_coords = [(2, -2), (5, -2), (5, 2), (2, 2)]
     world.add_room(name="storage", footprint=storage_coords, color=[0, 0, 1])
-    world.add_hallway("home", "storage", width=0.75, conn_method="auto")
+    world.add_hallway(
+        room_start="home", room_end="storage", width=0.75, conn_method="auto"
+    )
 
     # Add locations and objects
     table0 = world.add_location("table", "home", Pose(x=0.0, y=0.5, z=0, yaw=np.pi / 2))

--- a/test/planning/test_pddlstream_manip.py
+++ b/test/planning/test_pddlstream_manip.py
@@ -8,7 +8,7 @@ import os
 import pytest
 import threading
 
-from pyrobosim.core import Robot, Room, World
+from pyrobosim.core import Robot, World
 from pyrobosim.gui import start_gui
 from pyrobosim.manipulation import GraspGenerator, ParallelGraspProperties
 from pyrobosim.navigation import ConstantVelocityExecutor, RRTPlanner
@@ -30,12 +30,10 @@ def create_test_world(add_alt_desk=True):
 
     # Add rooms
     home_coords = [(-1, -1), (1, -1), (1, 1), (-1, 1)]
-    home = Room(home_coords, name="home", color=[1, 0, 0])
-    world.add_room(home)
+    world.add_room(name="home", footprint=home_coords, color=[1, 0, 0])
     storage_coords = [(2, -2), (5, -2), (5, 2), (2, 2)]
-    storage = Room(storage_coords, name="storage", color=[0, 0, 1])
-    world.add_room(storage)
-    world.add_hallway(home, storage, width=0.75, conn_method="auto")
+    world.add_room(name="storage", footprint=storage_coords, color=[0, 0, 1])
+    world.add_hallway("home", "storage", width=0.75, conn_method="auto")
 
     # Add locations and objects
     table0 = world.add_location("table", "home", Pose(x=0.0, y=0.5, z=0, yaw=np.pi / 2))

--- a/test/planning/test_pddlstream_nav.py
+++ b/test/planning/test_pddlstream_nav.py
@@ -6,7 +6,7 @@ Test script for PDDLStream planning with navigation streams.
 import os
 import threading
 
-from pyrobosim.core import Robot, Room, World
+from pyrobosim.core import Robot, World
 from pyrobosim.gui import start_gui
 from pyrobosim.navigation import ConstantVelocityExecutor, RRTPlanner
 from pyrobosim.planning import PDDLStreamPlanner
@@ -27,14 +27,11 @@ def create_test_world(add_hallway=True):
 
     # Add rooms
     main_room_coords = [(-1, -1), (1, -1), (1, 1), (-1, 1)]
-    main_room = Room(main_room_coords, name="main_room", color=[1, 0, 0])
-    world.add_room(main_room)
+    world.add_room(name="main_room", footprint=main_room_coords, color=[1, 0, 0])
     unreachable_coords = [(2, -1), (4, -1), (4, 1), (2, 1)]
-    unreachable_room = Room(unreachable_coords, name="unreachable", color=[0, 0, 1])
-    world.add_room(unreachable_room)
+    world.add_room(name="unreachable", footprint=unreachable_coords, color=[0, 0, 1])
     goal_room_coords = [(2, 2), (4, 2), (4, 4), (2, 4)]
-    goal_room = Room(goal_room_coords, name="goal_room", color=[0, 0.6, 0])
-    world.add_room(goal_room)
+    world.add_room(name="goal_room", footprint=goal_room_coords, color=[0, 0.6, 0])
 
     # Add hallway, if enabled.
     if add_hallway:

--- a/test/planning/test_pddlstream_nav.py
+++ b/test/planning/test_pddlstream_nav.py
@@ -37,8 +37,8 @@ def create_test_world(add_hallway=True):
     if add_hallway:
         hallway_points = [(0.0, 0.0), (0.0, 5.0), (3.0, 5.0), (3.0, 3.0)]
         world.add_hallway(
-            "main_room",
-            "goal_room",
+            room_start="main_room",
+            room_end="goal_room",
             width=0.7,
             conn_method="points",
             conn_points=hallway_points,

--- a/test/planning/test_pddlstream_nav.py
+++ b/test/planning/test_pddlstream_nav.py
@@ -48,11 +48,11 @@ def create_test_world(add_hallway=True):
     table0 = world.add_location(
         category="table", parent="unreachable", pose=Pose(x=3.5, y=-0.25, z=0.0)
     )
-    world.add_object("apple", table0)
+    world.add_object(category="apple", parent=table0)
     table1 = world.add_location(
         category="table", parent="goal_room", pose=Pose(x=3.5, y=2.75, z=0.0)
     )
-    world.add_object("apple", table1)
+    world.add_object(category="apple", parent=table1)
 
     # Add a robot
     robot = Robot(radius=0.1, path_executor=ConstantVelocityExecutor())

--- a/test/planning/test_pddlstream_nav.py
+++ b/test/planning/test_pddlstream_nav.py
@@ -45,9 +45,13 @@ def create_test_world(add_hallway=True):
         )
 
     # Add locations and objects
-    table0 = world.add_location("table", "unreachable", Pose(x=3.5, y=-0.25, z=0.0))
+    table0 = world.add_location(
+        category="table", parent="unreachable", pose=Pose(x=3.5, y=-0.25, z=0.0)
+    )
     world.add_object("apple", table0)
-    table1 = world.add_location("table", "goal_room", Pose(x=3.5, y=2.75, z=0.0))
+    table1 = world.add_location(
+        category="table", parent="goal_room", pose=Pose(x=3.5, y=2.75, z=0.0)
+    )
     world.add_object("apple", table1)
 
     # Add a robot

--- a/test/world_model/test_get_entities.py
+++ b/test/world_model/test_get_entities.py
@@ -27,17 +27,15 @@ class TestGetEntities:
         # Add rooms
         r1coords = [(-1, -1), (1.5, -1), (1.5, 1.5), (0.5, 1.5)]
         world.add_room(
-            Room(
-                r1coords,
-                name="kitchen",
-                color=[1, 0, 0],
-                nav_poses=[Pose(x=0.75, y=0.75, z=0.0, q=[1.0, 0.0, 0.0, 0.0])],
-            )
+            name="kitchen",
+            footprint=r1coords,
+            color=[1, 0, 0],
+            nav_poses=[Pose(x=0.75, y=0.75, z=0.0, q=[1.0, 0.0, 0.0, 0.0])],
         )
         r2coords = [(1.75, 2.5), (3.5, 2.5), (3.5, 4), (1.75, 4)]
-        world.add_room(Room(r2coords, name="bedroom", color=[0, 0.6, 0]))
+        world.add_room(name="bedroom", footprint=r2coords, color=[0, 0.6, 0])
         r3coords = [(-1, 1), (-1, 3.5), (-3.0, 3.5), (-2.5, 1)]
-        world.add_room(Room(r3coords, name="bathroom", color=[0, 0, 0.6]))
+        world.add_room(name="bathroom", footprint=r3coords, color=[0, 0, 0.6])
 
         # Add hallways between the rooms
         world.add_hallway("kitchen", "bathroom", width=0.7)
@@ -99,7 +97,7 @@ class TestGetEntities:
         """Checks adding a room and removing it cleanly."""
         room_name = "test_room"
         coords = [(9, 9), (11, 9), (11, 11), (9, 11)]
-        result = self.world.add_room(Room(coords, name=room_name, color=[0, 0, 0]))
+        result = self.world.add_room(name=room_name, footprint=coords, color=[0, 0, 0])
         assert result == True
         self.world.remove_room(room_name)
         result = self.world.get_room_by_name(room_name)

--- a/test/world_model/test_get_entities.py
+++ b/test/world_model/test_get_entities.py
@@ -38,18 +38,18 @@ class TestGetEntities:
         world.add_room(name="bathroom", footprint=r3coords, color=[0, 0, 0.6])
 
         # Add hallways between the rooms
-        world.add_hallway("kitchen", "bathroom", width=0.7)
+        world.add_hallway(room_start="kitchen", room_end="bathroom", width=0.7)
         world.add_hallway(
-            "bathroom",
-            "bedroom",
+            room_start="bathroom",
+            room_end="bedroom",
             width=0.5,
             conn_method="angle",
             conn_angle=0,
             offset=0.8,
         )
         world.add_hallway(
-            "kitchen",
-            "bedroom",
+            room_start="kitchen",
+            room_end="bedroom",
             width=0.6,
             conn_method="points",
             conn_points=[(1.0, 0.5), (2.5, 0.5), (2.5, 3.0)],

--- a/test/world_model/test_get_entities.py
+++ b/test/world_model/test_get_entities.py
@@ -71,15 +71,21 @@ class TestGetEntities:
         )
 
         # Add objects
-        world.add_object("banana", table, pose=Pose(x=1.0, y=-0.5, z=0, yaw=np.pi / 4))
         world.add_object(
-            "apple", desk, pose=Pose(x=3.2, y=3.5, z=0.0, q=[1.0, 0.0, 0.0, 0.0])
+            category="banana",
+            parent=table,
+            pose=Pose(x=1.0, y=-0.5, z=0.0, yaw=np.pi / 4.0),
         )
-        world.add_object("apple", table)
-        world.add_object("apple", table)
-        world.add_object("water", counter)
-        world.add_object("banana", counter)
-        world.add_object("water", desk)
+        world.add_object(
+            category="apple",
+            parent=desk,
+            pose=Pose(x=3.2, y=3.5, z=0.0, q=[1.0, 0.0, 0.0, 0.0]),
+        )
+        world.add_object(category="apple", parent=table)
+        world.add_object(category="apple", parent=table)
+        world.add_object(category="water", parent=counter)
+        world.add_object(category="banana", parent=counter)
+        world.add_object(category="water", parent=desk)
 
         # Add a robot
         robot = Robot(radius=0.1, name="robby")
@@ -175,7 +181,7 @@ class TestGetEntities:
         """Checks adding an object and removing it cleanly."""
         obj_name = "banana13"
         table = self.world.get_location_by_name("table0")
-        new_obj = self.world.add_object("banana", table, name=obj_name)
+        new_obj = self.world.add_object(category="banana", parent=table, name=obj_name)
         assert isinstance(new_obj, Object)
         self.world.remove_object(obj_name)
         result = self.world.get_object_by_name(obj_name)

--- a/test/world_model/test_get_entities.py
+++ b/test/world_model/test_get_entities.py
@@ -98,7 +98,7 @@ class TestGetEntities:
         room_name = "test_room"
         coords = [(9, 9), (11, 9), (11, 11), (9, 11)]
         result = self.world.add_room(name=room_name, footprint=coords, color=[0, 0, 0])
-        assert result == True
+        assert result is not None
         self.world.remove_room(room_name)
         result = self.world.get_room_by_name(room_name)
         assert result is None

--- a/test/world_model/test_get_entities.py
+++ b/test/world_model/test_get_entities.py
@@ -57,11 +57,17 @@ class TestGetEntities:
 
         # Add locations
         table = world.add_location(
-            "table", "kitchen", Pose(x=0.85, y=-0.5, z=0, yaw=-np.pi / 2)
+            category="table",
+            parent="kitchen",
+            pose=Pose(x=0.85, y=-0.5, z=0.0, yaw=-np.pi / 2.0),
         )
-        desk = world.add_location("desk", "bedroom", Pose(x=3.15, y=3.65, z=0.0))
+        desk = world.add_location(
+            category="desk", parent="bedroom", pose=Pose(x=3.15, y=3.65, z=0.0)
+        )
         counter = world.add_location(
-            "counter", "bathroom", Pose(x=-2.45, y=2.5, z=0, yaw=np.pi / 2 + np.pi / 16)
+            category="counter",
+            parent="bathroom",
+            pose=Pose(x=-2.45, y=2.5, z=0.0, yaw=np.pi / 2.0 + np.pi / 16.0),
         )
 
         # Add objects
@@ -115,6 +121,9 @@ class TestGetEntities:
 
     def test_valid_spawn(self):
         """Checks for existence of valid object spawn."""
+        print(self.world.locations)
+        counter0 = self.world.get_entity_by_name("counter0")
+        print(counter0.children)
         result = self.world.get_entity_by_name("counter0_left")
         assert isinstance(result, ObjectSpawn) and result.name == "counter0_left"
 
@@ -130,7 +139,10 @@ class TestGetEntities:
         """
         loc_name = "desk42"
         new_desk = self.world.add_location(
-            "desk", "kitchen", Pose(x=1.0, y=1.1, yaw=-np.pi / 2), name=loc_name
+            category="desk",
+            parent="kitchen",
+            pose=Pose(x=1.0, y=1.1, yaw=-np.pi / 2.0),
+            name=loc_name,
         )
         assert isinstance(new_desk, Location)
         self.world.remove_location(loc_name)

--- a/test/world_model/test_hallway.py
+++ b/test/world_model/test_hallway.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+"""
+Tests for hallway creation in pyrobosim.
+"""
+
+from pyrobosim.core import Hallway, World
+
+
+class TestHallway:
+    def test_add_hallway_to_world_from_object(self):
+        """Test adding a hallway from a Hallway object."""
+        world = World()
+
+        coords_start = [(-1.0, -1.0), (1.0, -1.0), (1.0, 1.0), (-1.0, 1.0)]
+        room_start = world.add_room(name="room_start", footprint=coords_start)
+
+        coords_end = [(3.0, 5.0), (5.0, 3.0), (5.0, 5.0), (3.0, 5.0)]
+        room_end = world.add_room(name="room_end", footprint=coords_end)
+
+        hallway = Hallway(room_start=room_start, room_end=room_end, width=0.1)
+        result = world.add_hallway(hallway=hallway)
+        assert isinstance(result, Hallway)
+        assert world.num_hallways == 1
+        assert world.hallways[0].room_start == room_start
+        assert world.hallways[0].room_end == room_end
+        assert world.hallways[0].width == 0.1
+
+    def test_add_hallway_to_world_from_args(self):
+        """Test adding a room from a list of named keyword arguments."""
+        world = World()
+
+        coords_start = [(-1.0, -1.0), (1.0, -1.0), (1.0, 1.0), (-1.0, 1.0)]
+        room_start = world.add_room(name="room_start", footprint=coords_start)
+
+        coords_end = [(3.0, 5.0), (5.0, 3.0), (5.0, 5.0), (3.0, 5.0)]
+        room_end = world.add_room(name="room_end", footprint=coords_end)
+
+        result = world.add_hallway(
+            room_start=room_start, room_end="room_end", width=0.1
+        )
+        assert isinstance(result, Hallway)
+        assert world.num_hallways == 1
+        assert world.hallways[0].room_start == room_start
+        assert world.hallways[0].room_end == room_end
+        assert world.hallways[0].width == 0.1
+
+
+if __name__ == "__main__":
+    t = TestHallway()
+    t.test_add_hallway_to_world_from_object()
+    t.test_add_hallway_to_world_from_args()
+    print("Tests passed!")

--- a/test/world_model/test_location.py
+++ b/test/world_model/test_location.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+
+"""
+Tests for location and object spawn creation in pyrobosim.
+"""
+
+import os
+import pytest
+
+from pyrobosim.core import Location, World
+from pyrobosim.utils.general import get_data_folder
+from pyrobosim.utils.pose import Pose
+
+
+data_folder = get_data_folder()
+
+
+class TestLocation:
+    def test_add_location_to_world_from_object(self):
+        """Test adding a location from a Location object."""
+        world = World()
+        world.set_metadata(
+            locations=os.path.join(data_folder, "example_location_data.yaml"),
+            objects=os.path.join(data_folder, "example_object_data.yaml"),
+        )
+
+        coords = [(-1.0, -1.0), (1.0, -1.0), (1.0, 1.0), (-1.0, 1.0)]
+        room = world.add_room(name="test_room", footprint=coords)
+        assert room is not None
+
+        location = Location(category="table", parent=room, pose=Pose(x=0.0, y=0.0))
+        result = world.add_location(location=location)
+        assert isinstance(result, Location)
+        assert world.num_locations == 1
+        assert world.locations[0].name == "table0"
+
+    def test_add_location_to_world_from_args(self):
+        """Test adding a location from a a list of named keyword arguments."""
+        world = World()
+        world.set_metadata(
+            locations=os.path.join(data_folder, "example_location_data.yaml"),
+            objects=os.path.join(data_folder, "example_object_data.yaml"),
+        )
+
+        coords = [(-1.0, -1.0), (1.0, -1.0), (1.0, 1.0), (-1.0, 1.0)]
+        room = world.add_room(name="test_room", footprint=coords)
+        assert room is not None
+
+        result = world.add_location(
+            name="test_table",
+            category="table",
+            parent="test_room",
+            pose=Pose(x=0.0, y=0.0),
+        )
+        assert isinstance(result, Location)
+        assert world.num_locations == 1
+        assert world.locations[0].name == "test_table"
+
+
+if __name__ == "__main__":
+    t = TestLocation()
+    t.test_add_location_to_world_from_object()
+    t.test_add_location_to_world_from_args()
+    print("Tests passed!")

--- a/test/world_model/test_locations.py
+++ b/test/world_model/test_locations.py
@@ -5,7 +5,6 @@ Tests for location and object spawn creation in pyrobosim.
 """
 
 import os
-import pytest
 
 from pyrobosim.core import Location, World
 from pyrobosim.utils.general import get_data_folder
@@ -15,7 +14,7 @@ from pyrobosim.utils.pose import Pose
 data_folder = get_data_folder()
 
 
-class TestLocation:
+class TestLocations:
     def test_add_location_to_world_from_object(self):
         """Test adding a location from a Location object."""
         world = World()
@@ -35,7 +34,7 @@ class TestLocation:
         assert world.locations[0].name == "table0"
 
     def test_add_location_to_world_from_args(self):
-        """Test adding a location from a a list of named keyword arguments."""
+        """Test adding a location from a list of named keyword arguments."""
         world = World()
         world.set_metadata(
             locations=os.path.join(data_folder, "example_location_data.yaml"),
@@ -58,7 +57,7 @@ class TestLocation:
 
 
 if __name__ == "__main__":
-    t = TestLocation()
+    t = TestLocations()
     t.test_add_location_to_world_from_object()
     t.test_add_location_to_world_from_args()
     print("Tests passed!")

--- a/test/world_model/test_objects.py
+++ b/test/world_model/test_objects.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+"""
+Tests for object creation in pyrobosim.
+"""
+
+import os
+
+from pyrobosim.core import Object, World
+from pyrobosim.utils.general import get_data_folder
+from pyrobosim.utils.pose import Pose
+
+
+data_folder = get_data_folder()
+
+
+class TestObjects:
+    def test_add_object_to_world_from_object(self):
+        """Test adding an object from an Object instance."""
+        world = World()
+        world.set_metadata(
+            locations=os.path.join(data_folder, "example_location_data.yaml"),
+            objects=os.path.join(data_folder, "example_object_data.yaml"),
+        )
+
+        coords = [(-1.0, -1.0), (1.0, -1.0), (1.0, 1.0), (-1.0, 1.0)]
+        room = world.add_room(name="test_room", footprint=coords)
+        assert room is not None
+
+        table = world.add_location(
+            name="test_table",
+            category="table",
+            parent="test_room",
+            pose=Pose(x=0.0, y=0.0),
+        )
+        assert table is not None
+
+        obj = Object(
+            category="banana",
+            parent=table.children[0],
+            pose=Pose(x=0.0, y=0.0, yaw=1.0),
+        )
+        result = world.add_object(object=obj)
+        assert isinstance(result, Object)
+        assert world.num_objects == 1
+        assert world.objects[0].name == "banana0"
+        assert world.objects[0].parent.parent == table
+
+    def test_add_object_to_world_from_args(self):
+        """Test adding an object from a list of named keyword arguments."""
+        world = World()
+        world.set_metadata(
+            locations=os.path.join(data_folder, "example_location_data.yaml"),
+            objects=os.path.join(data_folder, "example_object_data.yaml"),
+        )
+
+        coords = [(-1.0, -1.0), (1.0, -1.0), (1.0, 1.0), (-1.0, 1.0)]
+        room = world.add_room(name="test_room", footprint=coords)
+        assert room is not None
+
+        table = world.add_location(
+            name="test_table",
+            category="table",
+            parent="test_room",
+            pose=Pose(x=0.0, y=0.0),
+        )
+        assert table is not None
+
+        result = world.add_object(name="test_banana", category="banana", parent=table)
+        assert isinstance(result, Object)
+        assert world.num_objects == 1
+        assert world.objects[0].name == "test_banana"
+        assert world.objects[0].parent.parent == table
+
+
+if __name__ == "__main__":
+    t = TestObjects()
+    t.test_add_object_to_world_from_object()
+    t.test_add_object_to_world_from_args()
+    print("Tests passed!")

--- a/test/world_model/test_room.py
+++ b/test/world_model/test_room.py
@@ -16,7 +16,7 @@ class TestRoom:
         room = Room(footprint=coords)
         result = world.add_room(room=room)
 
-        assert result == True
+        assert isinstance(result, Room)
         assert world.num_rooms == 1
         assert world.rooms[0].name == "room_0"
 
@@ -28,7 +28,7 @@ class TestRoom:
         color = [1.0, 0.0, 0.1]
         result = world.add_room(name="test_room", footprint=coords, color=color)
 
-        assert result == True
+        assert isinstance(result, Room)
         assert world.num_rooms == 1
         assert world.rooms[0].name == "test_room"
         assert world.rooms[0].viz_color == color
@@ -38,7 +38,7 @@ class TestRoom:
         world = World()
 
         result = world.add_room(name="test_room")
-        assert result == False
+        assert result is None
 
     def test_add_room_to_world_in_collision(self):
         """Test adding a room in collision with another room."""
@@ -47,13 +47,13 @@ class TestRoom:
         # This room should be added correctly.
         orig_coords = [(-1.0, -1.0), (1.0, -1.0), (1.0, 1.0), (-1.0, 1.0)]
         result = world.add_room(footprint=orig_coords)
-        assert result == True
+        assert isinstance(result, Room)
         assert world.num_rooms == 1
 
         # This new room should fail to add since it's in the collision with the first room.
         new_coords = [(0.0, 0.0), (2.0, 0.0), (2.0, 2.0), (0.0, 2.0)]
         result = world.add_room(footprint=new_coords)
-        assert result == False
+        assert result is None
         assert world.num_rooms == 1
 
 

--- a/test/world_model/test_room.py
+++ b/test/world_model/test_room.py
@@ -4,6 +4,7 @@
 Tests for room creation in pyrobosim.
 """
 
+import pytest
 from pyrobosim.core import Room, World
 
 
@@ -18,7 +19,7 @@ class TestRoom:
 
         assert isinstance(result, Room)
         assert world.num_rooms == 1
-        assert world.rooms[0].name == "room_0"
+        assert world.rooms[0].name == "room0"
 
     def test_add_room_to_world_from_args(self):
         """Test adding a room from a list of named keyword arguments."""
@@ -34,11 +35,11 @@ class TestRoom:
         assert world.rooms[0].viz_color == color
 
     def test_add_room_to_world_empty_geometry(self):
-        """Test adding a room with an empty footprint. Should fail."""
+        """Test adding a room with an empty footprint. Should raise an exception."""
         world = World()
 
-        result = world.add_room(name="test_room")
-        assert result is None
+        with pytest.raises(Exception):
+            result = world.add_room(name="test_room")
 
     def test_add_room_to_world_in_collision(self):
         """Test adding a room in collision with another room."""

--- a/test/world_model/test_room.py
+++ b/test/world_model/test_room.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+"""
+Tests for room creation in pyrobosim.
+"""
+
+from pyrobosim.core import Room, World
+
+
+class TestRoom:
+    def test_add_room_to_world_from_object(self):
+        """Test adding a room from a Room object."""
+        world = World()
+
+        coords = [(-1.0, -1.0), (1.0, -1.0), (1.0, 1.0), (-1.0, 1.0)]
+        room = Room(footprint=coords)
+        result = world.add_room(room=room)
+
+        assert result == True
+        assert world.num_rooms == 1
+        assert world.rooms[0].name == "room_0"
+
+    def test_add_room_to_world_from_args(self):
+        """Test adding a room from a list of named keyword arguments."""
+        world = World()
+
+        coords = [(-1.0, -1.0), (1.0, -1.0), (1.0, 1.0), (-1.0, 1.0)]
+        color = [1.0, 0.0, 0.1]
+        result = world.add_room(name="test_room", footprint=coords, color=color)
+
+        assert result == True
+        assert world.num_rooms == 1
+        assert world.rooms[0].name == "test_room"
+        assert world.rooms[0].viz_color == color
+
+    def test_add_room_to_world_empty_geometry(self):
+        """Test adding a room with an empty footprint. Should fail."""
+        world = World()
+
+        result = world.add_room(name="test_room")
+        assert result == False
+
+    def test_add_room_to_world_in_collision(self):
+        """Test adding a room in collision with another room."""
+        world = World()
+
+        # This room should be added correctly.
+        orig_coords = [(-1.0, -1.0), (1.0, -1.0), (1.0, 1.0), (-1.0, 1.0)]
+        result = world.add_room(footprint=orig_coords)
+        assert result == True
+        assert world.num_rooms == 1
+
+        # This new room should fail to add since it's in the collision with the first room.
+        new_coords = [(0.0, 0.0), (2.0, 0.0), (2.0, 2.0), (0.0, 2.0)]
+        result = world.add_room(footprint=new_coords)
+        assert result == False
+        assert world.num_rooms == 1
+
+
+if __name__ == "__main__":
+    t = TestRoom()
+    t.test_add_room_to_world_from_object()
+    t.test_add_room_to_world_from_args()
+    t.test_add_room_to_world_empty_geometry()
+    t.test_add_room_to_world_in_collision()
+    print("Tests passed!")


### PR DESCRIPTION
This PR takes advantage of Python keyword arguments (`**kwargs`) to unify the interface to world entities, such as Rooms, Hallways, etc.

This way, the same arguments used to create an entity, for example a `Room` object, can be reused directly in world methods such as `add_room()`, but also in the YAML parsers.

There are breaking changes because everything now required named arguments, but I think now there is more consistency, less copy-pasting of code, and actually more functionality. The only reason this PR has added lines of code is because of all the unit tests I created in doing this refactoring.

Closes #77