### PR TITLE
Add PR write permissions to tests CI job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,8 @@ jobs:
   # Pure Python testing
   python-test:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v3


### PR DESCRIPTION
This seems to be needed to allow PRs to generate the coverage message?