### PR TITLE
Support ROS 2 Jazzy / Ubuntu 24.04

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,11 @@
-# Folders that don't need to be in the Docker build context.
+# Files and folders that don't need to be in the Docker build context.
 dependencies/
+docker/Dockerfile
 docs/
+test/results/
 
-# Metadata that definitely doesn't need to be in the Docker build context.
+# Metadata that doesn't need to be in the Docker build context.
+*/__pycache__
 .dockerignore
 .git/
 .github/

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,8 @@ docs/
 test/results/
 
 # Metadata that doesn't need to be in the Docker build context.
-*/__pycache__
+*/__pycache__/
+*.egg-info
 .dockerignore
 .git/
 .github/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,7 @@ jobs:
   ros2-test:
     strategy:
       matrix:
-        ros_distro: [humble, iron, rolling]
+        ros_distro: [humble, iron, jazzy, rolling]
 
     name: ros-${{ matrix.ros_distro }}-test
     runs-on: ubuntu-latest

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,7 +39,7 @@ services:
       - ./pyrobosim/:/pyrobosim_ws/src/pyrobosim/:rw
       - ./pyrobosim_msgs/:/pyrobosim_ws/src/pyrobosim_msgs/:rw
       - ./pyrobosim_ros/:/pyrobosim_ws/src/pyrobosim_ros/:rw
-      - ./test/:/pyrobosim_ws/test/:rw
+      - ./test/:/pyrobosim_ws/src/test/:rw
       - ./pytest.ini:/pyrobosim_ws/pytest.ini:rw
       # Allows graphical programs in the container.
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
@@ -48,7 +48,7 @@ services:
 
   test:
     extends: base
-    command: test/run_tests.bash ${ROS_DISTRO:-humble}
+    command: src/test/run_tests.bash ${ROS_DISTRO:-humble}
 
   ###############
   # Basic demos #

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,6 @@
 # Dockerfile for pyrobosim builds with and without ROS
 ARG ROS_DISTRO=humble
+ARG VIRTUAL_ENV=/python-virtualenvs/pyrobosim
 
 ##################################
 #
@@ -31,12 +32,15 @@ COPY setup/setup_pddlstream.bash setup/
 RUN setup/setup_pddlstream.bash
 
 # Install pip dependencies for testing
+ARG VIRTUAL_ENV
+RUN python3 -m venv ${VIRTUAL_ENV}
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 COPY test/python_test_requirements.txt test/
-RUN pip3 install --break-system-packages -r test/python_test_requirements.txt
+RUN pip3 install -r test/python_test_requirements.txt
 
 # Copy the rest of the source directory and install pyrobosim
 COPY . /opt/pyrobosim/
-RUN pip3 install --break-system-packages -e pyrobosim
+RUN pip3 install -e pyrobosim
 
 # Set the default startup command
 CMD /bin/bash
@@ -66,16 +70,23 @@ COPY setup/setup_pddlstream.bash /pyrobosim_ws/src/setup/
 WORKDIR /pyrobosim_ws/src/setup
 RUN ./setup_pddlstream.bash
 
-# Install pyrobosim and testing dependencies
-WORKDIR /pyrobosim_ws/src
 COPY . /pyrobosim_ws/src/
-RUN pip3 install --break-system-packages -e ./pyrobosim
-RUN pip3 install --break-system-packages -r test/python_test_requirements.txt
 
-# Build the workspace
+# Build the ROS workspace
+# TODO: Figure out why this has to be done first or otherwise there is an 'em' import error
 WORKDIR /pyrobosim_ws
 RUN . /opt/ros/${ROS_DISTRO}/setup.bash && \
     colcon build
+
+# Install pyrobosim and testing dependencies
+ARG VIRTUAL_ENV
+ENV VIRTUAL_ENV=${VIRTUAL_ENV}
+WORKDIR /pyrobosim_ws/src
+RUN python3 -m venv ${VIRTUAL_ENV}
+RUN . ${VIRTUAL_ENV}/bin/activate && \
+    pip3 install --upgrade pip && \
+    pip3 install -e ./pyrobosim && \
+    pip3 install -r test/python_test_requirements.txt
 
 # Remove display warnings
 RUN mkdir /tmp/runtime-root
@@ -84,6 +95,7 @@ RUN chmod -R 0700 /tmp/runtime-root
 ENV NO_AT_BRIDGE 1
 
 # Setup an entrypoint and working folder
+WORKDIR /pyrobosim_ws
 COPY setup /pyrobosim_ws/src/setup
 CMD /bin/bash
 COPY docker/entrypoint.sh /entrypoint.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,7 +69,6 @@ RUN ./setup_pddlstream.bash
 # Install pyrobosim and testing dependencies
 WORKDIR /pyrobosim_ws/src
 COPY . /pyrobosim_ws/src/
-RUN pip3 install --break-system-packages --upgrade pip
 RUN pip3 install --break-system-packages -e ./pyrobosim
 RUN pip3 install --break-system-packages -r test/python_test_requirements.txt
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,7 +59,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y \
-    apt-utils python3-full python3-pip python3-tk \
+    apt-utils python3-full python3-pip python3-tk ros-dev-tools \
     libgl1-mesa-dev libglu1-mesa-dev '^libxcb.*-dev' libx11-xcb-dev \
     libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libxrender-dev
 
@@ -74,7 +74,7 @@ RUN ./setup_pddlstream.bash
 COPY . /pyrobosim_ws/src/
 
 # Build the ROS workspace
-# TODO: Figure out why this has to be done first or otherwise there is an 'em' import error
+# TODO: Figure out why there is an import error with 'em' if this is done after the virtual env is created.
 WORKDIR /pyrobosim_ws
 RUN . /opt/ros/${ROS_DISTRO}/setup.bash && \
     colcon build
@@ -82,8 +82,8 @@ RUN . /opt/ros/${ROS_DISTRO}/setup.bash && \
 # Install pyrobosim and testing dependencies
 ARG VIRTUAL_ENV
 ENV VIRTUAL_ENV=${VIRTUAL_ENV}
-WORKDIR /pyrobosim_ws/src
 RUN python3 -m venv ${VIRTUAL_ENV}
+WORKDIR /pyrobosim_ws/src
 RUN . ${VIRTUAL_ENV}/bin/activate && \
     pip3 install --upgrade pip && \
     pip3 install -e ./pyrobosim && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update &&\
         python3 \
         python3-pip \
         python3-tk \
+        python3-venv \
         git \
         cmake \
         ffmpeg \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,7 +54,9 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y \
-    apt-utils python3-pip python3-tk
+    apt-utils python3-full python3-pip python3-tk \
+    libgl1-mesa-dev libglu1-mesa-dev '^libxcb.*-dev' libx11-xcb-dev \
+    libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libxrender-dev
 
 # Create a colcon workspace
 RUN mkdir -p /pyrobosim_ws/src/pyrobosim
@@ -67,9 +69,9 @@ RUN ./setup_pddlstream.bash
 # Install pyrobosim and testing dependencies
 WORKDIR /pyrobosim_ws/src
 COPY . /pyrobosim_ws/src/
-RUN python3 -m pip install --upgrade pip
-RUN pip3 install ./pyrobosim
-RUN pip3 install -r test/python_test_requirements.txt
+RUN pip3 install --break-system-packages --upgrade pip
+RUN pip3 install --break-system-packages -e ./pyrobosim
+RUN pip3 install --break-system-packages -r test/python_test_requirements.txt
 
 # Build the workspace
 WORKDIR /pyrobosim_ws

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,5 @@
 # Dockerfile for pyrobosim builds with and without ROS
 ARG ROS_DISTRO=humble
-ARG VIRTUAL_ENV=/python-virtualenvs/pyrobosim
 
 ##################################
 #
@@ -17,7 +16,6 @@ RUN apt-get update &&\
         python3 \
         python3-pip \
         python3-tk \
-        python3-venv \
         git \
         cmake \
         ffmpeg \
@@ -33,9 +31,7 @@ COPY setup/setup_pddlstream.bash setup/
 RUN setup/setup_pddlstream.bash
 
 # Install pip dependencies for testing
-ARG VIRTUAL_ENV
-RUN python3 -m venv ${VIRTUAL_ENV}
-ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
 COPY test/python_test_requirements.txt test/
 RUN pip3 install -r test/python_test_requirements.txt
 
@@ -59,7 +55,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y \
-    apt-utils python3-full python3-pip python3-tk ros-dev-tools \
+    apt-utils python3-pip python3-tk \
     libgl1-mesa-dev libglu1-mesa-dev '^libxcb.*-dev' libx11-xcb-dev \
     libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libxrender-dev
 
@@ -73,21 +69,17 @@ RUN ./setup_pddlstream.bash
 
 COPY . /pyrobosim_ws/src/
 
+# Install pyrobosim and testing dependencies
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+WORKDIR /pyrobosim_ws/src
+RUN pip3 install --upgrade pip && \
+    pip3 install -e ./pyrobosim && \
+    pip3 install -r test/python_test_requirements.txt
+
 # Build the ROS workspace
-# TODO: Figure out why there is an import error with 'em' if this is done after the virtual env is created.
 WORKDIR /pyrobosim_ws
 RUN . /opt/ros/${ROS_DISTRO}/setup.bash && \
     colcon build
-
-# Install pyrobosim and testing dependencies
-ARG VIRTUAL_ENV
-ENV VIRTUAL_ENV=${VIRTUAL_ENV}
-RUN python3 -m venv ${VIRTUAL_ENV}
-WORKDIR /pyrobosim_ws/src
-RUN . ${VIRTUAL_ENV}/bin/activate && \
-    pip3 install --upgrade pip && \
-    pip3 install -e ./pyrobosim && \
-    pip3 install -r test/python_test_requirements.txt
 
 # Remove display warnings
 RUN mkdir /tmp/runtime-root
@@ -96,7 +88,6 @@ RUN chmod -R 0700 /tmp/runtime-root
 ENV NO_AT_BRIDGE 1
 
 # Setup an entrypoint and working folder
-WORKDIR /pyrobosim_ws
 COPY setup /pyrobosim_ws/src/setup
 CMD /bin/bash
 COPY docker/entrypoint.sh /entrypoint.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,7 +46,7 @@ CMD /bin/bash
 # pyrobosim build for Ubuntu / ROS
 #
 ##################################
-FROM osrf/ros:${ROS_DISTRO}-desktop as pyrobosim_ros
+FROM ros:${ROS_DISTRO}-ros-base as pyrobosim_ros
 ENV ROS_DISTRO=${ROS_DISTRO}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
-# Source ROS and the Colcon workspace
+# Source ROS and the pyrobosim workspace
 source /opt/ros/${ROS_DISTRO}/setup.bash
 if [ ! -f /pyrobosim_ws/install/setup.bash ]
 then
   colcon build
 fi
 source /pyrobosim_ws/install/setup.bash
+
+# Activate virtual environment
+source ${VIRTUAL_ENV}/bin/activate
 
 # Add dependencies to path
 PDDLSTREAM_PATH=/pyrobosim_ws/src/dependencies/pddlstream

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,9 +8,6 @@ then
 fi
 source /pyrobosim_ws/install/setup.bash
 
-# Activate virtual environment
-source ${VIRTUAL_ENV}/bin/activate
-
 # Add dependencies to path
 PDDLSTREAM_PATH=/pyrobosim_ws/src/dependencies/pddlstream
 if [ -d "$PDDLSTREAM_PATH" ]

--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -3,8 +3,8 @@ Setup
 
 This package is being tested with:
 
-* Python 3.10 in Ubuntu 22.04
-* Optionally with ROS 2 Humble, Iron, Jazzy, or Rolling
+* Python 3.10 / Ubuntu 22.04 (optionally with ROS 2 Humble or Iron)
+* Python 3.12 / Ubuntu 24.04 (optionally with ROS 2 Jazzy or Rolling)
 
 pip install (Limited)
 ---------------------

--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -4,7 +4,7 @@ Setup
 This package is being tested with:
 
 * Python 3.10 in Ubuntu 22.04
-* Optionally with ROS 2 Humble and Iron
+* Optionally with ROS 2 Humble, Iron, Jazzy, or Rolling
 
 pip install (Limited)
 ---------------------

--- a/pyrobosim_msgs/CMakeLists.txt
+++ b/pyrobosim_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.22)
 project(pyrobosim_msgs)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/pyrobosim_ros/CMakeLists.txt
+++ b/pyrobosim_ros/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.22)
 project(pyrobosim_ros)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -13,8 +13,8 @@ find_package(rclpy REQUIRED)
 
 # Install pyrobosim Python package
 ament_python_install_package(
-    pyrobosim
-    PACKAGE_DIR ../pyrobosim/pyrobosim)
+  pyrobosim
+  PACKAGE_DIR ../pyrobosim/pyrobosim)
 install(PROGRAMS
   examples/demo.py
   examples/demo_commands.py

--- a/pyrobosim_ros/CMakeLists.txt
+++ b/pyrobosim_ros/CMakeLists.txt
@@ -31,8 +31,8 @@ install(PROGRAMS
 
 # Install pyrobosim_ros Python package
 ament_python_install_package(
-    pyrobosim_ros
-    PACKAGE_DIR pyrobosim_ros)
+  pyrobosim_ros
+  PACKAGE_DIR pyrobosim_ros)
 
 # Install data files
 install(DIRECTORY

--- a/setup/create_python_env.bash
+++ b/setup/create_python_env.bash
@@ -15,9 +15,9 @@ echo "Created Python virtual environment in $VIRTUALENV_FOLDER"
 source "${VIRTUALENV_FOLDER}/bin/activate"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 pushd "$SCRIPT_DIR/.." || exit
-python -m pip install --upgrade pip
+python3 -m pip install --upgrade pip
 # Install catkin-pkg because https://github.com/colcon/colcon-ros/issues/118
-pip install ./pyrobosim
+pip3 install ./pyrobosim
 pip3 install -r test/python_test_requirements.txt
 popd || exit
 deactivate

--- a/setup/create_python_env.bash
+++ b/setup/create_python_env.bash
@@ -6,20 +6,20 @@
 VIRTUALENV_FOLDER=~/python-virtualenvs/pyrobosim
 
 # Create a Python virtual environment
-[ ! -d "$VIRTUALENV_FOLDER" ] && mkdir -p $VIRTUALENV_FOLDER
-python3 -m venv $VIRTUALENV_FOLDER
-echo "Created Python virtual environment in $VIRTUALENV_FOLDER"
+[ ! -d "${VIRTUALENV_FOLDER}" ] && mkdir -p ${VIRTUALENV_FOLDER}
+python3 -m venv ${VIRTUALENV_FOLDER}
+echo "Created Python virtual environment in ${VIRTUALENV_FOLDER}"
 
 # Install all the Python packages required
 # Note that these overlay over whatever ROS 2 already contains
 source "${VIRTUALENV_FOLDER}/bin/activate"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-pushd "$SCRIPT_DIR/.." || exit
+pushd "${SCRIPT_DIR}/.." > /dev/null || exit
 python3 -m pip install --upgrade pip
 # Install catkin-pkg because https://github.com/colcon/colcon-ros/issues/118
 pip3 install ./pyrobosim
 pip3 install -r test/python_test_requirements.txt
-popd || exit
+popd > /dev/null || exit
 deactivate
 
 # Print confirmation and instructions at the end

--- a/setup/generate_docs.bash
+++ b/setup/generate_docs.bash
@@ -7,8 +7,8 @@
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source "${SCRIPT_DIR}/source_pyrobosim.bash"
-pushd "${SCRIPT_DIR}/../docs" || exit
+pushd "${SCRIPT_DIR}/../docs" > /dev/null || exit
 rm -rf build/
 rm -rf source/generated
 make html
-popd || exit
+popd > /dev/null || exit

--- a/setup/setup_pddlstream.bash
+++ b/setup/setup_pddlstream.bash
@@ -4,18 +4,18 @@
 
 # Set up the dependencies folder
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-DEPENDS_DIR=$SCRIPT_DIR/../dependencies
-if [ ! -d "$DEPENDS_DIR" ]
+DEPENDS_DIR=${SCRIPT_DIR}/../dependencies
+if [ ! -d "${DEPENDS_DIR}" ]
 then
-    mkdir $DEPENDS_DIR
+    mkdir ${DEPENDS_DIR}
 fi
 
 # Clone and build PDDLStream
-pushd $SCRIPT_DIR/../dependencies
+pushd ${SCRIPT_DIR}/../dependencies > /dev/null || exit
 git clone https://github.com/caelan/pddlstream.git
-pushd pddlstream
+pushd pddlstream > /dev/null || exit
 touch COLCON_IGNORE
 git submodule update --init --recursive
 ./downward/build.py
-popd
-popd
+popd > /dev/null || exit
+popd > /dev/null || exit

--- a/setup/source_pyrobosim.bash
+++ b/setup/source_pyrobosim.bash
@@ -27,35 +27,36 @@
 export VIRTUALENV_FOLDER=~/python-virtualenvs/pyrobosim
 export PYROBOSIM_WS=~/pyrobosim_ws
 
-if [ -n "$VIRTUAL_ENV" ]
+if [ -n "${VIRTUAL_ENV}" ]
 then
     deactivate
 fi
 
 # Parse ROS distro argument
 ROS_DISTRO=$1
-if [ "$ROS_DISTRO" == "" ]
+if [ "${ROS_DISTRO}" == "" ]
 then
     echo "Setting up pyrobosim with no ROS distro."
 else
-    echo "Setting up pyrobosim with ROS $ROS_DISTRO"
-    source /opt/ros/$ROS_DISTRO/setup.bash
-    cd $PYROBOSIM_WS
+    echo "Setting up pyrobosim with ROS ${ROS_DISTRO}"
+    source /opt/ros/${ROS_DISTRO}/setup.bash
+    pushd "${PYROBOSIM_WS}" > /dev/null || exit
     if [ ! -d "build" ]
     then
         echo "Building colcon workspace..."
         colcon build
     fi
     . install/local_setup.bash
+    popd > /dev/null || exit
 fi
 
 # Activate the Python virtual environment
-source $VIRTUALENV_FOLDER/bin/activate
+source ${VIRTUALENV_FOLDER}/bin/activate
 
 # Add dependencies to path
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-PDDLSTREAM_PATH=$SCRIPT_DIR/../dependencies/pddlstream
-if [ -d "$PDDLSTREAM_PATH" ]
+PDDLSTREAM_PATH=${SCRIPT_DIR}/../dependencies/pddlstream
+if [ -d "${PDDLSTREAM_PATH}" ]
 then
-    export PYTHONPATH=$PDDLSTREAM_PATH:$PYTHONPATH
+    export PYTHONPATH=${PDDLSTREAM_PATH}:$PYTHONPATH
 fi

--- a/test/python_test_requirements.txt
+++ b/test/python_test_requirements.txt
@@ -1,6 +1,6 @@
 lark
-py!=1.10.0
-pytest<8.1.0
+py
+pytest
 pytest-cov
 pytest-dependency
 pytest-html

--- a/test/python_test_requirements.txt
+++ b/test/python_test_requirements.txt
@@ -1,6 +1,6 @@
 lark
 py
-pytest
+pytest<8.1.0
 pytest-cov
 pytest-dependency
 pytest-html

--- a/test/run_tests.bash
+++ b/test/run_tests.bash
@@ -10,7 +10,7 @@
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 TEST_RESULTS_DIR="${SCRIPT_DIR}/results"
-mkdir -p "$TEST_RESULTS_DIR"
+mkdir -p "${TEST_RESULTS_DIR}"
 
 # Ensure we run everything for coverage purposes, but ensure failures are returned by the script
 SUCCESS=0
@@ -20,30 +20,29 @@ set -o pipefail
 
 # Run regular pytest tests
 echo "Running Python package unit tests..."
-python3 -m pytest "$SCRIPT_DIR" \
- --cov="$SCRIPT_DIR/../pyrobosim/pyrobosim" --cov-branch \
+python3 -m pytest "${SCRIPT_DIR}" \
+ --cov="${SCRIPT_DIR}/../pyrobosim/pyrobosim" --cov-branch \
  --cov-report term \
- --cov-report html:"$TEST_RESULTS_DIR/test_results_coverage_html" \
- --cov-report xml:"$TEST_RESULTS_DIR/test_results_coverage.xml" \
- --junitxml="$TEST_RESULTS_DIR/test_results.xml" \
- --html="$TEST_RESULTS_DIR/test_results.html" \
+ --cov-report html:"${TEST_RESULTS_DIR}/test_results_coverage_html" \
+ --cov-report xml:"${TEST_RESULTS_DIR}/test_results_coverage.xml" \
+ --junitxml="${TEST_RESULTS_DIR}/test_results.xml" \
+ --html="${TEST_RESULTS_DIR}/test_results.html" \
  --self-contained-html \
- | tee "$TEST_RESULTS_DIR"/pytest-coverage.txt || SUCCESS=$?
+ | tee "${TEST_RESULTS_DIR}/pytest-coverage.txt" || SUCCESS=$?
 echo ""
 
-# Run colcon tests, if using a ROS distro
+# Run ROS package tests, if using a ROS distro
 ROS_DISTRO=$1
-if [[ -n "$ROS_DISTRO" && -n "$COLCON_PREFIX_PATH" ]]
+if [[ -n "${ROS_DISTRO}" && -n "${COLCON_PREFIX_PATH}" ]]
 then
     WORKSPACE_DIR="${COLCON_PREFIX_PATH}/../"
-    echo "Running ROS package unit tests from ${WORKSPACE_DIR}..."
-    pushd "${WORKSPACE_DIR}" > /dev/null || exit
-    colcon test \
-        --event-handlers console_cohesion+ \
-        --pytest-with-coverage --pytest-args " --cov-report term" || SUCCESS=$?
-echo ""
-    colcon test-result --verbose
-    popd > /dev/null || exit
+    ROS_PKG_DIR="${WORKSPACE_DIR}/src/pyrobosim_ros"
+    echo "Running ROS package unit tests from ${ROS_PKG_DIR} ..."
+    python3 -m pytest "${ROS_PKG_DIR}" \
+     --junitxml="${TEST_RESULTS_DIR}/test_results_ros.xml" \
+     --html="${TEST_RESULTS_DIR}/test_results_ros.html" \
+     --self-contained-html || SUCCESS=$?
+    echo ""
 fi
 
-exit $SUCCESS
+exit ${SUCCESS}

--- a/test/run_tests.bash
+++ b/test/run_tests.bash
@@ -36,13 +36,15 @@ ROS_DISTRO=$1
 if [[ -n "${ROS_DISTRO}" && -n "${COLCON_PREFIX_PATH}" ]]
 then
     WORKSPACE_DIR="${COLCON_PREFIX_PATH}/../"
-    ROS_PKG_DIR="${WORKSPACE_DIR}/src/pyrobosim_ros"
-    echo "Running ROS package unit tests from ${ROS_PKG_DIR} ..."
-    python3 -m pytest "${ROS_PKG_DIR}" \
-     --junitxml="${TEST_RESULTS_DIR}/test_results_ros.xml" \
-     --html="${TEST_RESULTS_DIR}/test_results_ros.html" \
-     --self-contained-html || SUCCESS=$?
+    echo "Running ROS package unit tests from ${WORKSPACE_DIR}..."
+    pushd "${WORKSPACE_DIR}" > /dev/null || exit
+    colcon test \
+        --event-handlers console_cohesion+ \
+        --pytest-with-coverage --pytest-args " --cov-report term" || SUCCESS=$?
     echo ""
+    colcon test-result --verbose \
+     | tee "${TEST_RESULTS_DIR}/test_results_ros.xml"
+    popd > /dev/null || exit
 fi
 
 exit ${SUCCESS}


### PR DESCRIPTION
This PR switches to use [ROS (not OSRF) Docker images](https://hub.docker.com/_/ros/) and also adds Jazzy support now that it's out.