### PR TITLE
Use ROS actions to execute actions and task plans

### DIFF
--- a/docs/source/usage/basic_usage.rst
+++ b/docs/source/usage/basic_usage.rst
@@ -49,7 +49,7 @@ You can run a ROS 2 enabled demo and interact with the GUI:
     ros2 run pyrobosim_ros demo.py
 
 
-In a separate Terminal, you can publish a plan or a single action:
+In a separate Terminal, you can send an aaction goal with a task plan or a single action:
 
 ::
 
@@ -65,7 +65,7 @@ Or, you can run both of these nodes together using a provided launch file:
     ros2 launch pyrobosim_ros demo_commands.launch.py mode:=action
 
 
-The first command will start a world as a ROS 2 node, and the second one will publish a plan (or set of actions) to the node.
+The first command will start a world as a ROS 2 node, and the second one will execute a plan (or set of actions) to the node.
 
 .. image:: ../media/pyrobosim_demo_ros.png
     :align: center

--- a/docs/source/usage/basic_usage.rst
+++ b/docs/source/usage/basic_usage.rst
@@ -49,7 +49,7 @@ You can run a ROS 2 enabled demo and interact with the GUI:
     ros2 run pyrobosim_ros demo.py
 
 
-In a separate Terminal, you can send an aaction goal with a task plan or a single action:
+In a separate Terminal, you can send an action goal with a task plan or a single action:
 
 ::
 

--- a/docs/source/usage/multirobot.rst
+++ b/docs/source/usage/multirobot.rst
@@ -46,7 +46,7 @@ You can run a ROS 2 enabled multirobot demo and interact with the GUI:
     ros2 run pyrobosim_ros demo.py --ros-args -p world_file:=test_world_multirobot.yaml
 
 
-In a separate Terminal, you can publish a multirobot plan:
+In a separate Terminal, you can send an action goal with a multirobot plan:
 
 ::
 

--- a/pyrobosim/examples/demo_pddl.py
+++ b/pyrobosim/examples/demo_pddl.py
@@ -80,7 +80,7 @@ def start_planner(world, args):
         max_planner_time=10.0,
         max_time=60.0,
     )
-    robot.execute_plan(plan, blocking=True)
+    robot.execute_plan(plan)
 
 
 if __name__ == "__main__":

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -463,8 +463,8 @@ class Robot:
         :type blocking: bool, optional
         :param delay: Artificial delay between actions for visualization.
         :type delay: float, optional
-        :return: True if the plan succeeds, or False otherwise.
-        :rtype: bool
+        :return: A tuple containing a boolean for whether the plan succeeded, and the number of completed actions.
+        :rtype: tuple(bool, int)
         """
         if plan is None:
             print(f"[{self.name}] Plan is None. Returning.")
@@ -479,13 +479,17 @@ class Robot:
             self.world.gui.set_buttons_during_action(False)
 
         success = True
+        num_completed = 0
         num_acts = len(plan.actions)
         for n, act_msg in enumerate(plan.actions):
             print(f"[{self.name}] Executing action {act_msg.type} [{n+1}/{num_acts}]")
             success = self.execute_action(act_msg, blocking=blocking)
             if not success:
-                print(f"[{self.name}] Task plan failed to execute on action {n+1}")
+                print(
+                    f"[{self.name}] Task plan failed to execute on action {n+1}/{num_acts}"
+                )
                 break
+            num_completed += 1
             time.sleep(delay)  # Artificial delay between actions
 
         if self.world.has_gui:
@@ -494,7 +498,7 @@ class Robot:
         if blocking:
             self.executing_plan = False
             self.current_plan = None
-        return success
+        return success, num_completed
 
     def __repr__(self):
         """Returns printable string."""

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -452,15 +452,13 @@ class Robot:
             self.executing_action = False
         return success
 
-    def execute_plan(self, plan, blocking=False, delay=0.5):
+    def execute_plan(self, plan, delay=0.5):
         """
         Executes a task plan, specified as a
         :class:`pyrobosim.planning.actions.TaskPlan` object.
 
         :param plan: Task plan to execute.
         :type plan: :class:`pyrobosim.planning.actions.TaskPlan`
-        :param blocking: True to block execution until the action is complete.
-        :type blocking: bool, optional
         :param delay: Artificial delay between actions for visualization.
         :type delay: float, optional
         :return: A tuple containing a boolean for whether the plan succeeded, and the number of completed actions.
@@ -470,9 +468,8 @@ class Robot:
             print(f"[{self.name}] Plan is None. Returning.")
             return False
 
-        if blocking:
-            self.executing_plan = True
-            self.current_plan = plan
+        self.executing_plan = True
+        self.current_plan = plan
 
         print(f"[{self.name}] Executing task plan...")
         if self.world.has_gui:
@@ -483,7 +480,7 @@ class Robot:
         num_acts = len(plan.actions)
         for n, act_msg in enumerate(plan.actions):
             print(f"[{self.name}] Executing action {act_msg.type} [{n+1}/{num_acts}]")
-            success = self.execute_action(act_msg, blocking=blocking)
+            success = self.execute_action(act_msg, blocking=True)
             if not success:
                 print(
                     f"[{self.name}] Task plan failed to execute on action {n+1}/{num_acts}"
@@ -494,10 +491,10 @@ class Robot:
 
         if self.world.has_gui:
             self.world.gui.set_buttons_during_action(True)
+
         print(f"[{self.name}] Task plan completed with success: {success}")
-        if blocking:
-            self.executing_plan = False
-            self.current_plan = None
+        self.executing_plan = False
+        self.current_plan = None
         return success, num_completed
 
     def __repr__(self):

--- a/pyrobosim/pyrobosim/planning/actions.py
+++ b/pyrobosim/pyrobosim/planning/actions.py
@@ -133,7 +133,7 @@ class TaskPlan:
         :type actions: list[:class:`pyrobosim.planning.actions.TaskAction`]
         """
         self.actions = actions
-        self.total_cost = sum([a.cost for a in self.actions])
+        self.total_cost = sum([a.cost for a in self.actions if a.cost is not None])
 
     def size(self):
         """

--- a/pyrobosim_msgs/CMakeLists.txt
+++ b/pyrobosim_msgs/CMakeLists.txt
@@ -12,8 +12,8 @@ find_package(rclpy REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(geometry_msgs REQUIRED)
 
-# Generate custom messages
-rosidl_generate_interfaces(${PROJECT_NAME}
+# Generate custom interfaces
+set(msg_files
   "msg/GoalPredicate.msg"
   "msg/GoalSpecification.msg"
   "msg/LocationState.msg"
@@ -23,7 +23,21 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/TaskAction.msg"
   "msg/TaskPlan.msg"
   "msg/WorldState.msg"
+)
+
+set(srv_files
   "srv/RequestWorldState.srv"
+)
+
+set(action_files
+  "action/ExecuteTaskAction.action"
+  "action/ExecuteTaskPlan.action"
+)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${msg_files}
+  ${srv_files}
+  ${action_files}
   DEPENDENCIES geometry_msgs
 )
 

--- a/pyrobosim_msgs/action/ExecuteTaskAction.action
+++ b/pyrobosim_msgs/action/ExecuteTaskAction.action
@@ -1,0 +1,13 @@
+# Execute Task Plan -- ROS Action Definition
+
+# Goal
+pyrobosim_msgs/TaskAction action
+
+---
+
+# Result
+bool success
+
+---
+
+# No Feedback

--- a/pyrobosim_msgs/action/ExecuteTaskPlan.action
+++ b/pyrobosim_msgs/action/ExecuteTaskPlan.action
@@ -1,0 +1,15 @@
+# Execute Task Action -- ROS Action Definition
+
+# Goal
+pyrobosim_msgs/TaskPlan plan
+
+---
+
+# Result
+bool success
+int64 num_completed
+int64 num_total
+
+---
+
+# No Feedback

--- a/pyrobosim_msgs/package.xml
+++ b/pyrobosim_msgs/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>pyrobosim_msgs</name>
   <version>1.2.0</version>
-  <description>Message definitions for pyrobosim package.</description>
+  <description>ROS interface definitions for pyrobosim.</description>
   <maintainer email="sebas.a.castro@gmail.com">Sebastian Castro</maintainer>
   <license>MIT</license>
 

--- a/pyrobosim_ros/examples/demo.py
+++ b/pyrobosim_ros/examples/demo.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-Test script showing how to build a world and use it with pyrobosim,
+Example showing how to build a world and use it with pyrobosim,
 additionally starting up a ROS interface.
 """
 import os

--- a/pyrobosim_ros/examples/demo_pddl_goal_publisher.py
+++ b/pyrobosim_ros/examples/demo_pddl_goal_publisher.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-Test script showing how to publish a goal specification to a PDDLStream planner node.
+Example showing how to publish a goal specification to a PDDLStream planner node.
 """
 
 import rclpy

--- a/pyrobosim_ros/examples/demo_pddl_planner.py
+++ b/pyrobosim_ros/examples/demo_pddl_planner.py
@@ -20,7 +20,7 @@ from pyrobosim_ros.ros_conversions import (
     task_plan_to_ros,
 )
 from pyrobosim_msgs.action import ExecuteTaskPlan
-from pyrobosim_msgs.msg import GoalSpecification, TaskPlan
+from pyrobosim_msgs.msg import GoalSpecification
 from pyrobosim_msgs.srv import RequestWorldState
 
 
@@ -134,7 +134,7 @@ class PlannerNode(Node):
         self.latest_goal = goal_specification_from_ros(msg, self.world)
 
     def do_plan(self):
-        """Search for a plan and publish it."""
+        """Search for a plan and send it to the appropriate robot(s)."""
         if not self.latest_goal:
             return
 

--- a/pyrobosim_ros/examples/demo_pddl_world.py
+++ b/pyrobosim_ros/examples/demo_pddl_world.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-Test script showing how to start a pyrobosim world that receives a plan from a
+Example showing how to start a pyrobosim world that receives a plan from a
 Task and Motion Planner such as PDDLStream.
 """
 

--- a/pyrobosim_ros/examples/demo_velocity_publisher.py
+++ b/pyrobosim_ros/examples/demo_velocity_publisher.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-Test script showing how to publish velocity commands to a pyrobosim robot.
+Example showing how to publish velocity commands to a pyrobosim robot.
 """
 
 import rclpy

--- a/pyrobosim_ros/pyrobosim_ros/ros_interface.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_interface.py
@@ -276,11 +276,13 @@ class WorldROSWrapper(Node):
             self.get_logger().info(
                 f"Invalid robot name: {goal_handle.request.action.robot}"
             )
+            goal_handle.abort()
             return
         if self.is_robot_busy(robot):
             self.get_logger().info(
                 "Currently executing action(s). Discarding this one."
             )
+            goal_handle.abort()
             return
 
         # Execute the action
@@ -306,11 +308,13 @@ class WorldROSWrapper(Node):
             self.get_logger().info(
                 f"Invalid robot name: {goal_handle.request.plan.robot}"
             )
+            goal_handle.abort()
             return
         if self.is_robot_busy(robot):
             self.get_logger().info(
                 f"Currently executing action(s). Discarding this one."
             )
+            goal_handle.abort()
             return
 
         # Execute the plan

--- a/test/core/test_robot.py
+++ b/test/core/test_robot.py
@@ -210,15 +210,7 @@ class TestRobot:
         ]
         plan = TaskPlan(actions=actions)
 
-        # Blocking plan
-        result, num_completed = robot.execute_plan(plan, blocking=True)
+        result, num_completed = robot.execute_plan(plan)
+
         assert result
         assert num_completed == 3
-
-        # Non-blocking plan
-        robot.set_pose(init_pose)
-        result, num_completed = robot.execute_plan(plan, blocking=False)
-        assert result
-        while robot.executing_action:
-            time.sleep(0.1)
-        assert not robot.executing_action

--- a/test/core/test_robot.py
+++ b/test/core/test_robot.py
@@ -208,7 +208,7 @@ class TestRobot:
             TaskAction("pick", object="apple"),
             TaskAction("place", "object", "apple"),
         ]
-        plan = TaskPlan(actions)
+        plan = TaskPlan(actions=actions)
 
         # Blocking plan
         result, num_completed = robot.execute_plan(plan, blocking=True)

--- a/test/core/test_robot.py
+++ b/test/core/test_robot.py
@@ -211,12 +211,13 @@ class TestRobot:
         plan = TaskPlan(actions)
 
         # Blocking plan
-        result = robot.execute_plan(plan, blocking=True)
+        result, num_completed = robot.execute_plan(plan, blocking=True)
         assert result
+        assert num_completed == 3
 
         # Non-blocking plan
         robot.set_pose(init_pose)
-        result = robot.execute_plan(plan, blocking=False)
+        result, num_completed = robot.execute_plan(plan, blocking=False)
         assert result
         while robot.executing_action:
             time.sleep(0.1)

--- a/test/planning/test_pddlstream_manip.py
+++ b/test/planning/test_pddlstream_manip.py
@@ -115,7 +115,7 @@ def start_planner(
         max_planner_time=30.0,
     )
     if interactive:
-        robot.execute_plan(plan, blocking=True)
+        robot.execute_plan(plan)
     return plan
 
 

--- a/test/planning/test_pddlstream_nav.py
+++ b/test/planning/test_pddlstream_nav.py
@@ -95,7 +95,7 @@ def start_planner(world, domain_name="03_nav_stream", interactive=False):
         max_planner_time=30.0,
     )
     if interactive:
-        robot.execute_plan(plan, blocking=True)
+        robot.execute_plan(plan)
     return plan
 
 


### PR DESCRIPTION
Instead of unilaterally sending topics to the simulator ROS interface to execute actions or task plans, this PR uses a proper action interface.

There are probably more things to implement in this fashion in the example, as well as more state tracking (e.g., publishing feedback), but we'll start with this.

Closes #172 