### PR TITLE
Flesh out tests for RRT and PRM planner

### DIFF
--- a/pyrobosim/pyrobosim/navigation/prm.py
+++ b/pyrobosim/pyrobosim/navigation/prm.py
@@ -58,13 +58,12 @@ class PRMPlannerPolygon:
         for i in range(self.max_nodes):
             n_sample = self.sample_configuration()
             if not n_sample:
-                warnings.warn(f"Could not sample more than {i} nodes")
+                warnings.warn(f"Could not sample more than {i} nodes.")
                 break
-            self.graph.add_node(Node(pose=n_sample))
-        self.sampling_time = time.time() - t_start
-
-        for node in self.graph.nodes:
+            node = Node(pose=n_sample)
+            self.graph.add_node(node)
             self.connect_neighbors(node)
+        self.sampling_time = time.time() - t_start
 
     def connect_neighbors(self, node):
         """
@@ -156,7 +155,7 @@ class PRMPlanner(PathPlannerBase):
         self.impl = None
 
         if planner_config.get("grid", None):
-            raise NotImplementedError("Grid based PRM is not supported. ")
+            raise NotImplementedError("PRM planner does not support grid based search.")
         else:
             self.impl = PRMPlannerPolygon(**planner_config)
 

--- a/pyrobosim/pyrobosim/navigation/rrt.py
+++ b/pyrobosim/pyrobosim/navigation/rrt.py
@@ -3,6 +3,7 @@
 import copy
 import time
 import numpy as np
+import warnings
 
 from .planner_base import PathPlannerBase
 from ..utils.motion import Path, reduce_waypoints_polygon
@@ -191,12 +192,13 @@ class RRTPlannerPolygon:
             elif connected_node:
                 goal_found, _ = self.try_connect_until(self.graph_start, n_new, n_goal)
 
-            # Check max nodes samples or max time elapsed
+            # Check max nodes sampled or max time elapsed
             self.planning_time = time.time() - t_start
             if (
                 self.planning_time > self.max_time
                 or self.nodes_sampled > self.max_nodes_sampled
             ):
+                warnings.warn("Could not find a path from start to goal.")
                 self.latest_path = Path()
                 return self.latest_path
 
@@ -224,6 +226,7 @@ class RRTPlannerPolygon:
                 else:
                     n = n.parent
                     path_poses.append(n.pose)
+
         if self.compress_path:
             path_poses = reduce_waypoints_polygon(
                 self.world, path_poses, self.collision_check_step_dist
@@ -389,7 +392,7 @@ class RRTPlanner(PathPlannerBase):
 
         self.impl = None
         if planner_config.get("grid", None):
-            raise NotImplementedError("RRT does not support grid based search. ")
+            raise NotImplementedError("RRT planner does not support grid based search.")
         else:
             self.impl = RRTPlannerPolygon(**planner_config)
 

--- a/test/navigation/test_prm.py
+++ b/test/navigation/test_prm.py
@@ -80,3 +80,27 @@ def test_rrt_grid_not_supported():
     with pytest.raises(NotImplementedError) as exc_info:
         PathPlanner("prm", **planner_config)
     assert exc_info.value.args[0] == "PRM planner does not support grid based search."
+
+
+def test_prm_compress_path():
+    """Tests planning with path compression option."""
+    world = WorldYamlLoader().from_yaml(
+        os.path.join(get_data_folder(), "test_world.yaml")
+    )
+    planner_config = {
+        "world": world,
+        "compress_path": False,
+    }
+    prm = PathPlanner("prm", **planner_config)
+    start = Pose(x=-0.3, y=0.6)
+    goal = Pose(x=2.5, y=3.0)
+
+    np.random.seed(1234)  # Use same seed for reproducibility
+    orig_path = prm.plan(start, goal)
+    assert len(orig_path.poses) >= 2
+
+    np.random.seed(1234)  # Use same seed for reproducibility
+    prm.planner.impl.compress_path = True
+    new_path = prm.plan(start, goal)
+    assert len(new_path.poses) >= 2
+    assert new_path.length < orig_path.length

--- a/test/navigation/test_prm.py
+++ b/test/navigation/test_prm.py
@@ -65,7 +65,7 @@ def test_prm_no_path():
     assert warn_info[0].message.args[0] == "Could not find a path from start to goal."
 
 
-def test_rrt_grid_not_supported():
+def test_prm_grid_not_supported():
     """Test that PRM is not (yet) supported with occupancy grid maps."""
     world = WorldYamlLoader().from_yaml(
         os.path.join(get_data_folder(), "test_world.yaml")

--- a/test/navigation/test_prm.py
+++ b/test/navigation/test_prm.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+"""Unit tests for the PRM planner"""
+
+import os
+import numpy as np
+import pytest
+
+from pyrobosim.core import WorldYamlLoader
+from pyrobosim.navigation import OccupancyGrid, PathPlanner
+from pyrobosim.utils.general import get_data_folder
+from pyrobosim.utils.pose import Pose
+
+
+def test_prm_default():
+    """Tests planning with default world graph planner settings."""
+    world = WorldYamlLoader().from_yaml(
+        os.path.join(get_data_folder(), "test_world.yaml")
+    )
+    planner_config = {"world": world}
+
+    np.random.seed(1234)  # Fix seed for reproducibility
+    prm = PathPlanner("prm", **planner_config)
+    start = Pose(x=-1.6, y=2.8)
+    goal = Pose(x=2.5, y=3.0)
+
+    path = prm.plan(start, goal)
+    assert len(path.poses) >= 2
+    assert path.poses[0] == start
+    assert path.poses[-1] == goal
+
+
+def test_prm_default():
+    """Tests planning with default world graph planner settings."""
+    world = WorldYamlLoader().from_yaml(
+        os.path.join(get_data_folder(), "test_world.yaml")
+    )
+    planner_config = {"world": world}
+
+    np.random.seed(1234)  # Fix seed for reproducibility
+    prm = PathPlanner("prm", **planner_config)
+    start = Pose(x=-1.6, y=2.8)
+    goal = Pose(x=2.5, y=3.0)
+
+    path = prm.plan(start, goal)
+    assert len(path.poses) >= 2
+    assert path.poses[0] == start
+    assert path.poses[-1] == goal
+
+
+def test_prm_no_path():
+    """Test that PRM gracefully returns when there is no feasible path."""
+    world = WorldYamlLoader().from_yaml(
+        os.path.join(get_data_folder(), "test_world.yaml")
+    )
+    planner_config = {"world": world}
+
+    prm = PathPlanner("prm", **planner_config)
+    start = Pose(x=-1.6, y=2.8)
+    goal = Pose(x=12.5, y=3.0)
+
+    with pytest.warns(UserWarning) as warn_info:
+        path = prm.plan(start, goal)
+        assert len(path.poses) == 0
+    assert warn_info[0].message.args[0] == "Could not find a path from start to goal."
+
+
+def test_rrt_grid_not_supported():
+    """Test that PRM is not (yet) supported with occupancy grid maps."""
+    world = WorldYamlLoader().from_yaml(
+        os.path.join(get_data_folder(), "test_world.yaml")
+    )
+    robot = world.robots[0]
+    planner_config = {
+        "grid": OccupancyGrid.from_world(
+            world, resolution=0.05, inflation_radius=1.5 * robot.radius
+        ),
+    }
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        PathPlanner("prm", **planner_config)
+    assert exc_info.value.args[0] == "PRM planner does not support grid based search."

--- a/test/navigation/test_rrt.py
+++ b/test/navigation/test_rrt.py
@@ -3,9 +3,11 @@
 """Unit tests for the RRT planner"""
 
 import os
+import numpy as np
+import pytest
 
 from pyrobosim.core import WorldYamlLoader
-from pyrobosim.navigation import PathPlanner
+from pyrobosim.navigation import OccupancyGrid, PathPlanner
 from pyrobosim.utils.general import get_data_folder
 from pyrobosim.utils.pose import Pose
 
@@ -50,3 +52,130 @@ def test_rrt_short_distance_connect():
     assert len(path.poses) == 2
     assert path.poses[0] == start
     assert path.poses[1] == goal
+
+
+def test_rrt_no_path():
+    """Test that RRT gracefully returns when there is no feasible path."""
+    world = WorldYamlLoader().from_yaml(
+        os.path.join(get_data_folder(), "test_world.yaml")
+    )
+    planner_config = {
+        "world": world,
+        "max_time": 0.5,  # To make the test fail more quickly.
+    }
+
+    rrt = PathPlanner("rrt", **planner_config)
+    start = Pose(x=-1.6, y=2.8)
+    goal = Pose(x=12.5, y=3.0)
+
+    with pytest.warns(UserWarning) as warn_info:
+        path = rrt.plan(start, goal)
+        assert len(path.poses) == 0
+    assert warn_info[0].message.args[0] == "Could not find a path from start to goal."
+
+
+def test_rrt_bidirectional():
+    """Tests bidirectional RRT planning."""
+    world = WorldYamlLoader().from_yaml(
+        os.path.join(get_data_folder(), "test_world.yaml")
+    )
+    planner_config = {
+        "world": world,
+        "bidirectional": True,
+        "rrt_connect": False,
+        "rrt_star": False,
+    }
+    rrt = PathPlanner("rrt", **planner_config)
+    start = Pose(x=-1.6, y=2.8)
+    goal = Pose(x=2.5, y=3.0)
+
+    path = rrt.plan(start, goal)
+    assert len(path.poses) >= 2
+    assert path.poses[0] == start
+    assert path.poses[-1] == goal
+
+
+def test_rrt_connect():
+    """Tests RRTConnect planning."""
+    world = WorldYamlLoader().from_yaml(
+        os.path.join(get_data_folder(), "test_world.yaml")
+    )
+    planner_config = {
+        "world": world,
+        "bidirectional": False,
+        "rrt_connect": True,
+        "rrt_star": False,
+    }
+    rrt = PathPlanner("rrt", **planner_config)
+    start = Pose(x=-1.6, y=2.8)
+    goal = Pose(x=2.5, y=3.0)
+
+    path = rrt.plan(start, goal)
+    assert len(path.poses) >= 2
+    assert path.poses[0] == start
+    assert path.poses[-1] == goal
+
+
+def test_rrt_star():
+    """Tests RRT* planning."""
+    world = WorldYamlLoader().from_yaml(
+        os.path.join(get_data_folder(), "test_world.yaml")
+    )
+    planner_config = {
+        "world": world,
+        "bidirectional": False,
+        "rrt_connect": False,
+        "rrt_star": True,
+    }
+    rrt = PathPlanner("rrt", **planner_config)
+    start = Pose(x=-1.6, y=2.8)
+    goal = Pose(x=2.5, y=3.0)
+
+    path = rrt.plan(start, goal)
+    assert len(path.poses) >= 2
+    assert path.poses[0] == start
+    assert path.poses[-1] == goal
+
+
+def test_rrt_grid_not_supported():
+    """Test that RRT is not (yet) supported with occupancy grid maps."""
+    world = WorldYamlLoader().from_yaml(
+        os.path.join(get_data_folder(), "test_world.yaml")
+    )
+    robot = world.robots[0]
+    planner_config = {
+        "grid": OccupancyGrid.from_world(
+            world, resolution=0.05, inflation_radius=1.5 * robot.radius
+        ),
+    }
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        PathPlanner("rrt", **planner_config)
+    assert exc_info.value.args[0] == "RRT planner does not support grid based search."
+
+
+def test_rrt_compress_path():
+    """Tests planning with path compression option."""
+    world = WorldYamlLoader().from_yaml(
+        os.path.join(get_data_folder(), "test_world.yaml")
+    )
+    planner_config = {
+        "world": world,
+        "bidirectional": False,
+        "rrt_connect": False,
+        "rrt_star": False,
+        "compress_path": False,
+    }
+    rrt = PathPlanner("rrt", **planner_config)
+    start = Pose(x=-0.3, y=0.6)
+    goal = Pose(x=2.5, y=3.0)
+
+    np.random.seed(1234)  # Use same seed for reproducibility
+    orig_path = rrt.plan(start, goal)
+    assert len(orig_path.poses) >= 2
+
+    np.random.seed(1234)  # Use same seed for reproducibility
+    rrt.planner.impl.compress_path = True
+    new_path = rrt.plan(start, goal)
+    assert len(new_path.poses) >= 2
+    assert new_path.length < orig_path.length


### PR DESCRIPTION
Added tests for PRM and RRT planner, fixing a few small things along the way.

Notably, I found a very easy speedup to the PRM generation by not doing all the neighbor connection AFTER sampling; rather, doing it during sampling. Silly me.

Closes https://github.com/sea-bass/pyrobosim/issues/188