### PR TITLE
Split out CI jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,7 @@ jobs:
     strategy:
       matrix:
         ros_distro: [humble, iron, rolling]
+
     name: ros-${{ matrix.ros_distro }}-test
     runs-on: ubuntu-latest
     steps:
@@ -62,6 +63,8 @@ jobs:
         with:
           file: docker/Dockerfile
           context: .
+          build-args: |
+            ROS_DISTRO=${{ matrix.ros_distro }}
           tags: pyrobosim:${{ matrix.ros_distro }}
       - name: Run tests
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,21 +43,28 @@ jobs:
         # Always publish test results even when there are failures.
         if: ${{ always() }}
 
-  # Testing with ROS 2
-  ros2-test:
+  # Build and test with ROS 2
+  ros2-tests:
     strategy:
       matrix:
         ros_distro: [humble, iron, rolling]
-    env:
-      ROS_DISTRO: ${{ matrix.ros_distro }}
-
     name: ros-${{ matrix.ros_distro }}-test
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
-      - name: Run unit tests in Docker container
-        run: docker compose run test
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          file: docker/Dockerfile
+          context: .
+          tags: pyrobosim:${{ matrix.ros_distro }}
+      - name: Run tests
+        run: docker run --volume ./test/:/pyrobosim_ws/test/:rw --volume ./pytest.ini:/pyrobosim_ws/pytest.ini:rw pyrobosim:${{ matrix.ros_distro }} /bin/bash -c './test/run_tests.bash'
       - name: Upload test results
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
         if: ${{ always() }}
 
   # Build and test with ROS 2
-  ros2-tests:
+  ros2-test:
     strategy:
       matrix:
         ros_distro: [humble, iron, rolling]
@@ -64,7 +64,12 @@ jobs:
           context: .
           tags: pyrobosim:${{ matrix.ros_distro }}
       - name: Run tests
-        run: docker run --volume ./test/:/pyrobosim_ws/test/:rw --volume ./pytest.ini:/pyrobosim_ws/pytest.ini:rw pyrobosim:${{ matrix.ros_distro }} /bin/bash -c './test/run_tests.bash'
+        run: |
+          docker run \
+            --volume ./test/:/pyrobosim_ws/test/:rw \
+            --volume ./pytest.ini:/pyrobosim_ws/pytest.ini:rw \
+            pyrobosim:${{ matrix.ros_distro }} \
+            /bin/bash -c './test/run_tests.bash'
       - name: Upload test results
         uses: actions/upload-artifact@v3
         with:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,7 +13,7 @@
 
 services:
   base:
-    image: pyrobosim-${ROS_DISTRO:-humble}
+    image: pyrobosim:${ROS_DISTRO:-humble}
     build:
       context: .
       dockerfile: docker/Dockerfile


### PR DESCRIPTION
Instead of running a monolithic `docker compose` command, this PR breaks out the actions into build and test.

Hopefully this paves the way for being smarter about caching/breaking out the actions further to minimize CI times.