### PR TITLE
Pin pytest below 8.1.0 and fix warnings when creating entities with invalid categories

### DIFF
--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -313,7 +313,7 @@ class World:
             try:
                 loc = Location(**location_config)
             except InvalidEntityCategoryException as exception:
-                warnings.warn(exception)
+                warnings.warn(str(exception))
                 return None
         else:
             warnings.warn("Location instance or parent must be specified.")
@@ -484,7 +484,7 @@ class World:
             try:
                 obj = Object(**object_config)
             except InvalidEntityCategoryException as exception:
-                warnings.warn(exception)
+                warnings.warn(str(exception))
                 return None
         else:
             warnings.warn("Object instance or parent must be specified.")

--- a/test/python_test_requirements.txt
+++ b/test/python_test_requirements.txt
@@ -1,6 +1,6 @@
 lark
 py!=1.10.0
-pytest
+pytest<8.1.0
 pytest-cov
 pytest-dependency
 pytest-html


### PR DESCRIPTION
Somehow the recent release of pytest 8.1.1 changed things so that passing an exception to `warnings.warn()` yielded an error. Converting the exception to a string before passing it in seems to solve the issue.

In addition to that, seems like there are issues with ROS tests as shown here: https://github.com/ros2/launch/issues/765. Since the PR to fix it only went into rolling and it's being debated whether it will be backported, may as well just pin the pytest version for now