### PR TITLE
Fix circular imports in knowledge utilities

### DIFF
--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -51,6 +51,7 @@ class World:
         self.hallways = []
         self.locations = []
         self.objects = []
+        self.set_metadata()
 
         # Counters
         self.num_rooms = 0

--- a/pyrobosim/pyrobosim/utils/general.py
+++ b/pyrobosim/pyrobosim/utils/general.py
@@ -40,9 +40,16 @@ class EntityMetadata:
         :param filename: Path to metadata YAML file.
         :type filename: str
         """
-        self.filename = filename
-        with open(self.filename) as file:
-            self.data = yaml.load(file, Loader=yaml.FullLoader)
+        if filename:
+            if not os.path.isfile(filename):
+                raise FileNotFoundError(f"Metadata filename not found: {filename}")
+
+            self.filename = filename
+            with open(self.filename) as file:
+                self.data = yaml.load(file, Loader=yaml.FullLoader)
+        else:
+            self.filename = None
+            self.data = {}
 
     def has_category(self, category):
         """

--- a/pyrobosim/pyrobosim/utils/knowledge.py
+++ b/pyrobosim/pyrobosim/utils/knowledge.py
@@ -208,6 +208,8 @@ def resolve_to_location(
     :return: The location or object spawn that meets the category and/or room filters, or None.
     :rtype: :class:`pyrobosim.core.locations.Location`/:class:`pyrobosim.core.locations.ObjectSpawn`
     """
+    from ..core.locations import Location
+
     if room is None:
         room_name = None
         if category is None:

--- a/pyrobosim/pyrobosim/utils/knowledge.py
+++ b/pyrobosim/pyrobosim/utils/knowledge.py
@@ -7,9 +7,6 @@ import sys
 import warnings
 import numpy as np
 
-from ..core.locations import Location, ObjectSpawn
-from ..core.objects import Object
-
 
 def apply_resolution_strategy(world, entity_list, resolution_strategy, robot=None):
     """
@@ -75,6 +72,9 @@ def query_to_entity(world, query_list, mode, resolution_strategy="first", robot=
     :return: The entity that meets the mode and resolution strategy, or None.
     :rtype: Entity
     """
+    from ..core.locations import Location, ObjectSpawn
+    from ..core.objects import Object
+
     room = None
     named_location = None
     loc_category = None


### PR DESCRIPTION
This PR fixes circular imports in the knowledge utilities by importing from the core modules only in the functions that require it.

It also ensures that Location and Object metadata is always set to a blank dictionary even when nothing has been specified, to prevent runtime errors.

Closes https://github.com/sea-bass/pyrobosim/issues/122