### PR TITLE
Add robot velocity command ROS subscribers

### DIFF
--- a/docs/source/usage/robot_dynamics.rst
+++ b/docs/source/usage/robot_dynamics.rst
@@ -70,3 +70,55 @@ The full example is available here for you to run and modify.
 ::
 
     python3 examples/demo_dynamics.py
+
+ROS 2 Interface Usage
+---------------------
+
+If you launch ``pyrobosim`` with the ROS 2 interface, you can command each robot using ROS topics.
+
+For example, a robot named ``my_robot`` will have a topic ``my_robot/cmd_vel`` of type ``geometry_msgs/Twist``.
+To command this robot from an existing ROS 2 node in Python, you can do something like this:
+
+.. code-block:: python
+
+    from geometry_msgs.msg import Twist
+
+    vel_pub = node.create_publisher(
+        Twist, f"{robot_name}/cmd_vel", 10
+    )
+
+    vel_cmd = Twist()
+    vel_cmd.linear.x = 0.25
+    vel_cmd.angular.z = 1.0
+
+    vel_pub.publish(vel_cmd)
+
+To handle the nondeterminism of publishing velocity commands using ROS topics, the :doc:`WorldROSWrapper </generated/pyrobosim_ros.ros_interface.WorldROSWrapper>` class provides arguments to latch velocity commands and then ramp them down to zero velocity.
+While you can look at the documentation for a full list of arguments, the important ones to know are:
+
+.. code-block:: python
+
+    from pyrobosim_ros.ros_interface import WorldROSWrapper
+
+    node = WorldROSWrapper(
+        dynamics_rate=0.01,           # Dynamics update rate
+        dynamics_latch_time=0.5,      # Velocity command latch time
+        dynamics_ramp_down_time=0.5,  # Velocity command ramp down time
+    )
+
+You can try this out using the following example.
+
+::
+
+    # Launch pyrobosim
+    ros2 launch pyrobosim_ros demo.launch.py
+
+    # Launch a simple velocity publisher node
+    ros2 run pyrobosim_ros demo_velocity_publisher.py
+
+    # (Optional launch with parameters)
+    ros2 run pyrobosim_ros demo_velocity_publisher.py --ros-args -p robot_name:=robot -p lin_vel:=-0.1 -p ang_vel:=0.5
+
+    # (Optional) Modify the velocities at runtime
+    ros2 param set demo_velocity_publisher lin_vel -0.1
+    ros2 param set demo_velocity_publisher ang_vel 0.25

--- a/docs/source/usage/robot_dynamics.rst
+++ b/docs/source/usage/robot_dynamics.rst
@@ -83,9 +83,7 @@ To command this robot from an existing ROS 2 node in Python, you can do somethin
 
     from geometry_msgs.msg import Twist
 
-    vel_pub = node.create_publisher(
-        Twist, f"{robot_name}/cmd_vel", 10
-    )
+    vel_pub = node.create_publisher(Twist, "my_robot/cmd_vel", 10)
 
     vel_cmd = Twist()
     vel_cmd.linear.x = 0.25

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -722,7 +722,7 @@ class World:
         if self.has_gui:
             self.gui.canvas.show_robots()
         if self.has_ros_node:
-            self.ros_node.add_robot_state_publishers()
+            self.ros_node.add_robot_ros_interfaces()
 
     def remove_robot(self, robot_name):
         """
@@ -738,7 +738,7 @@ class World:
             if self.has_gui:
                 self.gui.canvas.show_robots()
             if self.has_ros_node:
-                self.ros_node.remove_robot_state_publisher(robot)
+                self.ros_node.remove_robot_ros_interfaces(robot)
 
             # Find the new max inflation radius and revert it.
             new_inflation_radius = max(

--- a/pyrobosim_msgs/package.xml
+++ b/pyrobosim_msgs/package.xml
@@ -9,9 +9,7 @@
 
   <!-- Build dependencies -->
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>rclcpp</build_depend>
   <build_depend>rosidl_default_generators</build_depend>
-  <build_depend>geometry_msgs</build_depend>
 
   <!-- Execution dependencies -->
   <exec_depend>rclcpp</exec_depend>

--- a/pyrobosim_ros/CMakeLists.txt
+++ b/pyrobosim_ros/CMakeLists.txt
@@ -21,6 +21,7 @@ install(PROGRAMS
   examples/demo_pddl_world.py
   examples/demo_pddl_planner.py
   examples/demo_pddl_goal_publisher.py
+  examples/demo_velocity_publisher.py
   ../pyrobosim/examples/demo_prm.py
   ../pyrobosim/examples/demo_rrt.py
   ../pyrobosim/examples/demo_pddl.py

--- a/pyrobosim_ros/examples/demo.py
+++ b/pyrobosim_ros/examples/demo.py
@@ -111,7 +111,7 @@ def create_world_from_yaml(world_file):
 def create_ros_node():
     """Initializes ROS node"""
     rclpy.init()
-    node = WorldROSWrapper(state_pub_rate=0.1, dynamics_dt=0.01)
+    node = WorldROSWrapper(state_pub_rate=0.1, dynamics_rate=0.01)
     node.declare_parameter("world_file", value="")
 
     # Set the world

--- a/pyrobosim_ros/examples/demo.py
+++ b/pyrobosim_ros/examples/demo.py
@@ -111,11 +111,11 @@ def create_world_from_yaml(world_file):
 def create_ros_node():
     """Initializes ROS node"""
     rclpy.init()
-    node = WorldROSWrapper(state_pub_rate=0.1)
+    node = WorldROSWrapper(state_pub_rate=0.1, dynamics_dt=0.01)
     node.declare_parameter("world_file", value="")
 
     # Set the world
-    world_file = node.get_parameter("world_file").value
+    world_file = node.get_parameter("world_file").get_parameter_value().string_value
     if world_file == "":
         node.get_logger().info("Creating demo world programmatically.")
         world = create_world()

--- a/pyrobosim_ros/examples/demo_velocity_publisher.py
+++ b/pyrobosim_ros/examples/demo_velocity_publisher.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+"""
+Test script showing how to publish velocity commands to a pyrobosim robot.
+"""
+
+import rclpy
+from rclpy.node import Node
+import time
+
+from geometry_msgs.msg import Twist
+
+
+class VelocityPublisher(Node):
+    def __init__(self):
+        super().__init__("demo_velocity_publisher")
+
+        # Declare parameters
+        self.declare_parameter("robot_name", value="robot")
+        self.declare_parameter("pub_period", value=0.1)
+        self.declare_parameter("lin_vel", value=0.2)
+        self.declare_parameter("ang_vel", value=0.5)
+
+        # Publisher for velocity commands
+        robot_name = self.get_parameter("robot_name").value
+        self.vel_pub = self.create_publisher(Twist, f"{robot_name}/cmd_vel", 10)
+        self.get_logger().info("Waiting for subscription")
+        while rclpy.ok() and self.vel_pub.get_subscription_count() < 1:
+            time.sleep(2.0)
+        if self.vel_pub.get_subscription_count() < 1:
+            self.get_logger().error(
+                f"Error while waiting for a velocity command subscriber to {self.vel_pub.topic_name}."
+            )
+            return
+
+        # Create a publisher timer
+        pub_period = self.get_parameter("pub_period").value
+        self.timer = self.create_timer(pub_period, self.vel_pub_callback)
+
+    def vel_pub_callback(self):
+        """Publisher callback for velocity commands."""
+        lin_vel = self.get_parameter("lin_vel").value
+        ang_vel = self.get_parameter("ang_vel").value
+
+        pub_cmd = Twist()
+        pub_cmd.linear.x = lin_vel
+        pub_cmd.angular.z = ang_vel
+        self.vel_pub.publish(pub_cmd)
+
+
+def main():
+    rclpy.init()
+    pub_node = VelocityPublisher()
+    rclpy.spin(pub_node)
+    pub_node.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyrobosim_ros/launch/demo.launch.py
+++ b/pyrobosim_ros/launch/demo.launch.py
@@ -9,7 +9,7 @@ def generate_launch_description():
     # Arguments
     world_file_arg = DeclareLaunchArgument(
         "world_file",
-        default_value=TextSubstitution(text=""),
+        default_value="",
         description="YAML file name (should be in the pyrobosim/data folder). "
         + "If not specified, a world will be created programmatically.",
     )

--- a/pyrobosim_ros/package.xml
+++ b/pyrobosim_ros/package.xml
@@ -10,10 +10,9 @@
   <!-- Build dependencies -->
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
-  <build_depend>rclcpp</build_depend>
-  <build_depend>pyrobosim_msgs</build_depend>
 
   <!-- Execution dependencies -->
+  <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>ros2launch</exec_depend>

--- a/pyrobosim_ros/pyrobosim_ros/ros_conversions.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_conversions.py
@@ -207,3 +207,15 @@ def task_plan_to_ros(plan):
         raise Exception("Input is not a TaskPlan object")
     act_msgs = [task_action_to_ros(act) for act in plan.actions]
     return ros_msgs.TaskPlan(robot=plan.robot, actions=act_msgs, cost=plan.total_cost)
+
+
+def ros_duration_to_float(ros_duration):
+    """
+    Converts an rclpy Duration object to a floating-point time value, in seconds.
+
+    :param ros_time: rclpy Duration object.
+    :type ros_time: :class:`rclpy.duration.Duration`
+    :return: The duration time, in seconds.
+    :type: float
+    """
+    return 1.0e-9 * ros_duration.nanoseconds

--- a/pyrobosim_ros/pyrobosim_ros/ros_interface.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_interface.py
@@ -38,7 +38,7 @@ class WorldROSWrapper(Node):
         dynamics_dt=0.01,
         dynamics_latch_time=0.5,
         dynamics_ramp_down_time=0.5,
-        dynamics_enable_collisionros=True,
+        dynamics_enable_collisions=True,
     ):
         """
         Creates a ROS 2 world wrapper node.
@@ -117,7 +117,7 @@ class WorldROSWrapper(Node):
         self.dynamics_latch_and_ramp_down_time = (
             self.dynamics_latch_time + self.dynamics_ramp_down_time
         )
-        self.dynamics_enable_collisions = dynamics_enable_collisionros
+        self.dynamics_enable_collisions = dynamics_enable_collisions
 
         self.get_logger().info("World node started.")
 

--- a/pyrobosim_ros/pyrobosim_ros/ros_interface.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_interface.py
@@ -49,7 +49,7 @@ class WorldROSWrapper(Node):
             * Subscribe to task plans on the ``commanded_plan`` topic.
             * Subscribe to robot velocity commands on the ``robot_name/cmd_vel`` topic.
             * Publish robot states on the ``robot_name/robot_state`` topic.
-            * Serve a ``request_world_state` service to retrieve the world state for planning.
+            * Serve a ``request_world_state`` service to retrieve the world state for planning.
 
         :param world: World model instance.
         :type world: :class:`pyrobosim.core.world.World`

--- a/pyrobosim_ros/test/test_ros_conversions.py
+++ b/pyrobosim_ros/test/test_ros_conversions.py
@@ -1,6 +1,7 @@
 # Tests for pyrobosim ROS conversions functionality
 
 import pytest
+from rclpy import Duration
 
 import pyrobosim.planning.actions as acts
 from pyrobosim.utils.motion import Path
@@ -10,6 +11,7 @@ from pyrobosim_ros.ros_conversions import (
     path_to_ros,
     pose_from_ros,
     pose_to_ros,
+    ros_duration_to_float,
     task_action_from_ros,
     task_action_to_ros,
     task_plan_from_ros,
@@ -161,3 +163,10 @@ def test_task_plan_conversion():
     for orig_action, new_action in zip(orig_plan.actions, new_plan.actions):
         assert orig_action.type == new_action.type
     assert new_plan.total_cost == pytest.approx(orig_plan.total_cost)
+
+
+def test_ros_duration_to_float():
+    """Tests conversion of rclpy Duration objects to floating-point time."""
+    ros_duration = Duration(seconds=1.0, nanoseconds=500000000)
+    float_duration = ros_duration_to_float(ros_duration)
+    assert float_duration == pytest.approx(1.5)


### PR DESCRIPTION
This PR follows from #151 and adds the ROS wrapper around robot dynamics.

Now, each spawned robot will additionally have a `<robot_name>/cmd_vel` subscriber where you can send it `geometry_msgs/Twist` commands like with most mobile bases in ROS.

Because of ROS Publishing timing, we also need a command latching and ramp-down time to be defined.

Closes #148