### PR TITLE
Handle missing parent and invalid categories when adding locations and objects

### DIFF
--- a/pyrobosim/pyrobosim/core/locations.py
+++ b/pyrobosim/pyrobosim/core/locations.py
@@ -3,7 +3,7 @@
 from shapely import intersects_xy
 from shapely.plotting import patch_from_polygon
 
-from ..utils.general import EntityMetadata
+from ..utils.general import EntityMetadata, InvalidEntityCategoryException
 from ..utils.pose import Pose, rot2d
 from ..utils.polygon import (
     inflate_polygon,
@@ -60,6 +60,11 @@ class Location:
         self.parent = parent
 
         self.metadata = Location.metadata.get(self.category)
+        if not self.metadata:
+            raise InvalidEntityCategoryException(
+                f"Invalid location category: {self.category}"
+            )
+
         if color is not None:
             self.viz_color = color
         elif "color" in self.metadata:

--- a/pyrobosim/pyrobosim/core/objects.py
+++ b/pyrobosim/pyrobosim/core/objects.py
@@ -4,7 +4,7 @@ import numpy as np
 from shapely.plotting import patch_from_polygon
 from scipy.spatial import ConvexHull
 
-from ..utils.general import EntityMetadata
+from ..utils.general import EntityMetadata, InvalidEntityCategoryException
 from ..utils.pose import Pose
 from ..utils.polygon import (
     convhull_to_rectangle,
@@ -69,6 +69,11 @@ class Object:
         self.viz_text = None
 
         self.metadata = Object.metadata.get(self.category)
+        if not self.metadata:
+            raise InvalidEntityCategoryException(
+                f"Invalid object category: {self.category}"
+            )
+
         if color is not None:
             self.viz_color = color
         elif "color" in self.metadata:

--- a/pyrobosim/pyrobosim/utils/general.py
+++ b/pyrobosim/pyrobosim/utils/general.py
@@ -74,6 +74,12 @@ class EntityMetadata:
         return self.data.get(category, None)
 
 
+class InvalidEntityCategoryException(Exception):
+    """Raised when an invalid entity metadata category is used."""
+
+    pass
+
+
 def replace_special_yaml_tokens(in_text, root_dir=None):
     """
     Replaces special tokens permitted in our YAML specification.

--- a/test/core/test_world.py
+++ b/test/core/test_world.py
@@ -8,7 +8,7 @@ import numpy as np
 from pyrobosim.core import Hallway, Object, World
 from pyrobosim.utils.pose import Pose
 
-from pyrobosim.utils.general import get_data_folder
+from pyrobosim.utils.general import get_data_folder, InvalidEntityCategoryException
 
 
 class TestWorldModeling:
@@ -104,6 +104,23 @@ class TestWorldModeling:
         assert len(TestWorldModeling.world.locations) == 2
         assert TestWorldModeling.world.get_location_by_name("study_desk") == desk
 
+        # Test missing parent
+        with pytest.warns(UserWarning):
+            result = TestWorldModeling.world.add_location(
+                category="desk",
+                pose=Pose(),
+            )
+            assert result is None
+
+        # Test invalid category
+        with pytest.warns(UserWarning):
+            result = TestWorldModeling.world.add_location(
+                category="does_not_exist",
+                parent="bedroom",
+                pose=Pose(),
+            )
+            assert result is None
+
     @staticmethod
     @pytest.mark.dependency(
         depends=[
@@ -126,6 +143,23 @@ class TestWorldModeling:
         assert (
             TestWorldModeling.world.get_object_by_name("apple1") == test_obj
         )  # Automatic naming
+
+        # Test missing parent
+        with pytest.warns(UserWarning):
+            result = TestWorldModeling.world.add_object(
+                category="apple",
+                pose=Pose(),
+            )
+            assert result is None
+
+        # Test invalid category
+        with pytest.warns(UserWarning):
+            result = TestWorldModeling.world.add_object(
+                category="does_not_exist",
+                parent="study_desk",
+                pose=Pose(),
+            )
+            assert result is None
 
     @staticmethod
     @pytest.mark.dependency(

--- a/test/core/test_yaml_utils.py
+++ b/test/core/test_yaml_utils.py
@@ -22,8 +22,10 @@ class TestWorldYamlLoading:
         TestWorldYamlLoading.yaml_loader = WorldYamlLoader()
 
         # Clean up metadata for test reproducibility
-        delattr(Location, "metadata")
-        delattr(Object, "metadata")
+        if hasattr(Location, "metadata"):
+            delattr(Location, "metadata")
+        if hasattr(Object, "metadata"):
+            delattr(Object, "metadata")
 
     @staticmethod
     @pytest.mark.dependency(
@@ -177,6 +179,33 @@ class TestWorldYamlLoading:
         loader.add_locations()
         assert len(loader.world.locations) == 0
 
+        # No parent means the location is not added.
+        loader.data = {
+            "locations": [
+                {
+                    "category": "table",
+                    "pose": [0.85, -0.5, 0.0, -1.57],
+                }
+            ]
+        }
+        with pytest.warns(UserWarning):
+            loader.add_locations()
+            assert len(loader.world.locations) == 0
+
+        # Invalid location category means the object is not added.
+        loader.data = {
+            "locations": [
+                {
+                    "category": "does_not_exist",
+                    "parent": "kitchen",
+                    "pose": [0.85, -0.5, 0.0, -1.57],
+                }
+            ]
+        }
+        with pytest.warns(UserWarning):
+            loader.add_locations()
+            assert len(loader.world.locations) == 0
+
         # Load locations from a YAML specified dictionary.
         locations_dict = {
             "locations": [
@@ -221,6 +250,33 @@ class TestWorldYamlLoading:
         loader.data = {}
         loader.add_objects()
         assert len(loader.world.objects) == 0
+
+        # No parent means the object is not added.
+        loader.data = {
+            "objects": [
+                {
+                    "category": "banana",
+                    "pose": [3.2, 3.5, 0.0, 0.707],
+                }
+            ]
+        }
+        with pytest.warns(UserWarning):
+            loader.add_objects()
+            assert len(loader.world.objects) == 0
+
+        # Invalid object category means the object is not added.
+        loader.data = {
+            "objects": [
+                {
+                    "category": "does_not_exist",
+                    "parent": "table0",
+                    "pose": [3.2, 3.5, 0.0, 0.707],
+                }
+            ]
+        }
+        with pytest.warns(UserWarning):
+            loader.add_objects()
+            assert len(loader.world.objects) == 0
 
         # Load objects from a YAML specified dictionary.
         objects_dict = {


### PR DESCRIPTION
When writing tests, I noticed that there were some cases in `World.add_location()` and `World.add_object()` that would lead to uncaught exceptions. This was specifically:

* Missing the `parent` input
* Using a nonexistent category and thereby getting no metadata

I've added some guards to that, as well as unit tests in both the world creation and YAML loading tests.