### PR TITLE
Fix angular velocity limiting in trajectory executor

### DIFF
--- a/pyrobosim/pyrobosim/navigation/trajectory.py
+++ b/pyrobosim/pyrobosim/navigation/trajectory.py
@@ -37,10 +37,10 @@ def get_constant_speed_trajectory(path, linear_velocity=0.2, max_angular_velocit
         if max_angular_velocity is None:
             ang_time = 0
         else:
-            ang_time = (
-                wrap_angle(start_pose.get_angular_distance(end_pose))
-                / max_angular_velocity
+            ang_distance = wrap_angle(
+                start_pose.get_angular_distance(end_pose) - start_pose.get_yaw()
             )
+            ang_time = ang_distance / max_angular_velocity
         t_pts[idx + 1] = t_pts[idx] + max(lin_time, ang_time)
 
     # Package up the trajectory


### PR DESCRIPTION
Found a small bug that was making the trajectory execution angular velocity limiting be super slow.

Turns out the check always assumed that the robot was at zero yaw, so we kept throttling the angular speed for no reason.

To test:
* Check out `main` and run the demo with an A* planner with diagonal moves allowed. Navigate to `counter0` and watch the robot struggle to follow the diagonal waypoints.
* Check out this branch and try the same