### PR TITLE
Fix pytest errors in 22.04 Docker images

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
-          pip3 install lark pytest pytest-dependency pytest-html
+          pip3 install lark py!=1.10.0 pytest pytest-dependency pytest-html
           pip3 install -e pyrobosim
           setup/setup_pddlstream.bash
       - name: Run unit tests

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,8 +22,9 @@ RUN ./setup_pddlstream.bash
 # Install pyrobosim and testing dependencies
 WORKDIR /pyrobosim_ws/src
 COPY . /pyrobosim_ws/src/
+RUN python3 -m pip install --upgrade pip
 RUN pip install ./pyrobosim
-RUN pip3 install lark pytest pytest-dependency pytest-html
+RUN pip3 install lark py!=1.10.0 pytest pytest-dependency pytest-html
 
 # Build the workspace
 WORKDIR /pyrobosim_ws

--- a/setup/create_python_env.bash
+++ b/setup/create_python_env.bash
@@ -17,7 +17,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 pushd "$SCRIPT_DIR/.." || exit
 python -m pip install --upgrade pip
 # Install catkin-pkg because https://github.com/colcon/colcon-ros/issues/118
-pip install catkin-pkg empy lark pytest pytest-dependency pytest-html wheel
+pip install catkin-pkg empy lark py!=1.10.0 pytest pytest-dependency pytest-html wheel
 pip install ./pyrobosim
 popd || exit
 deactivate


### PR DESCRIPTION
CI started failing because of some `pytest` error, and I found it's specific to the version of a dependency of `pytest-html`, namely `py 1.10.0`.

For now I've made avoiding this version explicit in the relevant `pip3 install` commands...