### PR TITLE
Add nav action path to GUI nav trigger signal

### DIFF
--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -361,7 +361,7 @@ class Robot:
                 else:
                     tgt_loc = action.target_location.name
 
-                self.world.gui.canvas.nav_trigger.emit(self.name, tgt_loc)
+                self.world.gui.canvas.nav_trigger.emit(self.name, tgt_loc, action.path)
                 while self.executing_nav:
                     time.sleep(0.5)  # Delay to wait for navigation
                 success = True  # TODO Need to keep track of nav status

--- a/pyrobosim/pyrobosim/data/pddlstream_simple_world.yaml
+++ b/pyrobosim/pyrobosim/data/pddlstream_simple_world.yaml
@@ -23,7 +23,7 @@ robots:
     pose: [0, 0, 0]
     path_planner:
       type: rrt
-      max_connection_dist: 0.5
+      max_connection_dist: 1.0
       bidirectional: false
       rrt_star: true
       rewire_radius: 1.5

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -371,7 +371,7 @@ class WorldCanvas(FigureCanvasQTAgg):
         y = obj.pose.y + 1.0 * (ymax - ymin)
         obj.viz_text.set_position((x, y))
 
-    def navigate_in_thread(self, robot, goal, path):
+    def navigate_in_thread(self, robot, goal, path=None):
         """
         Starts a thread to navigate a robot to a goal.
 
@@ -379,7 +379,7 @@ class WorldCanvas(FigureCanvasQTAgg):
         :type robot: :class:`pyrobosim.core.robot.Robot` or str
         :param goal: Name of goal location (resolved by the world model).
         :type goal: str
-        :param path: Path to goal location (can be None).
+        :param path: Path to goal location, defaults to None.
         :type path: :class:`pyrobosim.utils.motion.Path`
         :return: True if navigation succeeds, else False
         :rtype: bool
@@ -389,7 +389,7 @@ class WorldCanvas(FigureCanvasQTAgg):
         nav_thread = threading.Thread(target=self.navigate, args=(robot, goal, path))
         nav_thread.start()
 
-    def navigate(self, robot, goal, path):
+    def navigate(self, robot, goal, path=None):
         """
         Animates a path to a goal location using a robot's path executor.
 
@@ -397,7 +397,7 @@ class WorldCanvas(FigureCanvasQTAgg):
         :type robot: :class:`pyrobosim.core.robot.Robot`
         :param goal: Name of goal location (resolved by the world model).
         :type goal: str
-        :param path: Path to goal location (can be None).
+        :param path: Path to goal location, defaults to None.
         :type path: :class:`pyrobosim.utils.motion.Path`
         :return: True if navigation succeeds, else False
         :rtype: bool

--- a/test/planning/test_pddlstream_manip.py
+++ b/test/planning/test_pddlstream_manip.py
@@ -82,6 +82,7 @@ def create_test_world(add_alt_desk=True):
         "rrt_connect": False,
         "rrt_star": True,
         "compress_path": False,
+        "max_connection_dist": 1.0,
     }
     rrt = PathPlanner("rrt", **planner_config)
     robot.set_path_planner(rrt)
@@ -139,13 +140,13 @@ def test_manip_double_desk(domain_name):
 
 
 if __name__ == "__main__":
-    world = create_test_world(add_alt_desk=True)
-
     domain_name = "04_nav_manip_stream"
+    add_alt_desk = False
     interactive = True
     max_attempts = 3
 
     # Start task and motion planner in separate thread.
+    world = create_test_world(add_alt_desk)
     planner_thread = threading.Thread(
         target=start_planner, args=(world, domain_name, interactive, max_attempts)
     )

--- a/test/planning/test_pddlstream_nav.py
+++ b/test/planning/test_pddlstream_nav.py
@@ -64,6 +64,7 @@ def create_test_world(add_hallway=True):
         "bidirectional": False,
         "rrt_connect": False,
         "rrt_star": False,
+        "max_connection_dist": 1.0,
     }
     rrt = PathPlanner("rrt", **planner_config)
     robot.set_path_planner(rrt)


### PR DESCRIPTION
Found a small bug while testing before a presentation.

It seems like by removing some class attributes in a recent PR, sending an action to the GUI with an already-planned path was discarding the path and trying to plan again.