### PR TITLE
Add hallway open and close capabilities

### DIFF
--- a/docs/source/usage/robot_actions.rst
+++ b/docs/source/usage/robot_actions.rst
@@ -8,6 +8,8 @@ The actions currently supported are:
 * **Pick**: Picks up an object at the robot's current location.
 * **Place**: Places an object at the robot's current location.
 * **Detect**: Detects objects at the robot's current location. Refer to :ref:`partial_observability` for more details.
+* **Open**: Opens the robot's current location (currently, hallways are supported).
+* **Close**: Closes the robot's current location (currently, hallways are supported).
 
 Actions can be triggered in a variety of ways:
 

--- a/pyrobosim/pyrobosim/core/hallway.py
+++ b/pyrobosim/pyrobosim/core/hallway.py
@@ -247,4 +247,11 @@ class Hallway:
 
     def __repr__(self):
         """Returns printable string."""
-        return f"Hallway: Connecting {self.room_start.name} and {self.room_end.name}"
+        return f"Hallway: {self.name}"
+
+    def print_details(self):
+        """Prints string with details."""
+        open_str = "open" if self.is_open else "closed"
+        print(
+            f"Hallway: Connecting {self.room_start.name} and {self.room_end.name} ({open_str})"
+        )

--- a/pyrobosim/pyrobosim/core/hallway.py
+++ b/pyrobosim/pyrobosim/core/hallway.py
@@ -165,8 +165,8 @@ class Hallway:
         """
         Returns a patch of the hallway polygon to display when it is closed.
 
-        :param color: The color tuple to use for visualizing.
-        :type color: tuple[int, int, int], optional
+        :return: Polygon patch of the closed polygon.
+        :rtype: :class:`matplotlib.patches.PathPatch`
         """
         return patch_from_polygon(
             self.closed_polygon,
@@ -181,8 +181,8 @@ class Hallway:
         """
         Returns a patch of the collision polygon for debug visualization.
 
-        :param color: The color tuple to use for visualizing.
-        :type color: tuple[int, int, int], optional
+        :return: Polygon patch of the collision polygon.
+        :rtype: :class:`matplotlib.patches.PathPatch`
         """
         return patch_from_polygon(
             self.internal_collision_polygon,

--- a/pyrobosim/pyrobosim/core/hallway.py
+++ b/pyrobosim/pyrobosim/core/hallway.py
@@ -25,6 +25,7 @@ class Hallway:
         color=[0.4, 0.4, 0.4],
         wall_width=0.2,
         is_open=True,
+        is_locked=False,
     ):
         """
         Creates a Hallway instance between two rooms.
@@ -56,6 +57,8 @@ class Hallway:
         :type wall_width: float, optional
         :param is_open: If True, the hallway is open, otherwise it is closed.
         :type is_open: bool, optional
+        :param is_locked: If True, the hallway is locked, meaning it cannot be opened or closed.
+        :type is_locked: bool, optional
         """
         # Validate input
         if room_start is None:
@@ -75,6 +78,7 @@ class Hallway:
         self.viz_color = color
         self.graph_nodes = []
         self.is_open = is_open
+        self.is_locked = is_locked
 
         # Parse the connection method
         # If the connection is "auto" or "angle", the hallway is a simple rectangle
@@ -252,6 +256,8 @@ class Hallway:
     def print_details(self):
         """Prints string with details."""
         open_str = "open" if self.is_open else "closed"
+        locked_str = "locked" if self.is_locked else "unlocked"
         print(
-            f"Hallway: Connecting {self.room_start.name} and {self.room_end.name} ({open_str})"
+            f"Hallway: Connecting {self.room_start.name} and {self.room_end.name} "
+            + f"({open_str}, {locked_str})"
         )

--- a/pyrobosim/pyrobosim/core/hallway.py
+++ b/pyrobosim/pyrobosim/core/hallway.py
@@ -62,11 +62,11 @@ class Hallway:
         """
         # Validate input
         if room_start is None:
-            raise Exception("room_start must be a valid Room object.")
+            raise ValueError("room_start must be a valid Room object.")
         if room_end is None:
-            raise Exception("room_end must be a valid Room object.")
+            raise ValueError("room_end must be a valid Room object.")
         if width <= 0.0:
-            raise Exception("width must be a positive value.")
+            raise ValueError("width must be a positive value.")
 
         # Unpack input
         self.room_start = room_start
@@ -101,7 +101,7 @@ class Hallway:
             self.points = conn_points
 
         else:
-            raise Exception(f"No valid connection method: {conn_method}")
+            raise ValueError(f"No valid connection method: {conn_method}.")
 
         # Create the hallway polygon
         self.polygon = LineString(self.points)

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -6,6 +6,7 @@ import numpy as np
 import warnings
 
 from .dynamics import RobotDynamics2D
+from .hallway import Hallway
 from .locations import ObjectSpawn
 from .objects import Object
 from ..manipulation.grasping import Grasp
@@ -207,6 +208,15 @@ class Robot:
 
         return self.world.objects
 
+    def at_openable_location(self):
+        """
+        Checks whether the robot is at an openable location.
+
+        :return: True if the robot is at an openable location, else False.
+        :type: bool
+        """
+        return isinstance(self.location, Hallway)
+
     def follow_path(
         self,
         path,
@@ -283,7 +293,7 @@ class Robot:
         :type obj_query: str
         :param grasp_pose: A pose describing how to manipulate the object.
         :type grasp_pose: :class:`pyrobosim.utils.pose.Pose`, optional
-        :return: True if picking succeeds, else False
+        :return: True if picking succeeds, else False.
         :rtype: bool
         """
         # Validate input
@@ -363,7 +373,7 @@ class Robot:
 
         :param pose: Placement pose (if not specified, will be sampled).
         :type pose: :class:`pyrobosim.utils.pose.Pose`, optional
-        :return: True if placement succeeds, else False
+        :return: True if placement succeeds, else False.
         :rtype: bool
         """
         # Validate input
@@ -427,7 +437,8 @@ class Robot:
         :param target_object: The name of a target object or category.
             If None, the action succeeds regardless of which object is found.
             Otherwise, the action succeeds only if the target object is found.
-        :return: True if detection succeeds, else False
+        :type target_object: str
+        :return: True if detection succeeds, else False.
         :rtype: bool
         """
         self.last_detected_objects = []
@@ -452,6 +463,42 @@ class Robot:
                 if obj.name == target_object or obj.category == target_object
             ]
             return len(self.last_detected_objects) > 0
+
+    def open_location(self):
+        """
+        Opens the robot's current location, if available.
+
+        :return: True if opening the location succeeds, else False.
+        :rtype: bool
+        """
+        if self.location is None:
+            warnings.warn("Robot location is not set. Cannot open.")
+            return False
+
+        if self.at_openable_location() and not self.location.is_open:
+            self.location.is_open = True
+            return True
+
+        warnings.warn("Robot is not at an openable location.")
+        return False
+
+    def close_location(self):
+        """
+        Closes the robot's current location, if available.
+
+        :return: True if closing the location succeeds, else False.
+        :rtype: bool
+        """
+        if self.location is None:
+            warnings.warn("Robot location is not set. Cannot close.")
+            return False
+
+        if self.at_openable_location() and self.location.is_open:
+            self.location.is_open = False
+            return True
+
+        warnings.warn("Robot is not at a closeable location.")
+        return False
 
     def execute_action(self, action, blocking=False):
         """
@@ -521,6 +568,18 @@ class Robot:
                 success = self.world.gui.canvas.detect_objects(self, action.object)
             else:
                 success = self.detect_objects(action.object)
+
+        elif action.type == "open":
+            if self.world.has_gui:
+                success = self.world.gui.canvas.open_location(self)
+            else:
+                success = self.open_location()
+
+        elif action.type == "close":
+            if self.world.has_gui:
+                success = self.world.gui.canvas.close_location(self)
+            else:
+                success = self.close_location()
 
         else:
             print(f"[{self.name}] Invalid action type: {action.type}")

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -475,12 +475,20 @@ class Robot:
             warnings.warn("Robot location is not set. Cannot open.")
             return False
 
-        if self.at_openable_location() and not self.location.is_open:
-            self.location.is_open = True
-            return True
+        if self.manipulated_object is not None:
+            warnings.warn("Robot is holding an object. Cannot open.")
+            return False
 
-        warnings.warn("Robot is not at an openable location.")
-        return False
+        if not self.at_openable_location():
+            warnings.warn("Robot is not at an openable location.")
+            return False
+
+        if self.location.is_open:
+            warnings.warn(f"Location {self.location} is already open.")
+            return False
+
+        self.location.is_open = True
+        return True
 
     def close_location(self):
         """
@@ -493,12 +501,20 @@ class Robot:
             warnings.warn("Robot location is not set. Cannot close.")
             return False
 
-        if self.at_openable_location() and self.location.is_open:
-            self.location.is_open = False
-            return True
+        if self.manipulated_object is not None:
+            warnings.warn("Robot is holding an object. Cannot close.")
+            return False
 
-        warnings.warn("Robot is not at a closeable location.")
-        return False
+        if not self.at_openable_location():
+            warnings.warn("Robot is not at a closeable location.")
+            return False
+
+        if not self.location.is_open:
+            warnings.warn(f"Location {self.location} is already closed.")
+            return False
+
+        self.location.is_open = False
+        return True
 
     def execute_action(self, action, blocking=False):
         """

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -483,12 +483,11 @@ class Robot:
             warnings.warn("Robot is not at an openable location.")
             return False
 
-        if self.location.is_open:
-            warnings.warn(f"Location {self.location} is already open.")
-            return False
+        if isinstance(self.location, Hallway):
+            return self.world.open_hallway(self.location)
 
-        self.location.is_open = True
-        return True
+        # This should not happen
+        return False
 
     def close_location(self):
         """
@@ -509,12 +508,11 @@ class Robot:
             warnings.warn("Robot is not at a closeable location.")
             return False
 
-        if not self.location.is_open:
-            warnings.warn(f"Location {self.location} is already closed.")
-            return False
+        if isinstance(self.location, Hallway):
+            return self.world.close_hallway(self.location)
 
-        self.location.is_open = False
-        return True
+        # This should not happen
+        return False
 
     def execute_action(self, action, blocking=False):
         """

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -378,7 +378,7 @@ class Robot:
         """
         # Validate input
         if self.manipulated_object is None:
-            warnings.warn("No manipulated object.")
+            warnings.warn("No manipulated object. Cannot place.")
             return False
 
         # Validate the robot location
@@ -596,7 +596,7 @@ class Robot:
                 success = self.close_location()
 
         else:
-            print(f"[{self.name}] Invalid action type: {action.type}")
+            warnings.warn(f"[{self.name}] Invalid action type: {action.type}.")
             success = False
 
         if self.world.has_gui:
@@ -620,7 +620,7 @@ class Robot:
         :rtype: tuple(bool, int)
         """
         if plan is None:
-            print(f"[{self.name}] Plan is None. Returning.")
+            warnings.warn(f"[{self.name}] Plan is None. Returning.")
             return False
 
         self.executing_plan = True

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -308,6 +308,7 @@ class World:
         hallway.is_open = True
         if self.has_gui:
             self.gui.canvas.show_hallways()
+            self.gui.canvas.draw_and_sleep()
         return True
 
     def close_hallway(self, hallway):
@@ -335,6 +336,7 @@ class World:
         hallway.is_open = False
         if self.has_gui:
             self.gui.canvas.show_hallways()
+            self.gui.canvas.draw_and_sleep()
         return True
 
     def lock_hallway(self, hallway):

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -834,6 +834,35 @@ class World:
 
         return entity
 
+    def get_hallway_names(self):
+        """
+        Gets all hallway names.
+
+        :return: List of all hallway names.
+        :rtype: list[str]
+        """
+        return [hall.name for hall in self.hallways]
+
+    def get_hallway_by_name(self, name):
+        """
+        Gets a hallway object by its name.
+
+        :param name: Name of hallway.
+        :type name: str
+        :return: Hallway instance matching the input name, or ``None`` if not valid.
+        :rtype: :class:`pyrobosim.core.hallway.Hallway`
+        """
+        if name not in self.name_to_entity:
+            warnings.warn(f"Hallway not found: {name}")
+            return None
+
+        entity = self.name_to_entity[name]
+        if not isinstance(entity, Hallway):
+            warnings.warn(f"Entity {name} found but it is not a Hallway.")
+            return None
+
+        return entity
+
     def get_hallways_from_rooms(self, room1, room2):
         """
         Returns a list of hallways between two rooms.
@@ -1218,12 +1247,10 @@ class World:
         else:
             entity = entity_query
 
-        if (
-            isinstance(entity, ObjectSpawn)
-            or isinstance(entity, Room)
-            or isinstance(entity, Hallway)
-        ):
+        if isinstance(entity, ObjectSpawn) or isinstance(entity, Room):
             graph_nodes = entity.graph_nodes
+        elif isinstance(entity, Hallway):
+            graph_nodes = [entity.graph_nodes[0], entity.graph_nodes[-1]]
         elif isinstance(entity, Object):
             graph_nodes = entity.parent.graph_nodes
         elif isinstance(entity, Location):

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -263,7 +263,7 @@ class World:
         """
         Removes a hallway between two rooms.
 
-        :param hallway: Hallway object remove.
+        :param hallway: Hallway object to remove.
         :type hallway: :class:`pyrobosim.core.hallway.Hallway`
         :return: True if the hallway was successfully removed, else False.
         :rtype: bool
@@ -281,6 +281,102 @@ class World:
             room.update_collision_polygons()
             room.update_visualization_polygon()
             self.update_bounds(entity=hallway, remove=True)
+        return True
+
+    def open_hallway(self, hallway):
+        """
+        Opens a hallway between two rooms.
+
+        :param hallway: Hallway object to open.
+        :type hallway: :class:`pyrobosim.core.hallway.Hallway`
+        :return: True if the hallway was successfully opened, else False.
+        :rtype: bool
+        """
+        # Validate the input
+        if not hallway in self.hallways:
+            warnings.warn("Invalid hallway specified.")
+            return False
+
+        if hallway.is_open:
+            warnings.warn(f"{hallway} is already open.")
+            return False
+
+        if hallway.is_locked:
+            warnings.warn(f"{hallway} is locked.")
+            return False
+
+        hallway.is_open = True
+        if self.has_gui:
+            self.gui.canvas.show_hallways()
+        return True
+
+    def close_hallway(self, hallway):
+        """
+        Close a hallway between two rooms.
+
+        :param hallway: Hallway object to close.
+        :type hallway: :class:`pyrobosim.core.hallway.Hallway`
+        :return: True if the hallway was successfully closed, else False.
+        :rtype: bool
+        """
+        # Validate the input
+        if not hallway in self.hallways:
+            warnings.warn("Invalid hallway specified.")
+            return False
+
+        if not hallway.is_open:
+            warnings.warn(f"{hallway} is already closed.")
+            return False
+
+        if hallway.is_locked:
+            warnings.warn(f"{hallway} is locked.")
+            return False
+
+        hallway.is_open = False
+        if self.has_gui:
+            self.gui.canvas.show_hallways()
+        return True
+
+    def lock_hallway(self, hallway):
+        """
+        Locks a hallway between two rooms.
+
+        :param hallway: Hallway object to lock.
+        :type hallway: :class:`pyrobosim.core.hallway.Hallway`
+        :return: True if the hallway was successfully locked, else False.
+        :rtype: bool
+        """
+        # Validate the input
+        if not hallway in self.hallways:
+            warnings.warn("Invalid hallway specified.")
+            return False
+
+        if hallway.is_locked:
+            warnings.warn(f"{hallway} is already locked.")
+            return False
+
+        hallway.is_locked = True
+        return True
+
+    def unlock_hallway(self, hallway):
+        """
+        Unlocks a hallway between two rooms.
+
+        :param hallway: Hallway object to unlock.
+        :type hallway: :class:`pyrobosim.core.hallway.Hallway`
+        :return: True if the hallway was successfully unlocked, else False.
+        :rtype: bool
+        """
+        # Validate the input
+        if not hallway in self.hallways:
+            warnings.warn("Invalid hallway specified.")
+            return False
+
+        if not hallway.is_locked:
+            warnings.warn(f"{hallway} is already unlocked.")
+            return False
+
+        hallway.is_locked = False
         return True
 
     def add_location(self, **location_config):

--- a/pyrobosim/pyrobosim/data/pddlstream_simple_world.yaml
+++ b/pyrobosim/pyrobosim/data/pddlstream_simple_world.yaml
@@ -84,6 +84,7 @@ hallways:
     room_end: bathroom
     width: 0.7
     conn_method: auto
+    is_open: True
 
   - room_start: bathroom
     room_end: bedroom
@@ -91,6 +92,7 @@ hallways:
     conn_method: angle
     conn_angle: 0.0
     offset: 0.8
+    is_open: True
 
   - room_start: kitchen
     room_end: bedroom
@@ -100,6 +102,7 @@ hallways:
       - [1.0, 0.5]
       - [2.5, 0.5]
       - [2.5, 3.0]
+    is_open: True
 
 
 # LOCATIONS: Can contain objects

--- a/pyrobosim/pyrobosim/data/pddlstream_simple_world.yaml
+++ b/pyrobosim/pyrobosim/data/pddlstream_simple_world.yaml
@@ -85,6 +85,7 @@ hallways:
     width: 0.7
     conn_method: auto
     is_open: True
+    is_locked: False
 
   - room_start: bathroom
     room_end: bedroom
@@ -93,6 +94,7 @@ hallways:
     conn_angle: 0.0
     offset: 0.8
     is_open: True
+    is_locked: False
 
   - room_start: kitchen
     room_end: bedroom
@@ -103,6 +105,7 @@ hallways:
       - [2.5, 0.5]
       - [2.5, 3.0]
     is_open: True
+    is_locked: False
 
 
 # LOCATIONS: Can contain objects

--- a/pyrobosim/pyrobosim/data/test_world.yaml
+++ b/pyrobosim/pyrobosim/data/test_world.yaml
@@ -93,6 +93,7 @@ hallways:
     room_end: bathroom
     width: 0.7
     conn_method: auto
+    is_open: True
 
   - room_start: bathroom
     room_end: bedroom
@@ -100,6 +101,7 @@ hallways:
     conn_method: angle
     conn_angle: 0.0
     offset: 0.8
+    is_open: True
 
   - room_start: kitchen
     room_end: bedroom
@@ -109,6 +111,7 @@ hallways:
       - [1.0, 0.5]
       - [2.5, 0.5]
       - [2.5, 3.0]
+    is_open: True
 
 
 # LOCATIONS: Can contain objects

--- a/pyrobosim/pyrobosim/data/test_world.yaml
+++ b/pyrobosim/pyrobosim/data/test_world.yaml
@@ -94,6 +94,7 @@ hallways:
     width: 0.7
     conn_method: auto
     is_open: True
+    is_locked: False
 
   - room_start: bathroom
     room_end: bedroom
@@ -102,6 +103,7 @@ hallways:
     conn_angle: 0.0
     offset: 0.8
     is_open: True
+    is_locked: False
 
   - room_start: kitchen
     room_end: bedroom
@@ -112,6 +114,7 @@ hallways:
       - [2.5, 0.5]
       - [2.5, 3.0]
     is_open: True
+    is_locked: False
 
 
 # LOCATIONS: Can contain objects

--- a/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
+++ b/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
@@ -108,6 +108,7 @@ hallways:
     width: 0.7
     conn_method: auto
     is_open: True
+    is_locked: False
 
   - room_start: bathroom
     room_end: bedroom
@@ -116,6 +117,7 @@ hallways:
     conn_angle: 0.0
     offset: 0.8
     is_open: True
+    is_locked: False
 
   - room_start: kitchen
     room_end: bedroom
@@ -126,6 +128,7 @@ hallways:
       - [2.5, 0.5]
       - [2.5, 3.0]
     is_open: True
+    is_locked: False
 
 
 # LOCATIONS: Can contain objects

--- a/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
+++ b/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
@@ -107,6 +107,7 @@ hallways:
     room_end: bathroom
     width: 0.7
     conn_method: auto
+    is_open: True
 
   - room_start: bathroom
     room_end: bedroom
@@ -114,6 +115,7 @@ hallways:
     conn_method: angle
     conn_angle: 0.0
     offset: 0.8
+    is_open: True
 
   - room_start: kitchen
     room_end: bedroom
@@ -123,6 +125,7 @@ hallways:
       - [1.0, 0.5]
       - [2.5, 0.5]
       - [2.5, 3.0]
+    is_open: True
 
 
 # LOCATIONS: Can contain objects

--- a/pyrobosim/pyrobosim/gui/main.py
+++ b/pyrobosim/pyrobosim/gui/main.py
@@ -190,18 +190,14 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):
         if robot:
             at_object_spawn = robot.at_object_spawn()
             can_pick = robot.manipulated_object is None
-            at_openable_location = robot.at_openable_location()
+            can_open_close = robot.at_openable_location() and can_pick
 
             self.nav_button.setEnabled(not robot.is_moving())
             self.pick_button.setEnabled(can_pick and at_object_spawn)
             self.place_button.setEnabled((not can_pick) and at_object_spawn)
             self.detect_button.setEnabled(at_object_spawn)
-            self.open_button.setEnabled(
-                at_openable_location and not robot.location.is_open
-            )
-            self.close_button.setEnabled(
-                at_openable_location and robot.location.is_open
-            )
+            self.open_button.setEnabled(can_open_close and not robot.location.is_open)
+            self.close_button.setEnabled(can_open_close and robot.location.is_open)
 
             self.canvas.show_world_state(robot, navigating=False)
         else:

--- a/pyrobosim/pyrobosim/gui/main.py
+++ b/pyrobosim/pyrobosim/gui/main.py
@@ -154,10 +154,10 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):
         self.detect_button.clicked.connect(self.on_detect_click)
         self.action_layout.addWidget(self.detect_button, 1, 0)
         self.open_button = QtWidgets.QPushButton("Open")
-        self.open_button.setEnabled(False)  # TODO: Add functionality
+        self.open_button.clicked.connect(self.on_open_click)
         self.action_layout.addWidget(self.open_button, 1, 1)
         self.close_button = QtWidgets.QPushButton("Close")
-        self.close_button.setEnabled(False)  # TODO: Add functionality
+        self.close_button.clicked.connect(self.on_close_click)
         self.action_layout.addWidget(self.close_button, 1, 2)
 
         # World layout (Matplotlib affordances)
@@ -190,11 +190,18 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):
         if robot:
             at_object_spawn = robot.at_object_spawn()
             can_pick = robot.manipulated_object is None
+            at_openable_location = robot.at_openable_location()
 
             self.nav_button.setEnabled(not robot.is_moving())
             self.pick_button.setEnabled(can_pick and at_object_spawn)
             self.place_button.setEnabled((not can_pick) and at_object_spawn)
             self.detect_button.setEnabled(at_object_spawn)
+            self.open_button.setEnabled(
+                at_openable_location and not robot.location.is_open
+            )
+            self.close_button.setEnabled(
+                at_openable_location and robot.location.is_open
+            )
 
             self.canvas.show_world_state(robot, navigating=False)
         else:
@@ -239,7 +246,11 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):
 
     def rand_goal_cb(self):
         """Callback to randomize robot goal."""
-        all_entities = self.world.get_location_names() + self.world.get_room_names()
+        all_entities = (
+            self.world.get_location_names()
+            + self.world.get_hallway_names()
+            + self.world.get_room_names()
+        )
         entity_name = np.random.choice(all_entities)
         self.goal_textbox.setText(entity_name)
 
@@ -308,4 +319,20 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):
             print(f"[{robot.name}] Detecting objects")
             obj_query = self.goal_textbox.text() or None
             self.canvas.detect_objects(robot, obj_query)
+            self.update_button_state()
+
+    def on_open_click(self):
+        """Callback to open a location."""
+        robot = self.get_current_robot()
+        if robot and robot.location:
+            print(f"[{robot.name}] Opening {robot.location}")
+            self.canvas.open_location(robot)
+            self.update_button_state()
+
+    def on_close_click(self):
+        """Callback to close a location."""
+        robot = self.get_current_robot()
+        if robot and robot.location:
+            print(f"[{robot.name}] Closing {robot.location}")
+            self.canvas.close_location(robot)
             self.update_button_state()

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -366,19 +366,20 @@ class WorldCanvas(FigureCanvasQTAgg):
 
     def update_robots_plot(self):
         """Updates the robot visualization graphics objects."""
-        if len(self.world.robots) != len(self.robot_bodies):
-            self.show_robots()
-        for i, robot in enumerate(self.world.robots):
-            p = robot.get_pose()
-            self.robot_bodies[i].center = p.x, p.y
-            self.robot_dirs[i].set_xdata(
-                p.x + np.array([0, self.robot_lengths[i] * np.cos(p.get_yaw())])
-            )
-            self.robot_dirs[i].set_ydata(
-                p.y + np.array([0, self.robot_lengths[i] * np.sin(p.get_yaw())])
-            )
-            robot.viz_text.set_position((p.x, p.y - 2.0 * robot.radius))
-            self.update_object_plot(robot.manipulated_object)
+        with self.draw_lock:
+            if len(self.world.robots) != len(self.robot_bodies):
+                self.show_robots()
+            for i, robot in enumerate(self.world.robots):
+                p = robot.get_pose()
+                self.robot_bodies[i].center = p.x, p.y
+                self.robot_dirs[i].set_xdata(
+                    p.x + np.array([0, self.robot_lengths[i] * np.cos(p.get_yaw())])
+                )
+                self.robot_dirs[i].set_ydata(
+                    p.y + np.array([0, self.robot_lengths[i] * np.sin(p.get_yaw())])
+                )
+                robot.viz_text.set_position((p.x, p.y - 2.0 * robot.radius))
+                self.update_object_plot(robot.manipulated_object)
 
     def show_world_state(self, robot=None, navigating=False):
         """

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -75,7 +75,6 @@ class NavRunner(QRunnable):
 
         self.canvas.show_world_state(robot=robot)
         world.gui.update_button_state()
-        self.canvas.draw_and_sleep()
 
 
 class WorldCanvas(FigureCanvasQTAgg):
@@ -140,6 +139,7 @@ class WorldCanvas(FigureCanvasQTAgg):
         self.robot_lengths = []
         self.obj_patches = []
         self.obj_texts = []
+        self.hallway_patches = []
         self.path_planner_artists = {"graph": [], "path": []}
 
         # Debug displays (TODO: Should be available from GUI).
@@ -157,88 +157,103 @@ class WorldCanvas(FigureCanvasQTAgg):
 
     def show_robots(self):
         """Draws robots as circles with heading lines for visualization."""
-        self.draw_lock.acquire()
-        n_robots = len(self.world.robots)
-        for body in self.robot_bodies:
-            body.remove()
-        for dir in self.robot_dirs:
-            dir.remove()
-        self.robot_bodies = n_robots * [None]
-        self.robot_dirs = n_robots * [None]
-        self.robot_lengths = n_robots * [None]
+        with self.draw_lock:
+            n_robots = len(self.world.robots)
+            for body in self.robot_bodies:
+                body.remove()
+            for dir in self.robot_dirs:
+                dir.remove()
+            self.robot_bodies = n_robots * [None]
+            self.robot_dirs = n_robots * [None]
+            self.robot_lengths = n_robots * [None]
 
-        for i, robot in enumerate(self.world.robots):
-            p = robot.get_pose()
-            self.robot_bodies[i] = Circle(
-                (p.x, p.y),
-                radius=robot.radius,
-                edgecolor=robot.color,
-                fill=False,
-                linewidth=2,
-                zorder=self.robot_zorder,
-            )
-            self.axes.add_patch(self.robot_bodies[i])
+            for i, robot in enumerate(self.world.robots):
+                p = robot.get_pose()
+                self.robot_bodies[i] = Circle(
+                    (p.x, p.y),
+                    radius=robot.radius,
+                    edgecolor=robot.color,
+                    fill=False,
+                    linewidth=2,
+                    zorder=self.robot_zorder,
+                )
+                self.axes.add_patch(self.robot_bodies[i])
 
-            robot_length = self.robot_dir_line_factor * robot.radius
-            (self.robot_dirs[i],) = self.axes.plot(
-                p.x + np.array([0, robot_length * np.cos(p.get_yaw())]),
-                p.y + np.array([0, robot_length * np.sin(p.get_yaw())]),
-                linestyle="-",
-                color=robot.color,
-                linewidth=2,
-                zorder=self.robot_zorder,
-            )
-            self.robot_lengths[i] = robot_length
+                robot_length = self.robot_dir_line_factor * robot.radius
+                (self.robot_dirs[i],) = self.axes.plot(
+                    p.x + np.array([0, robot_length * np.cos(p.get_yaw())]),
+                    p.y + np.array([0, robot_length * np.sin(p.get_yaw())]),
+                    linestyle="-",
+                    color=robot.color,
+                    linewidth=2,
+                    zorder=self.robot_zorder,
+                )
+                self.robot_lengths[i] = robot_length
 
-            x = p.x
-            y = p.y - 2.0 * robot.radius
-            robot.viz_text = self.axes.text(
-                x,
-                y,
-                robot.name,
-                clip_on=True,
-                color=robot.color,
-                horizontalalignment="center",
-                verticalalignment="top",
-                fontsize=10,
-            )
-        self.robot_texts = [r.viz_text for r in (self.world.robots)]
-        self.draw_lock.release()
+                x = p.x
+                y = p.y - 2.0 * robot.radius
+                robot.viz_text = self.axes.text(
+                    x,
+                    y,
+                    robot.name,
+                    clip_on=True,
+                    color=robot.color,
+                    horizontalalignment="center",
+                    verticalalignment="top",
+                    fontsize=10,
+                )
+            self.robot_texts = [r.viz_text for r in (self.world.robots)]
+
+    def show_hallways(self):
+        """Draws hallways in the world."""
+        with self.draw_lock:
+            for hallway in self.hallway_patches:
+                hallway.remove()
+
+            self.hallway_patches = [h.viz_patch for h in self.world.hallways]
+
+            for h in self.world.hallways:
+                self.axes.add_patch(h.viz_patch)
+                if not h.is_open:
+                    closed_patch = h.get_closed_patch()
+                    self.axes.add_patch(closed_patch)
+                    self.hallway_patches.append(closed_patch)
+                elif self.show_collision_polygons:
+                    coll_patch = h.get_collision_patch()
+                    self.axes.add_patch(coll_patch)
+                    self.hallway_patches.append(coll_patch)
 
     def show_objects(self):
         """Draws objects and their associated texts."""
-        self.draw_lock.acquire()
+        with self.draw_lock:
+            for obj_patch in self.obj_patches:
+                obj_patch.remove()
+            for obj_text in self.obj_texts:
+                obj_text.remove()
+            self.obj_patches = []
+            self.obj_texts = []
 
-        for obj_patch in self.obj_patches:
-            obj_patch.remove()
-        for obj_text in self.obj_texts:
-            obj_text.remove()
-        self.obj_patches = []
-        self.obj_texts = []
+            robot = self.main_window.get_current_robot()
+            if robot:
+                known_objects = robot.get_known_objects()
+            else:
+                known_objects = self.world.objects
 
-        robot = self.main_window.get_current_robot()
-        if robot:
-            known_objects = robot.get_known_objects()
-        else:
-            known_objects = self.world.objects
+            for obj in known_objects:
+                self.axes.add_patch(obj.viz_patch)
+                xmin, ymin, xmax, ymax = obj.polygon.bounds
+                x = obj.pose.x + 1.0 * (xmax - xmin)
+                y = obj.pose.y + 1.0 * (ymax - ymin)
+                obj.viz_text = self.axes.text(
+                    x, y, obj.name, clip_on=True, color=obj.viz_color, fontsize=8
+                )
+            self.obj_patches = [o.viz_patch for o in known_objects]
+            self.obj_texts = [o.viz_text for o in known_objects]
 
-        for obj in known_objects:
-            self.axes.add_patch(obj.viz_patch)
-            xmin, ymin, xmax, ymax = obj.polygon.bounds
-            x = obj.pose.x + 1.0 * (xmax - xmin)
-            y = obj.pose.y + 1.0 * (ymax - ymin)
-            obj.viz_text = self.axes.text(
-                x, y, obj.name, clip_on=True, color=obj.viz_color, fontsize=8
+            # Adjust the text to try avoid collisions
+            adjustText.adjust_text(
+                self.obj_texts, iter_lim=100, objects=self.obj_patches, ax=self.axes
             )
-        self.obj_patches = [o.viz_patch for o in known_objects]
-        self.obj_texts = [o.viz_text for o in known_objects]
-
-        # Adjust the text to try avoid collisions
-        adjustText.adjust_text(
-            self.obj_texts, iter_lim=100, objects=self.obj_patches, ax=self.axes
-        )
-
-        self.draw_lock.release()
 
     def show(self):
         """
@@ -259,10 +274,7 @@ class WorldCanvas(FigureCanvasQTAgg):
             )
             if self.show_collision_polygons:
                 self.axes.add_patch(r.get_collision_patch())
-        for h in self.world.hallways:
-            self.axes.add_patch(h.viz_patch)
-            if self.show_collision_polygons:
-                self.axes.add_patch(h.get_collision_patch())
+        self.show_hallways()
 
         # Locations
         for loc in self.world.locations:
@@ -293,11 +305,10 @@ class WorldCanvas(FigureCanvasQTAgg):
 
     def draw_and_sleep(self):
         """Redraws the figure and waits a small amount of time."""
-        self.draw_lock.acquire()
-        self.fig.canvas.draw()
-        self.fig.canvas.flush_events()
-        time.sleep(0.005)
-        self.draw_lock.release()
+        with self.draw_lock:
+            self.fig.canvas.draw()
+            self.fig.canvas.flush_events()
+            time.sleep(0.01)
 
     def show_planner_and_path(self, robot=None, path=None):
         """
@@ -312,28 +323,27 @@ class WorldCanvas(FigureCanvasQTAgg):
         """
         # Since removing artists while drawing can cause issues,
         # this function should also lock drawing.
-        self.draw_lock.acquire()
+        with self.draw_lock:
+            if not robot:
+                warnings.warn("No robot found")
+            else:
+                color = robot.color if robot is not None else "m"
+                if robot.path_planner:
+                    path_planner_artists = robot.path_planner.plot(
+                        self.axes, path=path, path_color=color
+                    )
 
-        if not robot:
-            warnings.warn("No robot found")
-        else:
-            color = robot.color if robot is not None else "m"
-            if robot.path_planner:
-                path_planner_artists = robot.path_planner.plot(
-                    self.axes, path=path, path_color=color
-                )
+                    for artist in self.path_planner_artists["graph"]:
+                        artist.remove()
+                    self.path_planner_artists["graph"] = path_planner_artists.get(
+                        "graph", []
+                    )
 
-                for artist in self.path_planner_artists["graph"]:
-                    artist.remove()
-                self.path_planner_artists["graph"] = path_planner_artists.get(
-                    "graph", []
-                )
-
-                for artist in self.path_planner_artists["path"]:
-                    artist.remove()
-                self.path_planner_artists["path"] = path_planner_artists.get("path", [])
-
-        self.draw_lock.release()
+                    for artist in self.path_planner_artists["path"]:
+                        artist.remove()
+                    self.path_planner_artists["path"] = path_planner_artists.get(
+                        "path", []
+                    )
 
     def nav_animation_callback(self):
         """Timer callback function to animate navigating robots."""
@@ -444,7 +454,7 @@ class WorldCanvas(FigureCanvasQTAgg):
         :type obj_name: str
         :param grasp_pose: A pose describing how to manipulate the object.
         :type grasp_pose: :class:`pyrobosim.utils.pose.Pose`, optional
-        :return: True if picking succeeds, else False
+        :return: True if picking succeeds, else False.
         :rtype: bool
         """
         if robot is None:
@@ -465,7 +475,7 @@ class WorldCanvas(FigureCanvasQTAgg):
         :type robot: :class:`pyrobosim.core.robot.Robot`
         :param pose: Optional placement pose, defaults to None.
         :type pose: :class:`pyrobosim.utils.pose.Pose`, optional
-        :return: True if placing succeeds, else False
+        :return: True if placing succeeds, else False.
         :rtype: bool
         """
         if robot is None:
@@ -491,7 +501,7 @@ class WorldCanvas(FigureCanvasQTAgg):
         :type robot: :class:`pyrobosim.core.robot.Robot`
         :param query: Query for object detection.
         :type query: str, optional
-        :return: True if object detection succeeds, else False
+        :return: True if object detection succeeds, else False.
         :rtype: bool
         """
         if robot is None:
@@ -500,4 +510,40 @@ class WorldCanvas(FigureCanvasQTAgg):
         success = robot.detect_objects(query)
         self.show_objects()
         self.draw_and_sleep()
+        return success
+
+    def open_location(self, robot):
+        """
+        Opens the robot's current location, if available.
+
+        :param robot: Robot instance to execute action.
+        :type robot: :class:`pyrobosim.core.robot.Robot`
+        :return: True if opening the location succeeds, else False.
+        :rtype: bool
+        """
+        if robot is None:
+            return False
+
+        success = robot.open_location()
+        if success:
+            self.show_hallways()
+            self.draw_and_sleep()
+        return success
+
+    def close_location(self, robot):
+        """
+        Closes the robot's current location, if available.
+
+        :param robot: Robot instance to execute action.
+        :type robot: :class:`pyrobosim.core.robot.Robot`
+        :return: True if closing the location succeeds, else False.
+        :rtype: bool
+        """
+        if robot is None:
+            return False
+
+        success = robot.close_location()
+        if success:
+            self.show_hallways()
+            self.draw_and_sleep()
         return success

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -525,11 +525,7 @@ class WorldCanvas(FigureCanvasQTAgg):
         if robot is None:
             return False
 
-        success = robot.open_location()
-        if success:
-            self.show_hallways()
-            self.draw_and_sleep()
-        return success
+        return robot.open_location()
 
     def close_location(self, robot):
         """
@@ -543,8 +539,4 @@ class WorldCanvas(FigureCanvasQTAgg):
         if robot is None:
             return False
 
-        success = robot.close_location()
-        if success:
-            self.show_hallways()
-            self.draw_and_sleep()
-        return success
+        return robot.close_location()

--- a/pyrobosim/pyrobosim/navigation/rrt.py
+++ b/pyrobosim/pyrobosim/navigation/rrt.py
@@ -25,7 +25,7 @@ class RRTPlannerPolygon:
         collision_check_step_dist=0.025,
         max_connection_dist=0.25,
         max_nodes_sampled=1000,
-        max_time=5.0,
+        max_time=2.0,
         rewire_radius=1.0,
         compress_path=False,
     ):

--- a/pyrobosim/pyrobosim/planning/actions.py
+++ b/pyrobosim/pyrobosim/planning/actions.py
@@ -100,6 +100,15 @@ class TaskAction:
             act_str += "Detect"
             if self.object is not None:
                 act_str += f" {self.object}"
+        # OPEN / CLOSE
+        elif self.type == "open":
+            act_str += "Open"
+            if self.target_location is not None:
+                act_str += f" {self.target_location}"
+        elif self.type == "close":
+            act_str += "Close"
+            if self.target_location is not None:
+                act_str += f" {self.target_location}"
         else:
             print(f"Invalid action type {self.action_type}")
             return None

--- a/pyrobosim/pyrobosim/utils/knowledge.py
+++ b/pyrobosim/pyrobosim/utils/knowledge.py
@@ -98,6 +98,11 @@ def query_to_entity(world, query_list, mode, resolution_strategy="first", robot=
                 if elem == spawn.name:
                     named_location = spawn
                     resolved_queries.add(elem)
+        # Also search for hallway names
+        for hall in world.hallways:
+            if elem == hall.name:
+                named_location = hall
+                resolved_queries.add(elem)
         # Then, directly search for object names and get the location
         for obj in possible_objects:
             if elem == obj.name:

--- a/test/core/test_hallway.py
+++ b/test/core/test_hallway.py
@@ -4,50 +4,183 @@
 Tests for hallway creation in pyrobosim.
 """
 
+import pytest
+
 from pyrobosim.core import Hallway, World
 
 
 class TestHallway:
+    @pytest.fixture(autouse=True)
+    def create_test_world(self):
+        self.test_world = World()
+
+        coords_start = [(-1.0, -1.0), (1.0, -1.0), (1.0, 1.0), (-1.0, 1.0)]
+        self.room_start = self.test_world.add_room(
+            name="room_start", footprint=coords_start
+        )
+
+        coords_end = [(3.0, 5.0), (5.0, 3.0), (5.0, 5.0), (3.0, 5.0)]
+        self.room_end = self.test_world.add_room(name="room_end", footprint=coords_end)
+
     def test_add_hallway_to_world_from_object(self):
         """Test adding a hallway from a Hallway object."""
-        world = World()
 
-        coords_start = [(-1.0, -1.0), (1.0, -1.0), (1.0, 1.0), (-1.0, 1.0)]
-        room_start = world.add_room(name="room_start", footprint=coords_start)
-
-        coords_end = [(3.0, 5.0), (5.0, 3.0), (5.0, 5.0), (3.0, 5.0)]
-        room_end = world.add_room(name="room_end", footprint=coords_end)
-
-        hallway = Hallway(room_start=room_start, room_end=room_end, width=0.1)
-        result = world.add_hallway(hallway=hallway)
+        hallway = Hallway(room_start=self.room_start, room_end=self.room_end, width=0.1)
+        result = self.test_world.add_hallway(hallway=hallway)
         assert isinstance(result, Hallway)
-        assert world.num_hallways == 1
-        assert world.hallways[0].room_start == room_start
-        assert world.hallways[0].room_end == room_end
-        assert world.hallways[0].width == 0.1
+        assert self.test_world.num_hallways == 1
+        assert self.test_world.hallways[0].room_start == self.room_start
+        assert self.test_world.hallways[0].room_end == self.room_end
+        assert self.test_world.hallways[0].width == 0.1
 
     def test_add_hallway_to_world_from_args(self):
-        """Test adding a room from a list of named keyword arguments."""
-        world = World()
-
-        coords_start = [(-1.0, -1.0), (1.0, -1.0), (1.0, 1.0), (-1.0, 1.0)]
-        room_start = world.add_room(name="room_start", footprint=coords_start)
-
-        coords_end = [(3.0, 5.0), (5.0, 3.0), (5.0, 5.0), (3.0, 5.0)]
-        room_end = world.add_room(name="room_end", footprint=coords_end)
-
-        result = world.add_hallway(
-            room_start=room_start, room_end="room_end", width=0.1
+        """Test adding a hallway from a list of named keyword arguments."""
+        result = self.test_world.add_hallway(
+            room_start=self.room_start,
+            room_end="room_end",
+            width=0.1,
+            conn_method="points",
+            conn_points=[(0.0, 0.0), (2.0, 0.0), (4.0, 2.0), (4.0, 4.0)],
         )
         assert isinstance(result, Hallway)
-        assert world.num_hallways == 1
-        assert world.hallways[0].room_start == room_start
-        assert world.hallways[0].room_end == room_end
-        assert world.hallways[0].width == 0.1
+        assert self.test_world.num_hallways == 1
+        assert self.test_world.hallways[0].room_start == self.room_start
+        assert self.test_world.hallways[0].room_end == self.room_end
+        assert self.test_world.hallways[0].width == 0.1
 
+    def test_add_hallway_fail_validation(self):
+        """Test that all the hallway validation checks work."""
+        with pytest.warns(UserWarning) as warn_info:
+            with pytest.raises(ValueError) as exc_info:
+                self.test_world.add_hallway(
+                    room_start="bad_start_room", room_end="room_end", width=0.1
+                )
+        assert warn_info[0].message.args[0] == "Room not found: bad_start_room"
+        assert exc_info.value.args[0] == "room_start must be a valid Room object."
 
-if __name__ == "__main__":
-    t = TestHallway()
-    t.test_add_hallway_to_world_from_object()
-    t.test_add_hallway_to_world_from_args()
-    print("Tests passed!")
+        with pytest.warns(UserWarning) as warn_info:
+            with pytest.raises(ValueError) as exc_info:
+                self.test_world.add_hallway(
+                    room_start="room_start", room_end="bad_end_room", width=0.1
+                )
+        assert warn_info[0].message.args[0] == "Room not found: bad_end_room"
+        assert exc_info.value.args[0] == "room_end must be a valid Room object."
+
+        with pytest.raises(ValueError) as exc_info:
+            self.test_world.add_hallway(
+                room_start="room_start", room_end="room_end", width=0.0
+            )
+        assert exc_info.value.args[0] == "width must be a positive value."
+
+        with pytest.raises(ValueError) as exc_info:
+            self.test_world.add_hallway(
+                room_start="room_start",
+                room_end="room_end",
+                width=0.1,
+                conn_method="bad_conn_method",
+            )
+        assert exc_info.value.args[0] == "No valid connection method: bad_conn_method."
+
+    def test_add_hallway_open_close_lock_unlock(self):
+        """Test the open, close, lock, and unlock capabilities of hallways."""
+        result = self.test_world.add_hallway(
+            room_start="room_start",
+            room_end="room_end",
+            width=0.1,
+        )
+
+        assert isinstance(result, Hallway)
+        assert self.test_world.num_hallways == 1
+        hallway = self.test_world.hallways[0]
+        assert hallway.is_open
+        assert not hallway.is_locked
+
+        # When trying to open the hallway, it should say it's already open.
+        with pytest.warns(UserWarning) as warn_info:
+            result = self.test_world.open_hallway(hallway)
+        assert (
+            warn_info[0].message.args[0]
+            == "Hallway: hall_room_start_room_end is already open."
+        )
+        assert not result
+        assert hallway.is_open
+        assert not hallway.is_locked
+
+        # Closing should work
+        result = self.test_world.close_hallway(hallway)
+        assert result
+        assert not hallway.is_open
+        assert not hallway.is_locked
+
+        # Locking should work
+        result = self.test_world.lock_hallway(hallway)
+        assert result
+        assert not hallway.is_open
+        assert hallway.is_locked
+
+        # Opening should not work due to being locked
+        with pytest.warns(UserWarning) as warn_info:
+            result = self.test_world.open_hallway(hallway)
+        assert (
+            warn_info[0].message.args[0]
+            == "Hallway: hall_room_start_room_end is locked."
+        )
+        assert not result
+        assert not hallway.is_open
+        assert hallway.is_locked
+
+        # Closing should not work due to already being closed
+        with pytest.warns(UserWarning) as warn_info:
+            result = self.test_world.close_hallway(hallway)
+        assert (
+            warn_info[0].message.args[0]
+            == "Hallway: hall_room_start_room_end is already closed."
+        )
+        assert not result
+        assert not hallway.is_open
+        assert hallway.is_locked
+
+        # Locking should not work due to already being locked
+        with pytest.warns(UserWarning) as warn_info:
+            result = self.test_world.lock_hallway(hallway)
+        assert (
+            warn_info[0].message.args[0]
+            == "Hallway: hall_room_start_room_end is already locked."
+        )
+        assert not result
+        assert not hallway.is_open
+        assert hallway.is_locked
+
+        # Unlocking should work
+        result = self.test_world.unlock_hallway(hallway)
+        assert result
+        assert not hallway.is_open
+        assert not hallway.is_locked
+
+        # Unlocking should not work due to already being unlocked
+        with pytest.warns(UserWarning) as warn_info:
+            result = self.test_world.unlock_hallway(hallway)
+        assert (
+            warn_info[0].message.args[0]
+            == "Hallway: hall_room_start_room_end is already unlocked."
+        )
+        assert not result
+        assert not hallway.is_open
+        assert not hallway.is_locked
+
+        # Opening should work
+        result = self.test_world.open_hallway(hallway)
+        assert result
+        assert hallway.is_open
+        assert not hallway.is_locked
+
+        # Opening again should not work due to already being open
+        with pytest.warns(UserWarning) as warn_info:
+            result = self.test_world.open_hallway(hallway)
+        assert (
+            warn_info[0].message.args[0]
+            == "Hallway: hall_room_start_room_end is already open."
+        )
+        assert not result
+        assert hallway.is_open
+        assert not hallway.is_locked

--- a/test/utils/test_knowledge_utils.py
+++ b/test/utils/test_knowledge_utils.py
@@ -93,12 +93,25 @@ def test_apply_nearest_resolution_strategy():
 
 def test_query_to_entity():
     test_world = load_world()
+
+    # Query exactly named entities
+    entity = query_to_entity(test_world, ["apple0"], "object")
+    assert entity.name == "apple0"
+    entity = query_to_entity(test_world, ["table0"], "location")
+    assert entity.name == "table0"
+    entity = query_to_entity(test_world, ["kitchen"], "location")
+    assert entity.name == "kitchen"
+    entity = query_to_entity(test_world, ["my_desk_desktop"], "location")
+    assert entity.name == "my_desk_desktop"
+    entity = query_to_entity(test_world, ["hall_kitchen_bathroom"], "location")
+    assert entity.name == "hall_kitchen_bathroom"
+
+    # Query entities based on locations and categories
     query = "kitchen table apple"
     entity = query_to_entity(test_world, query.split(), "location")
     assert entity.name == "table0_tabletop"
     entity = query_to_entity(test_world, query.split(), "object")
     assert entity.name == "gala"
-
     query = "kitchen table"
     entity = query_to_entity(test_world, query.split(), "location")
     assert entity.name == "table0"


### PR DESCRIPTION
This PR adds the ability for a robot to open/close a hallway when navigating to its doorways (which is also a new feature).

You can also lock and unlock the hallway. When locked, open/close will not work so the robot's actions will fail.

Known limitations:
* Occupancy grid based planners like A* will still navigate through closed hallways unless the occupancy grid is explicitly regenerated.
* When the robot navigates to a hallway, it picks the closest endpoint by direct distance, which may lead to roundabout paths in certain cases.

![image](https://github.com/sea-bass/pyrobosim/assets/4603398/06049d03-f73e-4372-93c4-20644539e751)