### PR TITLE
Remove ROS 2 Foxy support, add Iron support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
   ros2-test:
     strategy:
       matrix:
-        ros_distro: [foxy, humble]
+        ros_distro: [humble, iron]
     env:
       ROS_DISTRO: ${{ matrix.ros_distro }}
 

--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -3,8 +3,8 @@ Setup
 
 This package is being tested with:
 
-* Python 3.8 in Ubuntu 20.04, optionally with ROS 2 Foxy
-* Python 3.10 in Ubuntu 22.04, optionally with ROS 2 Humble
+* Python 3.10 in Ubuntu 22.04
+* Optionally with ROS 2 Humble and Iron
 
 Local Setup
 -----------

--- a/setup/source_pyrobosim.bash
+++ b/setup/source_pyrobosim.bash
@@ -14,7 +14,7 @@
 #  So you can then run this from your Terminal:
 #    pyrobosim
 #
-# For ROS workflows, enter the ROS distro (foxy/humble) as an argument:
+# For ROS workflows, enter the ROS distro (humble/iron) as an argument:
 #
 #   pyrobosim_ros() {
 #     source /path/to/pyrobosim/setup/source_pyrobosim.bash humble


### PR DESCRIPTION
Since ROS 2 Foxy is now EOL, I will drop support and add ROS 2 Iron.

You can try installing `pyrobosim` with ROS 2 Iron locally, or build the Docker image with:

```
export ROS_DISTRO=iron
docker compose build
```