### PR TITLE
Containerize the non-ros testing pipeline

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
-      - name: Login to DockerHub Registry
+      - name: Login to Docker Hub Registry
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -79,7 +79,7 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
-      - name: Login to DockerHub Registry
+      - name: Login to Docker Hub Registry
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
   # Run python tests
   python-test:
     runs-on: ubuntu-latest
-    container: ${{ secrets.DOCKERHUB_USERNAME }}/pyrobosim:base
+    container: iridiumxi/pyrobosim:base
     steps:
       - name: Run unit tests
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
   # Run python tests
   python-test:
     runs-on: ubuntu-latest
-    container: "${{ secrets.DOCKERHUB_USERNAME }}/pyrobosim:base"
+    container: iridiumxi/pyrobosim:base
     steps:
       - name: Run unit tests
         working-directory: /opt/pyrobosim

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   # Build the base, non-ros image
-  build-pyrobosim:
+  python-test:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -44,25 +44,19 @@ jobs:
             type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/pyrobosim:buildcache-base
           cache-to: |
             type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/pyrobosim:buildcache-base,mode=max
-
-  # Run python tests
-  python-test:
-    runs-on: ubuntu-latest
-    needs: build-pyrobosim
-    # TODO: Can we not use secrets here?!?
-    container: iridiumxi/pyrobosim:base
-    steps:
-      - name: Run unit tests
-        working-directory: /opt/pyrobosim
+      - name: Run tests
         run: |
-          export PYTHONPATH=./dependencies/pddlstream:$PYTHONPATH
-          test/run_tests.bash
+          docker run \
+            -w /opt/pyrobosim \
+            --volume ./test/results:/opt/pyrobosim/test/results:rw \
+            ${{ secrets.DOCKERHUB_USERNAME }}/pyrobosim:base \
+            /bin/bash -c 'PYTHONPATH=./dependencies/pddlstream:$PYTHONPATH ./test/run_tests.bash'
       - name: Pytest coverage comment
         uses: MishaKav/pytest-coverage-comment@main
         with:
-          pytest-coverage-path: /opt/pyrobosim/test/results/pytest-coverage.txt
-          junitxml-path: /opt/pyrobosim/test/results/test_results.xml
-          pytest-xml-coverage-path: /opt/pyrobosim/test/results/test_results_coverage.xml
+          pytest-coverage-path: ./test/results/pytest-coverage.txt
+          junitxml-path: ./test/results/test_results.xml
+          pytest-xml-coverage-path: ./test/results/test_results_coverage.xml
           coverage-path-prefix: pyrobosim/pyrobosim/
         # This will break on PRs from forks
         if: ${{ !github.event.pull_request.head.repo.fork }}
@@ -70,7 +64,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: /opt/pyrobosim/test/results/
+          path: test/results/
         # Always publish test results even when there are failures.
         if: ${{ always() }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,34 +46,30 @@ jobs:
             type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/pyrobosim:buildcache-base,mode=max
 
   # Run python tests
-  # python-test:
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: ${{ secrets.DOCKERHUB_USERNAME }}/pyrobosim:base
-  #   steps:
-  #     - name: Run unit tests
-  #       run: |
-  #         export PYTHONPATH=./dependencies/pddlstream:$PYTHONPATH
-  #         test/run_tests.bash
-  #       working-directory: /opt/pyrobosim
-  #     - name: Pytest coverage comment
-  #       uses: MishaKav/pytest-coverage-comment@main
-  #       working-directory: /opt/pyrobosim
-  #       with:
-  #         pytest-coverage-path: ./test/results/pytest-coverage.txt
-  #         junitxml-path: ./test/results/test_results.xml
-  #         pytest-xml-coverage-path: ./test/results/test_results_coverage.xml
-  #         coverage-path-prefix: pyrobosim/pyrobosim/
-  #       # This will break on PRs from forks
-  #       if: ${{ !github.event.pull_request.head.repo.fork }}
-  #     - name: Upload test results
-  #       uses: actions/upload-artifact@v3
-  #       working-directory: /opt/pyrobosim
-  #       with:
-  #         name: test-results
-  #         path: test/results/
-  #       # Always publish test results even when there are failures.
-  #       if: ${{ always() }}
+  python-test:
+    runs-on: ubuntu-latest
+    container: ${{ secrets.DOCKERHUB_USERNAME }}/pyrobosim:base
+    steps:
+      - name: Run unit tests
+        run: |
+          export PYTHONPATH=./dependencies/pddlstream:$PYTHONPATH
+          test/run_tests.bash
+      - name: Pytest coverage comment
+        uses: MishaKav/pytest-coverage-comment@main
+        with:
+          pytest-coverage-path: ./test/results/pytest-coverage.txt
+          junitxml-path: ./test/results/test_results.xml
+          pytest-xml-coverage-path: ./test/results/test_results_coverage.xml
+          coverage-path-prefix: pyrobosim/pyrobosim/
+        # This will break on PRs from forks
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+      - name: Upload test results
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: test/results/
+        # Always publish test results even when there are failures.
+        if: ${{ always() }}
 
   # Build and test with ROS 2
   ros2-test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,30 +15,50 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Pure Python testing
-  python-test:
+  # Build the base, non-ros image
+  build-pyrobosim:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v3
+      - name: Login to DockerHub Registry
+        uses: docker/login-action@v3
         with:
-          python-version: '3.10'
-      - name: Install dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          pip3 install -e pyrobosim
-          pip3 install -r test/python_test_requirements.txt
-          setup/setup_pddlstream.bash
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PAT }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          file: docker/Dockerfile
+          target: pyrobosim
+          context: .
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/pyrobosim:base
+          push: true
+          cache-from: |
+            type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/pyrobosim:buildcache-base
+          cache-to: |
+            type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/pyrobosim:buildcache-base,mode=max
+
+  # Run python tests
+  python-test:
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ secrets.DOCKERHUB_USERNAME }}/pyrobosim:base
+    steps:
       - name: Run unit tests
         run: |
           export PYTHONPATH=./dependencies/pddlstream:$PYTHONPATH
           test/run_tests.bash
+        working-directory: /opt/pyrobosim
       - name: Pytest coverage comment
         uses: MishaKav/pytest-coverage-comment@main
+        working-directory: /opt/pyrobosim
         with:
           pytest-coverage-path: ./test/results/pytest-coverage.txt
           junitxml-path: ./test/results/test_results.xml
@@ -48,6 +68,7 @@ jobs:
         if: ${{ !github.event.pull_request.head.repo.fork }}
       - name: Upload test results
         uses: actions/upload-artifact@v3
+        working-directory: /opt/pyrobosim
         with:
           name: test-results
           path: test/results/
@@ -78,6 +99,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           file: docker/Dockerfile
+          target: pyrobosim_ros
           context: .
           build-args: |
             ROS_DISTRO=${{ matrix.ros_distro }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,9 +48,7 @@ jobs:
   # Run python tests
   python-test:
     runs-on: ubuntu-latest
-    # TODO: Uncomment when this is green...
-    # needs:
-    #   - build-pyrobosim
+    needs: build-pyrobosim
     container: iridiumxi/pyrobosim:base
     steps:
       - name: Run unit tests
@@ -60,7 +58,6 @@ jobs:
           test/run_tests.bash
       - name: Pytest coverage comment
         uses: MishaKav/pytest-coverage-comment@main
-        working-directory: /opt/pyrobosim
         with:
           pytest-coverage-path: ./test/results/pytest-coverage.txt
           junitxml-path: ./test/results/test_results.xml
@@ -70,7 +67,6 @@ jobs:
         if: ${{ !github.event.pull_request.head.repo.fork }}
       - name: Upload test results
         uses: actions/upload-artifact@v3
-        working-directory: /opt/pyrobosim
         with:
           name: test-results
           path: test/results/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,9 +48,10 @@ jobs:
   # Run python tests
   python-test:
     runs-on: ubuntu-latest
-    container: iridiumxi/pyrobosim:base
+    container: "${{ secrets.DOCKERHUB_USERNAME }}/pyrobosim:base"
     steps:
       - name: Run unit tests
+        working-directory: /opt/pyrobosim
         run: |
           export PYTHONPATH=./dependencies/pddlstream:$PYTHONPATH
           test/run_tests.bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Build the base, non-ros image
+  # Build and test the base, non-ros image
   python-test:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,9 @@ jobs:
   # Run python tests
   python-test:
     runs-on: ubuntu-latest
+    # TODO: Uncomment when this is green...
+    # needs:
+    #   - build-pyrobosim
     container: iridiumxi/pyrobosim:base
     steps:
       - name: Run unit tests
@@ -57,6 +60,7 @@ jobs:
           test/run_tests.bash
       - name: Pytest coverage comment
         uses: MishaKav/pytest-coverage-comment@main
+        working-directory: /opt/pyrobosim
         with:
           pytest-coverage-path: ./test/results/pytest-coverage.txt
           junitxml-path: ./test/results/test_results.xml
@@ -66,6 +70,7 @@ jobs:
         if: ${{ !github.event.pull_request.head.repo.fork }}
       - name: Upload test results
         uses: actions/upload-artifact@v3
+        working-directory: /opt/pyrobosim
         with:
           name: test-results
           path: test/results/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Build and test the base, non-ros image
+  # Build and test the base, non-ROS image
   python-test:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,34 +46,34 @@ jobs:
             type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/pyrobosim:buildcache-base,mode=max
 
   # Run python tests
-  python-test:
-    runs-on: ubuntu-latest
-    container:
-      image: ${{ secrets.DOCKERHUB_USERNAME }}/pyrobosim:base
-    steps:
-      - name: Run unit tests
-        run: |
-          export PYTHONPATH=./dependencies/pddlstream:$PYTHONPATH
-          test/run_tests.bash
-        working-directory: /opt/pyrobosim
-      - name: Pytest coverage comment
-        uses: MishaKav/pytest-coverage-comment@main
-        working-directory: /opt/pyrobosim
-        with:
-          pytest-coverage-path: ./test/results/pytest-coverage.txt
-          junitxml-path: ./test/results/test_results.xml
-          pytest-xml-coverage-path: ./test/results/test_results_coverage.xml
-          coverage-path-prefix: pyrobosim/pyrobosim/
-        # This will break on PRs from forks
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-      - name: Upload test results
-        uses: actions/upload-artifact@v3
-        working-directory: /opt/pyrobosim
-        with:
-          name: test-results
-          path: test/results/
-        # Always publish test results even when there are failures.
-        if: ${{ always() }}
+  # python-test:
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: ${{ secrets.DOCKERHUB_USERNAME }}/pyrobosim:base
+  #   steps:
+  #     - name: Run unit tests
+  #       run: |
+  #         export PYTHONPATH=./dependencies/pddlstream:$PYTHONPATH
+  #         test/run_tests.bash
+  #       working-directory: /opt/pyrobosim
+  #     - name: Pytest coverage comment
+  #       uses: MishaKav/pytest-coverage-comment@main
+  #       working-directory: /opt/pyrobosim
+  #       with:
+  #         pytest-coverage-path: ./test/results/pytest-coverage.txt
+  #         junitxml-path: ./test/results/test_results.xml
+  #         pytest-xml-coverage-path: ./test/results/test_results_coverage.xml
+  #         coverage-path-prefix: pyrobosim/pyrobosim/
+  #       # This will break on PRs from forks
+  #       if: ${{ !github.event.pull_request.head.repo.fork }}
+  #     - name: Upload test results
+  #       uses: actions/upload-artifact@v3
+  #       working-directory: /opt/pyrobosim
+  #       with:
+  #         name: test-results
+  #         path: test/results/
+  #       # Always publish test results even when there are failures.
+  #       if: ${{ always() }}
 
   # Build and test with ROS 2
   ros2-test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,7 @@ jobs:
   python-test:
     runs-on: ubuntu-latest
     needs: build-pyrobosim
+    # TODO: Can we not use secrets here?!?
     container: iridiumxi/pyrobosim:base
     steps:
       - name: Run unit tests
@@ -59,9 +60,9 @@ jobs:
       - name: Pytest coverage comment
         uses: MishaKav/pytest-coverage-comment@main
         with:
-          pytest-coverage-path: ./test/results/pytest-coverage.txt
-          junitxml-path: ./test/results/test_results.xml
-          pytest-xml-coverage-path: ./test/results/test_results_coverage.xml
+          pytest-coverage-path: /opt/pyrobosim/test/results/pytest-coverage.txt
+          junitxml-path: /opt/pyrobosim/test/results/test_results.xml
+          pytest-xml-coverage-path: /opt/pyrobosim/test/results/test_results_coverage.xml
           coverage-path-prefix: pyrobosim/pyrobosim/
         # This will break on PRs from forks
         if: ${{ !github.event.pull_request.head.repo.fork }}
@@ -69,7 +70,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: test/results/
+          path: /opt/pyrobosim/test/results/
         # Always publish test results even when there are failures.
         if: ${{ always() }}
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,10 +13,11 @@
 
 services:
   base:
-    image: pyrobosim:${ROS_DISTRO:-humble}
+    image: pyrobosim_ros:${ROS_DISTRO:-humble}
     build:
       context: .
       dockerfile: docker/Dockerfile
+      target: pyrobosim_ros
       args:
         ROS_DISTRO: ${ROS_DISTRO:-humble}
     # Ensures signals are actually passed and reaped in the container for shutdowns.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,7 @@ WORKDIR /opt/pyrobosim/
 COPY test/python_test_requirements.txt test/
 RUN pip3 install -r test/python_test_requirements.txt
 
-# Install PDDL
+# Install PDDLStream
 COPY setup/setup_pddlstream.bash setup/
 RUN setup/setup_pddlstream.bash
 
@@ -38,7 +38,7 @@ RUN setup/setup_pddlstream.bash
 COPY . /opt/pyrobosim/
 RUN pip3 install -e pyrobosim
 
-# Start it up
+# Set the default startup command
 CMD /bin/bash
 
 ##################################
@@ -84,7 +84,7 @@ ENV NO_AT_BRIDGE 1
 
 # Setup an entrypoint and working folder
 COPY setup /pyrobosim_ws/src/setup
-CMD ["/usr/bin/bash"]
+CMD /bin/bash
 COPY docker/entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 RUN echo "source /entrypoint.sh" >> ~/.bashrc

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,49 @@
+# Dockerfile for pyrobosim builds with and without ROS
 ARG ROS_DISTRO=humble
 
-# pyrobosim Dockerfile for Ubuntu / ROS
-FROM osrf/ros:${ROS_DISTRO}-desktop
+##################################
+#
+# base pyrobosim build for Ubuntu
+#
+##################################
+from ubuntu:latest as pyrobosim
+
+# Install dependencies
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install -y \
+    apt-utils \
+    python3 \
+    python3-pip \
+    python3-tk \
+    git \
+    cmake
+
+RUN mkdir -p /opt/pyrobosim/test
+RUN mkdir -p /opt/pyrobosim/setup
+WORKDIR /opt/pyrobosim/
+
+# Install baseline pip dependencies
+COPY test/python_test_requirements.txt test/
+RUN pip3 install -r test/python_test_requirements.txt
+
+# Install PDDL
+COPY setup/setup_pddlstream.bash setup/
+RUN setup/setup_pddlstream.bash
+
+# Copy the rest of the source directory
+COPY . /opt/pyrobosim/
+RUN pip3 install -e pyrobosim
+
+# Start it up
+CMD /bin/bash
+
+##################################
+#
+# pyrobosim build for Ubuntu / ROS
+#
+##################################
+FROM osrf/ros:${ROS_DISTRO}-desktop as pyrobosim_ros
 ENV ROS_DISTRO=${ROS_DISTRO}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,14 +10,17 @@ from ubuntu:latest as pyrobosim
 
 # Install dependencies
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y \
-    apt-utils \
-    python3 \
-    python3-pip \
-    python3-tk \
-    git \
-    cmake
+RUN apt-get update \
+    apt-get install -y \
+        apt-utils \
+        python3 \
+        python3-pip \
+        python3-tk \
+        git \
+        cmake \
+        ffmpeg \
+        libsm6 \
+        libxext6
 
 RUN mkdir -p /opt/pyrobosim/test
 RUN mkdir -p /opt/pyrobosim/setup

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ from ubuntu:latest as pyrobosim
 
 # Install dependencies
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update \
+RUN apt-get update &&\
     apt-get install -y \
         apt-utils \
         python3 \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ ARG ROS_DISTRO=humble
 # base pyrobosim build for Ubuntu
 #
 ##################################
-from ubuntu:latest as pyrobosim
+FROM ubuntu:latest as pyrobosim
 
 # Install dependencies
 ARG DEBIAN_FRONTEND=noninteractive

--- a/test/run_tests.bash
+++ b/test/run_tests.bash
@@ -21,7 +21,7 @@ set -o pipefail
 # Run regular pytest tests
 echo "Running Python package unit tests..."
 python3 -m pytest "$SCRIPT_DIR" \
- --cov="$SCRIPT_DIR/../pyrobosim/pyrobosim" --cov-branch \
+ --cov="$SCRIPT_DIR/../pyrobosim/pyrobosim/utils" --cov-branch \
  --cov-report term \
  --cov-report html:"$TEST_RESULTS_DIR/test_results_coverage_html" \
  --cov-report xml:"$TEST_RESULTS_DIR/test_results_coverage.xml" \

--- a/test/run_tests.bash
+++ b/test/run_tests.bash
@@ -21,7 +21,7 @@ set -o pipefail
 # Run regular pytest tests
 echo "Running Python package unit tests..."
 python3 -m pytest "$SCRIPT_DIR" \
- --cov="$SCRIPT_DIR/../pyrobosim/pyrobosim/utils" --cov-branch \
+ --cov="$SCRIPT_DIR/../pyrobosim/pyrobosim" --cov-branch \
  --cov-report term \
  --cov-report html:"$TEST_RESULTS_DIR/test_results_coverage_html" \
  --cov-report xml:"$TEST_RESULTS_DIR/test_results_coverage.xml" \


### PR DESCRIPTION
Will allow us to take advantage of docker's cache for pddl builds in the base python tests, finishing off the @ibrahiminfinite's request from https://github.com/sea-bass/pyrobosim/issues/85.

I added another stage to the Dockerfile for a very, very basic non-ros build. This should keep the docker build cache until you blow up the dependencies (note this can happen when apt or pip packages get updated... so it's not bulletproof). The tests are now run in the built container.

Renamed the ROS images accordingly.

Build times for a cached build:
![image](https://github.com/sea-bass/pyrobosim/assets/7966037/280aa992-deac-4631-8c29-f4ddce949e7d)


I fully recognize that I have a problem...