### PR TITLE
Do not require PDDLStream for tests, switch to main repo

### DIFF
--- a/pyrobosim/examples/demo_pddl.py
+++ b/pyrobosim/examples/demo_pddl.py
@@ -10,8 +10,7 @@ import threading
 
 from pyrobosim.core import WorldYamlLoader
 from pyrobosim.gui import start_gui
-from pyrobosim.planning import PDDLStreamPlanner
-from pyrobosim.planning.pddlstream.utils import get_default_domains_folder
+from pyrobosim.planning.pddlstream import PDDLStreamPlanner, get_default_domains_folder
 from pyrobosim.utils.general import get_data_folder
 
 

--- a/pyrobosim/pyrobosim/planning/__init__.py
+++ b/pyrobosim/pyrobosim/planning/__init__.py
@@ -5,9 +5,3 @@ This module contains tools associated with task and motion planning
 a plan, as well as infrastructure to come up with such a plan given the
 current and desired state of the world.
 """
-
-import importlib
-
-# Only import PDDLStream planner if the module is available.
-if importlib.util.find_spec("pddlstream") is not None:
-    from .pddlstream.planner import *

--- a/pyrobosim/pyrobosim/planning/pddlstream/__init__.py
+++ b/pyrobosim/pyrobosim/planning/pddlstream/__init__.py
@@ -6,3 +6,13 @@ algorithms, as well as mechanisms to integrate PDDL domains and PDDLStream
 stream definition files, along with their mappings to Python functions with
 the actual implementations.
 """
+
+import importlib
+
+if importlib.util.find_spec("pddlstream") is None:
+    raise ModuleNotFoundError("PDDLStream is not available. Cannot import planner.")
+
+from .default_mappings import *
+from .planner import *
+from .primitives import *
+from .utils import *

--- a/pyrobosim_ros/examples/demo_pddl_planner.py
+++ b/pyrobosim_ros/examples/demo_pddl_planner.py
@@ -10,8 +10,7 @@ import rclpy
 from rclpy.node import Node
 
 from pyrobosim.core import WorldYamlLoader
-from pyrobosim.planning import PDDLStreamPlanner
-from pyrobosim.planning.pddlstream.utils import get_default_domains_folder
+from pyrobosim.planning.pddlstream import PDDLStreamPlanner, get_default_domains_folder
 from pyrobosim.utils.general import get_data_folder
 
 from pyrobosim_ros.ros_interface import update_world_from_state_msg

--- a/setup/setup_pddlstream.bash
+++ b/setup/setup_pddlstream.bash
@@ -11,9 +11,8 @@ then
 fi
 
 # Clone and build PDDLStream
-# TODO: Once PDDLStream works with Python 3.10, go back to the original repo.
 pushd $SCRIPT_DIR/../dependencies
-git clone https://github.com/sea-bass/pddlstream.git
+git clone https://github.com/caelan/pddlstream.git
 pushd pddlstream
 touch COLCON_IGNORE
 git submodule update --init --recursive

--- a/test/planning/test_pddlstream_manip.py
+++ b/test/planning/test_pddlstream_manip.py
@@ -3,10 +3,15 @@
 """
 Tests for PDDLStream planning with manipulation streams.
 """
+
+import importlib
 import numpy as np
 import os
 import pytest
 import threading
+
+if importlib.util.find_spec("pddlstream") is None:
+    pytest.skip(allow_module_level=True, reason="PDDLStream not available")
 
 from pyrobosim.core import Robot, World
 from pyrobosim.gui import start_gui

--- a/test/planning/test_pddlstream_manip.py
+++ b/test/planning/test_pddlstream_manip.py
@@ -3,7 +3,6 @@
 """
 Tests for PDDLStream planning with manipulation streams.
 """
-
 import importlib
 import numpy as np
 import os
@@ -17,8 +16,7 @@ from pyrobosim.core import Robot, World
 from pyrobosim.gui import start_gui
 from pyrobosim.manipulation import GraspGenerator, ParallelGraspProperties
 from pyrobosim.navigation import ConstantVelocityExecutor, PathPlanner
-from pyrobosim.planning import PDDLStreamPlanner
-from pyrobosim.planning.pddlstream.utils import get_default_domains_folder
+from pyrobosim.planning.pddlstream import PDDLStreamPlanner, get_default_domains_folder
 from pyrobosim.utils.general import get_data_folder
 from pyrobosim.utils.pose import Pose
 

--- a/test/planning/test_pddlstream_nav.py
+++ b/test/planning/test_pddlstream_nav.py
@@ -14,7 +14,7 @@ if importlib.util.find_spec("pddlstream") is None:
 from pyrobosim.core import Robot, World
 from pyrobosim.gui import start_gui
 from pyrobosim.navigation import ConstantVelocityExecutor, PathPlanner
-from pyrobosim.planning import PDDLStreamPlanner
+from pyrobosim.planning.pddlstream.planner import PDDLStreamPlanner
 from pyrobosim.planning.pddlstream.utils import get_default_domains_folder
 from pyrobosim.utils.general import get_data_folder
 from pyrobosim.utils.pose import Pose

--- a/test/planning/test_pddlstream_nav.py
+++ b/test/planning/test_pddlstream_nav.py
@@ -3,8 +3,13 @@
 """
 Tests for PDDLStream planning with navigation streams.
 """
+import importlib
 import os
+import pytest
 import threading
+
+if importlib.util.find_spec("pddlstream") is None:
+    pytest.skip(allow_module_level=True, reason="PDDLStream not available")
 
 from pyrobosim.core import Robot, World
 from pyrobosim.gui import start_gui

--- a/test/test_dependencies.py
+++ b/test/test_dependencies.py
@@ -1,9 +1,0 @@
-"""
-Basic checks for external dependencies.
-"""
-
-
-def test_import_pddlstream():
-    import pddlstream
-
-    assert "__init__.py" in pddlstream.__file__

--- a/test/test_pyrobosim.py
+++ b/test/test_pyrobosim.py
@@ -2,14 +2,12 @@
 Basic sanity checks for pyrobosim module.
 """
 
-import sys
+import importlib
 from importlib.metadata import version
 
 
 def test_import():
-    import pyrobosim
-
-    assert "pyrobosim" in sys.modules
+    assert importlib.util.find_spec("pyrobosim")
 
 
 def test_version():


### PR DESCRIPTION
This PR makes PDDLStream optional for tests, and also updates to the main PDDLStream repo.

It also shuffles around some of the import code so that users get a more readable error message when they try to import the PDDLStream planner and don't have the module available.