### PR TITLE
Fix robot name in multirobot ROS demo

### DIFF
--- a/pyrobosim_ros/examples/demo_commands.py
+++ b/pyrobosim_ros/examples/demo_commands.py
@@ -82,7 +82,7 @@ def main():
             TaskAction(type="navigate", target_location="counter0_left"),
             TaskAction(type="place"),
         ]
-        plan_msg = TaskPlan(robot="robby", actions=task_actions)
+        plan_msg = TaskPlan(robot="robot2", actions=task_actions)
         cmd.plan_pub.publish(plan_msg)
 
     else:


### PR DESCRIPTION
There was an old mention of a "robby" robot in the ROS demo file, which was renamed to "robot2".

To test:
* Local: `ros2 launch pyrobosim_ros demo_commands_multirobot.launch.py`
* Docker: `docker compose up demo_multirobot_ros`