### PR TITLE
Allow path planning failures to fail navigate actions

### DIFF
--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -454,6 +454,12 @@ class WorldCanvas(FigureCanvasQTAgg):
         goal_node = self.world.graph_node_from_entity(goal, robot=robot)
         if not path or path.num_poses < 2:
             path = robot.plan_path(robot.get_pose(), goal_node.pose)
+        if path.num_poses == 0:
+            warnings.warn(f"Failed to plan a path.")
+            robot.executing_nav = False
+            robot.last_nav_successful = False
+            return False
+
         self.show_planner_and_path(robot=robot, path=path)
         robot.follow_path(
             path,
@@ -468,7 +474,7 @@ class WorldCanvas(FigureCanvasQTAgg):
 
         self.show_world_state(robot=robot)
         self.draw_and_sleep()
-        return True
+        return robot.last_nav_successful
 
     def pick_object(self, robot, obj_name, grasp_pose=None):
         """

--- a/pyrobosim/pyrobosim/navigation/execution.py
+++ b/pyrobosim/pyrobosim/navigation/execution.py
@@ -3,7 +3,6 @@
 import time
 import warnings
 
-from ..utils.pose import Pose
 from ..utils.trajectory import get_constant_speed_trajectory, interpolate_trajectory
 
 
@@ -72,6 +71,7 @@ class ConstantVelocityExecutor:
         # Finalize path execution
         time.sleep(0.1)  # To ensure background threads get the end of the path.
         self.robot.executing_nav = False
+        self.robot.last_nav_successful = True
         self.robot.executing_action = False
         self.robot.current_action = None
-        return True
+        return self.robot.last_nav_successful

--- a/setup/setup_pyrobosim.bash
+++ b/setup/setup_pyrobosim.bash
@@ -17,7 +17,7 @@ echo -e "Created Python virtual environment in ${VIRTUALENV_FOLDER}\n"
 source "${VIRTUALENV_FOLDER}/bin/activate"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 pushd "${SCRIPT_DIR}/.." > /dev/null
-pip3 install ./pyrobosim
+pip3 install -e ./pyrobosim
 pip3 install -r test/python_test_requirements.txt
 
 # Write key variables to file

--- a/test/core/test_robot.py
+++ b/test/core/test_robot.py
@@ -129,6 +129,7 @@ class TestRobot:
         while robot.executing_nav:
             time.sleep(0.1)
         assert not robot.executing_nav
+        assert robot.last_nav_successful
         pose = robot.get_pose()
         assert pose.x == pytest.approx(goal_pose.x)
         assert pose.y == pytest.approx(goal_pose.y)


### PR DESCRIPTION
Previously, non-blocking navigation actions were returning `True` as the path planning was simply delegated but its status was never checked.

This adds a new state to the robot for us to be able to check navigation status, and also adds more checks for cases where path planning fails before it starts executing (which was also not being validated).