### PR TITLE
Mount Xauthority file to Docker container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,6 +38,7 @@ services:
     - ./test/:/pyrobosim_ws/src/test/:rw
     # Allows graphical programs in the container.
     - /tmp/.X11-unix:/tmp/.X11-unix:rw
+    - ${XAUTHORITY:-$HOME/.Xauthority}:/root/.Xauthority
     command: /bin/bash
 
   test:


### PR DESCRIPTION
This small change makes it so you don't need to run `xhost + local:docker` before launching pyrobosim in the Docker container.

To test:

```
xhost - local:docker  # (or restart your machine)
docker compose build
docker compose up demo
```

Does the GUI appear?