### PR TITLE
Add unit tests for `TaskPlan` and `TaskAction` objects

### DIFF
--- a/pyrobosim/pyrobosim/navigation/planner_base.py
+++ b/pyrobosim/pyrobosim/navigation/planner_base.py
@@ -2,7 +2,6 @@
 
 import matplotlib.pyplot as plt
 from matplotlib.collections import LineCollection
-import numpy as np
 
 from pyrobosim.utils.motion import Path
 

--- a/pyrobosim/pyrobosim/planning/pddlstream/primitives.py
+++ b/pyrobosim/pyrobosim/planning/pddlstream/primitives.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from ...manipulation.grasping import GraspFace
 from ...utils.pose import Pose
-from ...utils.polygon import inflate_polygon, sample_from_polygon, transform_polygon
+from ...utils.polygon import sample_from_polygon, transform_polygon
 
 
 def get_pick_place_cost(loc, obj):

--- a/pyrobosim/pyrobosim/utils/motion.py
+++ b/pyrobosim/pyrobosim/utils/motion.py
@@ -45,6 +45,20 @@ class Path:
             yaw = prev_pose.get_angular_distance(cur_pose)
             cur_pose.set_euler_angles(yaw=yaw)
 
+    def __eq__(self, other):
+        """
+        Check if two paths are exactly equal.
+
+        :param other: Path with which to check equality.
+        :type other: :class:`pyrobosim.utils.motion.Path`
+        :return: True if the paths are equal, else False
+        :rtype: bool
+        """
+        if not (isinstance(other, Path)):
+            raise TypeError("Expected a Path object")
+
+        return self.poses == other.poses
+
     def __repr__(self):
         """Return brief description of the path."""
         print_str = f"Path with {self.num_poses} points, Length {self.length:.3f}"

--- a/pyrobosim/pyrobosim/utils/motion.py
+++ b/pyrobosim/pyrobosim/utils/motion.py
@@ -2,8 +2,6 @@
 Motion planning utilities.
 """
 
-import numpy as np
-
 
 class Path:
     """Representation of a path for motion planning."""

--- a/pyrobosim/pyrobosim/utils/pose.py
+++ b/pyrobosim/pyrobosim/utils/pose.py
@@ -224,7 +224,7 @@ class Pose:
         :rtype: bool
         """
         if not (isinstance(other, Pose)):
-            raise TypeError("Expected a Pose")
+            raise TypeError("Expected a Pose object")
 
         return np.all(self.get_translation() == other.get_translation()) and np.all(
             self.q == other.q

--- a/pyrobosim_ros/test/test_ros_conversions.py
+++ b/pyrobosim_ros/test/test_ros_conversions.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-import pyrobosim_msgs.msg as ros_msgs
 import pyrobosim.planning.actions as acts
 from pyrobosim.utils.motion import Path
 from pyrobosim.utils.pose import Pose

--- a/test/planning/test_task_objects.py
+++ b/test/planning/test_task_objects.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+"""Unit tests for task action and plan objects"""
+
+import pytest
+
+from pyrobosim.planning.actions import TaskAction, TaskPlan
+from pyrobosim.utils.motion import Path
+from pyrobosim.utils.pose import Pose
+
+
+def test_task_action_default_args():
+    action = TaskAction("pick")
+
+    assert action.type == "pick"
+    assert action.robot is None
+    assert action.cost is None
+    assert action.object is None
+    assert action.room is None
+    assert action.source_location is None
+    assert action.target_location is None
+    assert action.pose is None
+    assert isinstance(action.path, Path)
+    assert action.path.num_poses == 0
+
+
+def test_task_action_nondefault_args():
+    test_path = Path(
+        poses=[
+            Pose(x=0.0, y=0.0, yaw=0.0),
+            Pose(x=0.5, y=1.0, yaw=1.5),
+            Pose(x=1.0, y=2.0, yaw=3.0),
+        ]
+    )
+
+    action = TaskAction(
+        "Pick",
+        robot="robot0",
+        object="apple0",
+        room="kitchen",
+        source_location="table0_tabletop",
+        target_location="counter0_right",
+        pose=test_path.poses[-1],
+        path=test_path,
+        cost=42.0,
+    )
+
+    assert action.type == "pick"  # Should be converted to lower case
+    assert action.robot == "robot0"
+    assert action.cost == pytest.approx(42.0)
+    assert action.object == "apple0"
+    assert action.room == "kitchen"
+    assert action.source_location == "table0_tabletop"
+    assert action.target_location == "counter0_right"
+    assert action.pose == test_path.poses[-1]
+    assert action.path == test_path
+
+
+def test_task_plan_default_args():
+    plan = TaskPlan()
+
+    assert plan.robot is None
+    assert plan.actions == []
+    assert plan.total_cost == pytest.approx(0.0)
+    assert plan.size() == 0
+
+
+def test_task_plan_nondefault_args():
+    nav_path = Path(
+        [
+            Pose(x=0.0, y=0.0, z=0.0, q=[1.0, 0.0, 0.0, 0.0]),
+            Pose(x=1.0, y=0.0, z=0.0, q=[0.707, 0.0, 0.0, 0.707]),
+            Pose(x=1.0, y=1.0, z=0.0, q=[0.0, 0.0, 0.0, 1.0]),
+        ]
+    )
+    place_pose = Pose(x=0.8, y=1.0, z=0.5, q=[1.0, 0.0, 0.0, 0.0])
+
+    actions = [
+        TaskAction("pick", object="apple", source_location="table0", cost=0.5),
+        TaskAction(
+            "navigate",
+            source_location="table0",
+            target_location="desk0",
+            path=nav_path,
+            cost=0.75,
+        ),
+        TaskAction(
+            "place", object="apple", target_location="desk0", pose=place_pose, cost=0.5
+        ),
+    ]
+    plan = TaskPlan(robot="robot0", actions=actions)
+
+    assert plan.robot == "robot0"
+    assert len(plan.actions) == 3
+    assert plan.size() == 3
+    assert plan.actions[0].type == "pick"
+    assert plan.actions[1].type == "navigate"
+    assert plan.actions[2].type == "place"
+    assert plan.total_cost == pytest.approx(1.75)

--- a/test/planning/test_task_objects.py
+++ b/test/planning/test_task_objects.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-"""Unit tests for task action and plan objects"""
+"""Unit tests for task action and plan objects."""
 
 import pytest
 
@@ -10,6 +10,7 @@ from pyrobosim.utils.pose import Pose
 
 
 def test_task_action_default_args():
+    """Create TaskAction object with default arguments and validate results."""
     action = TaskAction("pick")
 
     assert action.type == "pick"
@@ -25,6 +26,7 @@ def test_task_action_default_args():
 
 
 def test_task_action_nondefault_args():
+    """Create TaskAction object with nondefault arguments and validate results."""
     test_poses = [
         Pose(x=0.0, y=0.0, yaw=0.0),
         Pose(x=0.5, y=1.0, yaw=1.5),
@@ -55,6 +57,7 @@ def test_task_action_nondefault_args():
 
 
 def test_task_plan_default_args():
+    """Create TaskPlan object with default arguments and validate results."""
     plan = TaskPlan()
 
     assert plan.robot is None
@@ -64,6 +67,7 @@ def test_task_plan_default_args():
 
 
 def test_task_plan_nondefault_args():
+    """Create TaskAction object with nondefault arguments and validate results."""
     nav_path = Path(
         poses=[
             Pose(x=0.0, y=0.0, z=0.0, q=[1.0, 0.0, 0.0, 0.0]),

--- a/test/planning/test_task_objects.py
+++ b/test/planning/test_task_objects.py
@@ -25,13 +25,11 @@ def test_task_action_default_args():
 
 
 def test_task_action_nondefault_args():
-    test_path = Path(
-        poses=[
-            Pose(x=0.0, y=0.0, yaw=0.0),
-            Pose(x=0.5, y=1.0, yaw=1.5),
-            Pose(x=1.0, y=2.0, yaw=3.0),
-        ]
-    )
+    test_poses = [
+        Pose(x=0.0, y=0.0, yaw=0.0),
+        Pose(x=0.5, y=1.0, yaw=1.5),
+        Pose(x=1.0, y=2.0, yaw=3.0),
+    ]
 
     action = TaskAction(
         "Pick",
@@ -40,8 +38,8 @@ def test_task_action_nondefault_args():
         room="kitchen",
         source_location="table0_tabletop",
         target_location="counter0_right",
-        pose=test_path.poses[-1],
-        path=test_path,
+        pose=test_poses[-1],
+        path=Path(poses=test_poses),
         cost=42.0,
     )
 
@@ -52,8 +50,8 @@ def test_task_action_nondefault_args():
     assert action.room == "kitchen"
     assert action.source_location == "table0_tabletop"
     assert action.target_location == "counter0_right"
-    assert action.pose == test_path.poses[-1]
-    assert action.path == test_path
+    assert action.pose == test_poses[-1]
+    assert action.path == Path(poses=test_poses)
 
 
 def test_task_plan_default_args():
@@ -67,7 +65,7 @@ def test_task_plan_default_args():
 
 def test_task_plan_nondefault_args():
     nav_path = Path(
-        [
+        poses=[
             Pose(x=0.0, y=0.0, z=0.0, q=[1.0, 0.0, 0.0, 0.0]),
             Pose(x=1.0, y=0.0, z=0.0, q=[0.707, 0.0, 0.0, 0.707]),
             Pose(x=1.0, y=1.0, z=0.0, q=[0.0, 0.0, 0.0, 1.0]),

--- a/test/test_dependencies.py
+++ b/test/test_dependencies.py
@@ -2,8 +2,6 @@
 Basic checks for external dependencies.
 """
 
-import pytest
-
 
 def test_import_pddlstream():
     import pddlstream

--- a/test/utils/test_knowledge_utils.py
+++ b/test/utils/test_knowledge_utils.py
@@ -5,12 +5,10 @@ Unit tests for world knowledge utilities.
 """
 
 import os
-import numpy as np
 import pytest
 
 from pyrobosim.core import WorldYamlLoader
 from pyrobosim.core import Robot
-from pyrobosim.core import World
 
 # import functions to test
 from pyrobosim.utils.knowledge import (
@@ -19,7 +17,6 @@ from pyrobosim.utils.knowledge import (
     resolve_to_location,
     resolve_to_object,
 )
-
 from pyrobosim.utils.pose import Pose
 from pyrobosim.utils.general import get_data_folder
 

--- a/test/utils/test_motion_utils.py
+++ b/test/utils/test_motion_utils.py
@@ -55,6 +55,23 @@ def test_path_fill_yaws():
         assert pose.get_yaw() == pytest.approx(expected_yaw)
 
 
+def test_path_equality():
+    """Tests for equality of Path objects."""
+    test_poses = [
+        Pose(x=0.0, y=0.0),
+        Pose(x=1.0, y=0.0, yaw=np.pi / 2.0),
+        Pose(x=1.0, y=3.0, q=[0.707, 0.0, 0.707, 0.0]),
+    ]
+
+    path1 = Path(poses=test_poses)
+    path2 = Path(poses=test_poses)  # Same poses, but different object
+    path3 = Path(poses=list(reversed(test_poses)))  # Different poses
+
+    assert path1 == path1
+    assert path1 == path2
+    assert not path1 == path3
+
+
 ##########################################
 # Tests for waypoint reduction utilities #
 ##########################################

--- a/test/utils/test_pose_utils.py
+++ b/test/utils/test_pose_utils.py
@@ -185,6 +185,7 @@ def test_equality():
     # Completely different values
     pose3 = Pose(x=0.0, y=0.0, z=0.0)
 
+    assert pose1 == pose1
     assert pose1 == pose2
     assert not pose1 == pose3
 


### PR DESCRIPTION
This PR adds some basic unit tests for the task and motion planning object representations. These classes are simple, so not much to be done here.

Closes https://github.com/sea-bass/pyrobosim/issues/96