### PR TITLE
Fix pip install in Ubuntu 24.04 Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,11 +30,11 @@ WORKDIR /opt/pyrobosim/
 COPY setup/setup_pddlstream.bash setup/
 RUN setup/setup_pddlstream.bash
 
-# Install baseline pip dependencies
+# Install pip dependencies for testing
 COPY test/python_test_requirements.txt test/
 RUN pip3 install --break-system-packages -r test/python_test_requirements.txt
 
-# Copy the rest of the source directory
+# Copy the rest of the source directory and install pyrobosim
 COPY . /opt/pyrobosim/
 RUN pip3 install --break-system-packages -e pyrobosim
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,13 +26,13 @@ RUN mkdir -p /opt/pyrobosim/test
 RUN mkdir -p /opt/pyrobosim/setup
 WORKDIR /opt/pyrobosim/
 
-# Install baseline pip dependencies
-COPY test/python_test_requirements.txt test/
-RUN pip3 install --break-system-packages -r test/python_test_requirements.txt
-
 # Install PDDLStream
 COPY setup/setup_pddlstream.bash setup/
 RUN setup/setup_pddlstream.bash
+
+# Install baseline pip dependencies
+COPY test/python_test_requirements.txt test/
+RUN pip3 install --break-system-packages -r test/python_test_requirements.txt
 
 # Copy the rest of the source directory
 COPY . /opt/pyrobosim/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,7 @@ WORKDIR /opt/pyrobosim/
 
 # Install baseline pip dependencies
 COPY test/python_test_requirements.txt test/
-RUN pip3 install -r test/python_test_requirements.txt
+RUN pip3 install --break-system-packages -r test/python_test_requirements.txt
 
 # Install PDDLStream
 COPY setup/setup_pddlstream.bash setup/
@@ -36,7 +36,7 @@ RUN setup/setup_pddlstream.bash
 
 # Copy the rest of the source directory
 COPY . /opt/pyrobosim/
-RUN pip3 install -e pyrobosim
+RUN pip3 install --break-system-packages -e pyrobosim
 
 # Set the default startup command
 CMD /bin/bash


### PR DESCRIPTION
Turns out after Ubuntu 23.04, Canonical got way more strict about using system Python to install stuff... https://www.reddit.com/r/Python/comments/1338oge/you_cant_use_pip_on_ubuntu_2304_anymore/

This is why the recent breakages came in, as in https://github.com/sea-bass/pyrobosim/actions/runs/8841625181, since `runs-on: ubuntu-latest` now points to Ubuntu 24.04.

I'm going to do the "band-aid" fix for now and worry about something more principled once we make the move officially to Ubuntu 24.04 / ROS 2 Jazzy. Will likely involve using a virtual environment in the Dockerfiles as well, as we already do for local setup instructions.