### PR TITLE
Tune parameters for complex PDDLStream examples

### DIFF
--- a/pyrobosim/examples/demo.py
+++ b/pyrobosim/examples/demo.py
@@ -115,6 +115,8 @@ def create_world(multirobot=False):
         "bidirectional": True,
         "rrt_connect": False,
         "rrt_star": True,
+        "max_connection_dist": 0.5,
+        "rewire_radius": 1.5,
         "compress_path": False,
     }
     rrt_planner = PathPlanner("rrt", **planner_config_rrt)

--- a/pyrobosim/examples/demo_pddl.py
+++ b/pyrobosim/examples/demo_pddl.py
@@ -27,7 +27,7 @@ def parse_args():
     parser.add_argument(
         "--search-sample-ratio",
         type=float,
-        default=2.0,
+        default=0.5,
         help="Search to sample ratio for planner",
     )
     return parser.parse_args()
@@ -75,9 +75,11 @@ def start_planner(world, args):
         robot,
         goal_literals,
         verbose=args.verbose,
+        max_attempts=3,
         search_sample_ratio=args.search_sample_ratio,
         planner="ff-astar",
-        max_planner_time=30.0,
+        max_planner_time=10.0,
+        max_time=60.0,
     )
     robot.execute_plan(plan, blocking=True)
 

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -19,7 +19,7 @@ class World:
     """Core world modeling class."""
 
     def __init__(
-        self, name="world", inflation_radius=0.0, object_radius=0.05, wall_height=2.0
+        self, name="world", inflation_radius=0.0, object_radius=0.0375, wall_height=2.0
     ):
         """
         Creates a new world model instance.
@@ -489,7 +489,7 @@ class World:
                 x_sample, y_sample = sample_from_polygon(obj_spawn.polygon)
                 yaw_sample = np.random.uniform(-np.pi, np.pi)
                 pose_sample = Pose(x=x_sample, y=y_sample, z=0.0, yaw=yaw_sample)
-                poly = transform_polygon(obj.collision_polygon, pose_sample)
+                poly = transform_polygon(obj.raw_collision_polygon, pose_sample)
 
                 is_valid_pose = poly.within(obj_spawn.polygon)
                 for other_obj in obj_spawn.children:

--- a/pyrobosim/pyrobosim/data/pddlstream_simple_world.yaml
+++ b/pyrobosim/pyrobosim/data/pddlstream_simple_world.yaml
@@ -5,8 +5,8 @@
 # WORLD PARAMETERS
 params:
   name: pddlstream_simple_world
-  object_radius: 0.05 # Radius around objects
-  wall_height: 2.0 # Wall height for exporting to Gazebo
+  object_radius: 0.0375  # Radius around objects
+  wall_height: 2.0  # Wall height for exporting to Gazebo
 
 
 # METADATA: Describes information about locations and objects
@@ -23,7 +23,7 @@ robots:
     pose: [0, 0, 0]
     path_planner:
       type: rrt
-      max_connection_dist: 0.25
+      max_connection_dist: 0.5
       bidirectional: false
       rrt_star: true
       rewire_radius: 1.5

--- a/pyrobosim/pyrobosim/data/test_world.yaml
+++ b/pyrobosim/pyrobosim/data/test_world.yaml
@@ -5,8 +5,8 @@
 # WORLD PARAMETERS
 params:
   name: test_world
-  object_radius: 0.05 # Radius around objects
-  wall_height: 2.0 # Wall height for exporting to Gazebo
+  object_radius: 0.0375  # Radius around objects
+  wall_height: 2.0  # Wall height for exporting to Gazebo
 
 
 # METADATA: Describes information about locations and objects
@@ -27,10 +27,10 @@ robots:
       # occupancy_grid:
       #   resolution: 0.05
       #   inflation_radius: 0.15
-      max_connection_dist: 0.25
+      max_connection_dist: 0.5
       bidirectional: true
       rrt_star: true
-      rewire_radius: 1.0
+      rewire_radius: 1.5
       compress_path: false
     # Linear motion path executor
     path_executor:

--- a/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
+++ b/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
@@ -5,8 +5,8 @@
 # WORLD PARAMETERS
 params:
   name: test_world
-  object_radius: 0.05 # Radius around objects
-  wall_height: 2.0 # Wall height for exporting to Gazebo
+  object_radius: 0.0375  # Radius around objects
+  wall_height: 2.0  # Wall height for exporting to Gazebo
 
 
 # METADATA: Describes information about locations and objects
@@ -24,10 +24,10 @@ robots:
     pose: [0, 0, 0]
     path_planner:
       type: rrt
-      max_connection_dist: 0.25
+      max_connection_dist: 0.5
       bidirectional: true
       rrt_star: true
-      rewire_radius: 1.0
+      rewire_radius: 1.5
     path_executor:
       type: constant_velocity
       linear_velocity: 1.0

--- a/pyrobosim/pyrobosim/planning/pddlstream/default_mappings.py
+++ b/pyrobosim/pyrobosim/planning/pddlstream/default_mappings.py
@@ -50,7 +50,6 @@ def get_stream_map(world, robot):
             lambda loc, obj: primitives.sample_place_pose(
                 loc,
                 obj,
-                padding=world.object_radius,
                 max_tries=world.max_object_sample_tries,
             )
         ),

--- a/pyrobosim/pyrobosim/planning/pddlstream/primitives.py
+++ b/pyrobosim/pyrobosim/planning/pddlstream/primitives.py
@@ -186,7 +186,7 @@ def sample_grasp_pose(
         yield (g,)
 
 
-def sample_place_pose(loc, obj, padding=0.0, max_tries=100):
+def sample_place_pose(loc, obj, max_tries=100):
     """
     Samples a feasible placement pose for an object at a specific location.
 
@@ -194,14 +194,11 @@ def sample_place_pose(loc, obj, padding=0.0, max_tries=100):
     :type loc: Location
     :param obj: Object to place.
     :type obj: Object
-    :param padding: Padding around edge of location polygon for collision checking.
-    :type padding: float, optional
     :param max_tries: Maximum samples to try before giving up.
     :type max_tries: int, optional
     :return: Generator yielding tuple containing a placement pose
     :rtype: generator[tuple[:class:`pyrobosim.utils.pose.Pose`]]
     """
-    obj_poly = inflate_polygon(obj.raw_polygon, padding)
     while True:
         is_valid_pose = False
         while not is_valid_pose:
@@ -215,7 +212,7 @@ def sample_place_pose(loc, obj, padding=0.0, max_tries=100):
             )
 
             # Check that the object is inside the polygon.
-            poly_sample = transform_polygon(obj_poly, pose_sample)
+            poly_sample = transform_polygon(obj.raw_collision_polygon, pose_sample)
             is_valid_pose = poly_sample.within(loc.polygon)
             if not is_valid_pose:
                 continue  # If our sample is in collision, simply retry.

--- a/pyrobosim_ros/examples/demo.py
+++ b/pyrobosim_ros/examples/demo.py
@@ -87,6 +87,8 @@ def create_world():
         "bidirectional": True,
         "rrt_connect": False,
         "rrt_star": True,
+        "max_connection_dist": 0.5,
+        "rewire_radius": 1.5,
         "compress_path": False,
     }
     path_planner = PathPlanner("rrt", **planner_config)

--- a/pyrobosim_ros/examples/demo_pddl_planner.py
+++ b/pyrobosim_ros/examples/demo_pddl_planner.py
@@ -41,7 +41,7 @@ class PlannerNode(Node):
         self.declare_parameter("example", value="01_simple")
         self.declare_parameter("subscribe", value=True)
         self.declare_parameter("verbose", value=True)
-        self.declare_parameter("search_sample_ratio", value=1.0)
+        self.declare_parameter("search_sample_ratio", value=0.5)
 
         # Publisher for a task plan
         self.plan_pub = self.create_publisher(TaskPlan, "commanded_plan", 10)
@@ -146,9 +146,11 @@ class PlannerNode(Node):
         plan = self.planner.plan(
             robot,
             self.latest_goal,
+            max_attempts=3,
             search_sample_ratio=self.get_parameter("search_sample_ratio").value,
             planner="ff-astar",
-            max_planner_time=30.0,
+            max_planner_time=10.0,
+            max_time=60.0,
         )
         if self.get_parameter("verbose").value == True:
             self.get_logger().info(f"{plan}")

--- a/pyrobosim_ros/launch/demo_pddl.launch.py
+++ b/pyrobosim_ros/launch/demo_pddl.launch.py
@@ -48,7 +48,7 @@ def generate_launch_description():
     )
     search_sample_ratio_arg = DeclareLaunchArgument(
         "search_sample_ratio",
-        default_value=TextSubstitution(text="1.0"),
+        default_value=TextSubstitution(text="0.5"),
         description="Search to sample ratio for planner",
     )
 

--- a/test/planning/test_pddlstream_manip.py
+++ b/test/planning/test_pddlstream_manip.py
@@ -19,7 +19,7 @@ from pyrobosim.utils.pose import Pose
 
 
 def create_test_world(add_alt_desk=True):
-    world = World(object_radius=0.05)
+    world = World(object_radius=0.0375)
 
     # Set the location and object metadata
     data_folder = get_data_folder()
@@ -90,7 +90,7 @@ def create_test_world(add_alt_desk=True):
 
 
 def start_planner(
-    world, domain_name, interactive=False, max_attempts=1, search_sample_ratio=1.0
+    world, domain_name, interactive=False, max_attempts=1, search_sample_ratio=0.5
 ):
     domain_folder = os.path.join(get_default_domains_folder(), domain_name)
     planner = PDDLStreamPlanner(world, domain_folder)
@@ -124,7 +124,7 @@ domains_to_test = ["04_nav_manip_stream", "05_nav_grasp_stream"]
 def test_manip_single_desk(domain_name):
     world = create_test_world(add_alt_desk=False)
     plan = start_planner(
-        world, domain_name=domain_name, max_attempts=3, search_sample_ratio=1.0
+        world, domain_name=domain_name, max_attempts=3, search_sample_ratio=0.5
     )
     assert plan is not None
 

--- a/test/system/test_system_world.yaml
+++ b/test/system/test_system_world.yaml
@@ -5,8 +5,8 @@
 # WORLD PARAMETERS
 params:
   name: test_system_world
-  object_radius: 0.05 # Radius around objects
-  wall_height: 2.0 # Wall height for exporting to Gazebo
+  object_radius: 0.0375  # Radius around objects
+  wall_height: 2.0  # Wall height for exporting to Gazebo
 
 
 # METADATA: Describes information about locations and objects


### PR DESCRIPTION
I recently did a few demos where the PDDLStream examples `04_nav_manip_stream` and `05_nav_grasp_stream` were failing almost all the time. Did some tuning here to make things work better and look nicer.

* Reduced the object radius from 0.05 to 0.0375
* Reduced the max planning time and search-sample ratio in PDDLStream + added retries
* Removed padding option to PDDLStream object placement streams, as the calls to inflate the polygons each function call were unnecessary
* Tuned RRT to have higher connection distances and rewire radius so the paths were less "jagged" (more cosmetic than anything)

To test, run these a bunch of times:

```
python pyrobosim/examples/demo_pddl.py --example 04_nav_manip_stream
python pyrobosim/examples/demo_pddl.py --example 05_nav_grasp_stream
```