### PR TITLE
Fix coverage base folder

### DIFF
--- a/test/run_tests.bash
+++ b/test/run_tests.bash
@@ -14,7 +14,8 @@ TEST_RESULTS_DIR="${SCRIPT_DIR}/results"
 # Run regular pytest tests
 echo "Running Python package unit tests..."
 python3 -m pytest "$SCRIPT_DIR" \
- --cov="$SCRIPT_DIR" --cov-branch --cov-report term \
+ --cov="$SCRIPT_DIR/../pyrobosim/pyrobosim" --cov-branch \
+ --cov-report term \
  --cov-report html:"$TEST_RESULTS_DIR/test_results_coverage_html" \
  --cov-report xml:"$TEST_RESULTS_DIR/test_results_coverage.xml" \
  --junitxml="$TEST_RESULTS_DIR/test_results.xml" \


### PR DESCRIPTION
Found an issue in the test script, where the coverage was meant to point at the source directory and not the test directory.

OLD:
![image](https://github.com/sea-bass/pyrobosim/assets/4603398/1137ccd9-2011-4091-a4be-f133b0b76265)

NEW:
![image](https://github.com/sea-bass/pyrobosim/assets/4603398/b50646f9-fc98-4660-8933-ff7fd8ae3503)
