### PR TITLE
Unpin NumPy and do not upgrade pip in scripts and CI

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,8 +74,7 @@ COPY . /pyrobosim_ws/src/
 # Install pyrobosim and testing dependencies
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 WORKDIR /pyrobosim_ws/src
-RUN pip3 install --upgrade pip && \
-    pip3 install -e ./pyrobosim && \
+RUN pip3 install -e ./pyrobosim && \
     pip3 install -r test/python_test_requirements.txt
 
 # Build the ROS workspace

--- a/pyrobosim/setup.py
+++ b/pyrobosim/setup.py
@@ -21,7 +21,7 @@ install_requires = [
     "adjustText",
     "astar",
     "matplotlib",
-    "numpy<2.0.0",
+    "numpy",
     "pycollada",
     "PySide6",
     "PyYAML",

--- a/setup/create_python_env.bash
+++ b/setup/create_python_env.bash
@@ -15,7 +15,6 @@ echo "Created Python virtual environment in ${VIRTUALENV_FOLDER}"
 source "${VIRTUALENV_FOLDER}/bin/activate"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 pushd "${SCRIPT_DIR}/.." > /dev/null || exit
-python3 -m pip install --upgrade pip
 pip3 install ./pyrobosim
 pip3 install -r test/python_test_requirements.txt
 popd > /dev/null || exit


### PR DESCRIPTION
This reverts commit 3ee93eefe4da2cf505af2b99360842d163848357.

`adjustText` came out with a 1.2.0 version which is compatible with NumPy 2.0.0, so we are good.