### PR TITLE
Cleanup navigation display and execution in GUI

### DIFF
--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -479,7 +479,7 @@ class Robot:
                 else:
                     tgt_loc = action.target_location.name
 
-                self.world.gui.canvas.nav_trigger.emit(self.name, tgt_loc, action.path)
+                self.world.gui.canvas.navigate(self, tgt_loc, action.path)
                 while self.executing_nav:
                     time.sleep(0.5)  # Delay to wait for navigation
                 success = self.last_nav_successful

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -491,6 +491,8 @@ class Robot:
 
                 if path.num_poses == 0:
                     warnings.warn("Failed to plan a path.")
+                    self.executing_nav = False
+                    self.last_nav_successful = False
                     success = False
                 else:
                     success = self.follow_path(

--- a/pyrobosim/pyrobosim/gui/main.py
+++ b/pyrobosim/pyrobosim/gui/main.py
@@ -83,7 +83,7 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):
     def closeEvent(self, _):
         """Cleans up running threads on closing the window."""
         self.canvas.nav_animator.stop()
-        self.canvas.nav_animator.wait()
+        self.canvas.thread_pool.waitForDone()
 
     def set_window_dims(self, screen_fraction=0.8):
         """
@@ -198,6 +198,9 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):
             self.detect_button.setEnabled(at_object_spawn)
 
             self.canvas.show_world_state(robot, navigating=False)
+        else:
+            self.nav_button.setEnabled(False)
+
         self.canvas.draw_and_sleep()
 
     def set_buttons_during_action(self, state):
@@ -264,7 +267,7 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):
             return
 
         print(f"[{robot.name}] Navigating to {loc}")
-        self.canvas.navigate_in_thread(robot, loc)
+        self.canvas.navigate(robot, loc)
 
     def on_pick_click(self):
         """Callback to pick an object."""

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -358,42 +358,6 @@ class WorldCanvas(FigureCanvasQTAgg):
         time.sleep(0.001)
         self.draw_lock.release()
 
-    def monitor_nav_animation(self):
-        """
-        Monitors the navigation animation (to be started in a separate thread).
-        """
-        sleep_time = self.animation_dt / self.realtime_factor
-        while self.nav_animator.running:
-            # Check if any robot is currently navigating.
-            nav_status = [robot.is_moving() for robot in self.world.robots]
-            if any(nav_status):
-                active_robot_indices = [
-                    i for i, status in enumerate(nav_status) if status
-                ]
-
-                # Update the animation.
-                self.update_robots_plot()
-                self.show_world_state(
-                    self.world.robots[active_robot_indices[0]], navigating=True
-                )
-                self.draw_and_sleep()
-
-                # Check if GUI buttons should be disabled
-                if self.world.has_gui and self.world.gui.layout_created:
-                    cur_robot = self.world.gui.get_current_robot()
-                    is_cur_robot_moving = (
-                        cur_robot in self.world.robots and cur_robot.is_moving()
-                    )
-                    self.world.gui.set_buttons_during_action(not is_cur_robot_moving)
-
-            else:
-                # If the GUI button states did not toggle correctly, force them
-                # to be active once no robots are moving.
-                if self.world.has_gui and self.world.gui.layout_created:
-                    self.world.gui.update_button_state()
-
-            time.sleep(sleep_time)
-
     def show_planner_and_path(self, robot=None, path=None):
         """
         Plot the path planner and latest path, if specified.

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -104,10 +104,10 @@ class NavRunner(QRunnable):
             robot = world.get_robot_by_name(robot)
         if robot is None:
             warnings.warn("No robot found.")
-            return False
+            return
         if robot.path_planner is None:
             warnings.warn(f"No path planner attached to robot {robot.name}.")
-            return False
+            return
 
         # Find a path, or use an existing one, and start the navigation thread.
         goal_node = world.graph_node_from_entity(self.goal, robot=robot)
@@ -117,7 +117,7 @@ class NavRunner(QRunnable):
             warnings.warn(f"Failed to plan a path.")
             robot.executing_nav = False
             robot.last_nav_successful = False
-            return False
+            return
 
         self.canvas.show_planner_and_path(robot=robot, path=path)
         robot.follow_path(
@@ -133,7 +133,6 @@ class NavRunner(QRunnable):
 
         self.canvas.show_world_state(robot=robot)
         self.canvas.draw_and_sleep()
-        return robot.last_nav_successful
 
 
 class WorldCanvas(FigureCanvasQTAgg):
@@ -468,8 +467,6 @@ class WorldCanvas(FigureCanvasQTAgg):
         :type goal: str
         :param path: Path to goal location, defaults to None.
         :type path: :class:`pyrobosim.utils.motion.Path`, optional
-        :return: True if navigation succeeds, else False
-        :rtype: bool
         """
         nav_thread = NavRunner(self, robot, goal, path)
         self.thread_pool.start(nav_thread)

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -40,27 +40,18 @@ class NavAnimator(QRunnable):
             # Check if any robot is currently navigating.
             nav_status = [robot.is_moving() for robot in world.robots]
             if any(nav_status):
-                active_robot_indices = [
-                    i for i, status in enumerate(nav_status) if status
-                ]
-
-                # Update the animation.
                 self.canvas.update_robots_plot()
-                self.canvas.show_world_state(
-                    world.robots[active_robot_indices[0]], navigating=True
-                )
-                self.canvas.draw_and_sleep()
 
-                # Check if GUI buttons should be disabled
+                # Show the state of the currently selected robot
                 cur_robot = world.gui.get_current_robot()
-                is_cur_robot_moving = (
-                    cur_robot in world.robots and cur_robot.is_moving()
-                )
-                world.gui.set_buttons_during_action(not is_cur_robot_moving)
+                if cur_robot is not None and cur_robot.is_moving():
+                    self.canvas.show_world_state(cur_robot, navigating=True)
+                    world.gui.set_buttons_during_action(False)
 
+                self.canvas.draw_and_sleep()
             else:
-                # If the GUI button states did not toggle correctly, force them
-                # to be active once no robots are moving.
+                # If the GUI button states did not toggle correctly,
+                # force them to be active once no robots are moving.
                 world.gui.update_button_state()
 
             time.sleep(sleep_time)
@@ -301,7 +292,7 @@ class WorldCanvas(FigureCanvasQTAgg):
         # Rooms and hallways
         for r in self.world.rooms:
             self.axes.add_patch(r.viz_patch)
-            t = self.axes.text(
+            self.axes.text(
                 r.centroid[0],
                 r.centroid[1],
                 r.name,
@@ -321,7 +312,7 @@ class WorldCanvas(FigureCanvasQTAgg):
         # Locations
         for loc in self.world.locations:
             self.axes.add_patch(loc.viz_patch)
-            t = self.axes.text(
+            self.axes.text(
                 loc.pose.x,
                 loc.pose.y,
                 loc.name,

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -52,7 +52,6 @@ class NavAnimator(QRunnable):
                 self.canvas.draw_and_sleep()
 
                 # Check if GUI buttons should be disabled
-                # if world.has_gui and world.gui.layout_created:
                 cur_robot = world.gui.get_current_robot()
                 is_cur_robot_moving = (
                     cur_robot in world.robots and cur_robot.is_moving()
@@ -62,7 +61,6 @@ class NavAnimator(QRunnable):
             else:
                 # If the GUI button states did not toggle correctly, force them
                 # to be active once no robots are moving.
-                # if self.world.has_gui and self.world.gui.layout_created:
                 world.gui.update_button_state()
 
             time.sleep(sleep_time)


### PR DESCRIPTION
I was originally trying to get rid of these occasional prints:

```
QBasicTimer::stop: Failed. Possibly trying to stop from a different thread
```

... but to no avail. However, it did clean some stuff up. Maybe?