### PR TITLE
Pin NumPy below 2.0.0

### DIFF
--- a/pyrobosim/setup.py
+++ b/pyrobosim/setup.py
@@ -21,7 +21,7 @@ install_requires = [
     "adjustText",
     "astar",
     "matplotlib",
-    "numpy",
+    "numpy<2.0.0",
     "pycollada",
     "PySide6",
     "PyYAML",


### PR DESCRIPTION
Until [adjustText](https://github.com/Phlya/adjustText) releases a new version with the fixes, it will not be compatible with NumPy 2.0.0. So pinning for now.