### PR TITLE
Unify navigation code and automatically extract robot location

### DIFF
--- a/pyrobosim/pyrobosim/core/hallway.py
+++ b/pyrobosim/pyrobosim/core/hallway.py
@@ -77,6 +77,7 @@ class Hallway:
         self.offset = offset
         self.viz_color = color
         self.graph_nodes = []
+        self.nav_poses = []
         self.is_open = is_open
         self.is_locked = is_locked
 
@@ -248,6 +249,8 @@ class Hallway:
             (self.graph_nodes[-2].pose.x, self.graph_nodes[-2].pose.y),
         )
         self.graph_nodes[-1].pose.set_euler_angles(yaw=door_pose_end_yaw)
+
+        self.nav_poses = [self.graph_nodes[0].pose, self.graph_nodes[-1].pose]
 
     def __repr__(self):
         """Returns printable string."""

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -288,6 +288,7 @@ class Robot:
             return False
 
         if path.num_poses == 0:
+            self.last_nav_successful = True
             success = True
         elif use_thread:
             # Start a thread with the path execution
@@ -296,7 +297,7 @@ class Robot:
             )
             self.nav_thread.start()
             if blocking:
-                # Check that robot made it to its goal pose at the end of execution.
+                # Check that the robot made it to its goal pose at the end of execution.
                 self.nav_thread.join()
                 success = self.get_pose().is_approx(path.poses[-1])
             else:

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -136,23 +136,6 @@ class Robot:
         """
         self.path_planner = path_planner
 
-    def plan_path(self, start=None, goal=None):
-        """
-        Plans a path to a goal position.
-
-        :param start: Start pose for the robot.
-            If not specified, will default to the robot pose.
-        :type start: :class:`pyrobosim.utils.pose.Pose`, optional
-        :param goal: Goal pose for the robot. If not specified,returns None.
-        :type goal: :class:`pyrobosim.utils.pose.Pose`, optional
-        """
-        if start is None:
-            start = self.get_pose()
-        if goal is None:
-            warnings.warn("Did not specify a goal. Returning None.")
-            return None
-        return self.path_planner.plan(start, goal)
-
     def set_path_executor(self, path_executor):
         """
         Sets a path executor for navigation.
@@ -217,60 +200,6 @@ class Robot:
         """
         return isinstance(self.location, Hallway)
 
-    def follow_path(
-        self,
-        path,
-        target_location=None,
-        realtime_factor=1.0,
-        use_thread=True,
-        blocking=False,
-    ):
-        """
-        Follows a specified path using the attached path executor.
-
-        :param path: The path to follow.
-        :type path: :class:`pyrobosim.utils.motion.Path`
-        :param target_location: The target location at the intended goal,
-            used for tracking robot state.
-        :type target_location: Entity.
-        :param realtime_factor: A real-time multiplier on execution speed,
-            defaults to 1.0.
-        :type realtime_factor: float
-        :param use_thread: If True, spawns a new thread to execute the path.
-        :type use_thread: bool
-        :param blocking: If path executes in a new thread, set to True to block
-            and wait for the thread to complete before returning.
-        :return: True if path following is successful, or the path following
-            thread is successfully started.
-        :rtype: bool
-        """
-        if path is None or self.path_executor is None:
-            return
-
-        if use_thread:
-            # Start a thread with the path execution
-            self.nav_thread = threading.Thread(
-                target=self.path_executor.execute, args=(path, realtime_factor)
-            )
-            self.nav_thread.start()
-            if blocking:
-                self.nav_thread.join()
-
-                # Validate that the robot made it to its goal pose
-                if path.num_poses == 0:
-                    success = True
-                else:
-                    success = self.get_pose().is_approx(path.poses[-1])
-            else:
-                success = True
-        else:
-            success = self.path_executor.execute(path, realtime_factor)
-
-        # Update the robot state if successful.
-        if success and target_location is not None:
-            self.location = target_location
-        return success
-
     def _attach_object(self, obj):
         """
         Helper function to attach an object in the world to the robot.
@@ -284,6 +213,151 @@ class Robot:
         obj.parent.children.remove(obj)
         obj.parent = self
         obj.set_pose(self.get_pose())
+
+    def plan_path(self, start=None, goal=None):
+        """
+        Plans a path to a goal position.
+
+        :param start: Start pose for the robot.
+            If not specified, will default to the robot pose.
+        :type start: :class:`pyrobosim.utils.pose.Pose`, optional
+        :param goal: Goal pose or entity name for the robot.
+            If not specified, returns None.
+        :type goal: :class:`pyrobosim.utils.pose.Pose` / str, optional
+        :return: The path, if one was found, otherwise None.
+        :rtype: :class:`pyrobosim.utils.motion.Path` or None
+        """
+        if self.path_planner is None:
+            warnings.warn(f"No path planner attached to robot {self.name}.")
+            return None
+
+        if start is None:
+            start = self.get_pose()
+
+        if goal is None:
+            warnings.warn("Did not specify a goal. Returning None.")
+            return None
+
+        # If the goal is not a pose, we need to extract it from the world knowledge.
+        if not isinstance(goal, Pose):
+            if self.world is None:
+                warnings.warn("Cannot specify a string goal if there is no world set.")
+                return None
+            goal_node = self.world.graph_node_from_entity(goal, robot=self)
+            if goal_node is None:
+                return None
+            goal = goal_node.pose
+
+        path = self.path_planner.plan(start, goal)
+        if self.world and self.world.has_gui:
+            self.world.gui.canvas.show_planner_and_path(robot=self, path=path)
+        return path
+
+    def follow_path(
+        self,
+        path,
+        realtime_factor=1.0,
+        use_thread=True,
+        blocking=False,
+    ):
+        """
+        Follows a specified path using the attached path executor.
+
+        :param path: The path to follow.
+        :type path: :class:`pyrobosim.utils.motion.Path`
+        :param realtime_factor: A real-time multiplier on execution speed,
+            defaults to 1.0.
+        :type realtime_factor: float
+        :param use_thread: If True, spawns a new thread to execute the path.
+        :type use_thread: bool
+        :param blocking: If path executes in a new thread, set to True to block
+            and wait for the thread to complete before returning.
+        :return: True if path following is successful, or the path following
+            thread is successfully started.
+        :rtype: bool
+        """
+        self.last_nav_successful = False
+
+        if path is None:
+            warnings.warn("No path to execute.")
+            self.executing_nav = False
+            return False
+        if self.path_executor is None:
+            warnings.warn("No path executor. Cannot follow path.")
+            self.executing_nav = False
+            return False
+
+        if path.num_poses == 0:
+            success = True
+        elif use_thread:
+            # Start a thread with the path execution
+            self.nav_thread = threading.Thread(
+                target=self.path_executor.execute, args=(path, realtime_factor)
+            )
+            self.nav_thread.start()
+            if blocking:
+                # Check that robot made it to its goal pose at the end of execution.
+                self.nav_thread.join()
+                success = self.get_pose().is_approx(path.poses[-1])
+            else:
+                # Cannot check in the non-blocking case, so we just assume success.
+                success = True
+        else:
+            # Execute in this thread and check that the robot made it to its goal pose.
+            success = self.path_executor.execute(path, realtime_factor)
+            success |= self.get_pose().is_approx(path.poses[-1])
+
+        # Update the robot state if successful.
+        if self.world:
+            self.location = self.world.get_location_from_pose(self.get_pose())
+        self.last_nav_successful = success
+        return success
+
+    def navigate(
+        self,
+        start=None,
+        goal=None,
+        path=None,
+        realtime_factor=1.0,
+        use_thread=True,
+        blocking=False,
+    ):
+        """
+        Executes a navigation task, which combines path planning and following.
+
+        :param start: Start pose for the robot.
+            If not specified, will default to the robot pose.
+        :type start: :class:`pyrobosim.utils.pose.Pose`, optional
+        :param goal: Goal pose or entity name for the robot.
+            If not specified, returns None.
+        :type goal: :class:`pyrobosim.utils.pose.Pose` / str, optional
+        :param path: The path to follow.
+        :type path: :class:`pyrobosim.utils.motion.Path`
+        :param realtime_factor: A real-time multiplier on execution speed,
+            defaults to 1.0.
+        :type realtime_factor: float
+        :param use_thread: If True, spawns a new thread to execute the path.
+        :type use_thread: bool
+        :param blocking: If path executes in a new thread, set to True to block
+            and wait for the thread to complete before returning.
+        :return: True if path following is successful, or the path following
+            thread is successfully started.
+        :rtype: bool
+        """
+        if path is None:
+            path = self.plan_path(start, goal)
+            if path is None or path.num_poses == 0:
+                warnings.warn("Failed to plan a path.")
+                self.executing_nav = False
+                self.last_nav_successful = False
+                return False
+
+        return self.follow_path(
+            path,
+            realtime_factor=realtime_factor,
+            use_thread=use_thread,
+            blocking=blocking,
+        )
 
     def pick_object(self, obj_query, grasp_pose=None):
         """
@@ -533,35 +607,21 @@ class Robot:
 
         if action.type == "navigate":
             self.executing_nav = True
-            self.last_nav_successful = False
+            path = action.path if action.path.num_poses > 0 else None
             if self.world.has_gui:
-                if isinstance(action.target_location, str):
-                    tgt_loc = action.target_location
-                else:
-                    tgt_loc = action.target_location.name
-
-                self.world.gui.canvas.navigate(self, tgt_loc, action.path)
+                self.world.gui.canvas.navigate(self, action.target_location, path)
                 while self.executing_nav:
                     time.sleep(0.5)  # Delay to wait for navigation
                 success = self.last_nav_successful
             else:
-                goal_node = self.world.graph_node_from_entity(
-                    action.target_location, robot=self
+                success = self.navigate(
+                    goal=action.target_location,
+                    path=path,
+                    realtime_factor=1.0,
+                    use_thread=True,
+                    blocking=blocking,
                 )
-                path = self.plan_path(self.get_pose(), goal_node.pose)
-
-                if path.num_poses == 0:
-                    warnings.warn("Failed to plan a path.")
-                    self.executing_nav = False
-                    self.last_nav_successful = False
-                    success = False
-                else:
-                    success = self.follow_path(
-                        path,
-                        target_location=goal_node.parent,
-                        realtime_factor=1.0,
-                        blocking=blocking,
-                    )
+            self.executing_nav = False
 
         elif action.type == "pick":
             if self.world.has_gui:

--- a/pyrobosim/pyrobosim/gui/main.py
+++ b/pyrobosim/pyrobosim/gui/main.py
@@ -5,7 +5,6 @@ import signal
 import sys
 
 from PySide6 import QtWidgets
-from PySide6.QtCore import QTimer
 from PySide6.QtGui import QFont, QScreen
 from matplotlib.backends.qt_compat import QtCore
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT
@@ -22,13 +21,7 @@ def start_gui(world):
     :type world: :class:`pyrobosim.core.world.World`
     """
     app = PyRoboSimGUI(world, sys.argv)
-
-    signal.signal(signal.SIGINT, lambda *args: app.quit())
-
-    timer = QTimer(parent=app)
-    timer.timeout.connect(lambda: None)
-    timer.start(1000)
-
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
     sys.exit(app.exec_())
 
 

--- a/test/core/test_robot.py
+++ b/test/core/test_robot.py
@@ -100,7 +100,6 @@ class TestRobot:
         """Check that path executors can be used from a robot."""
         init_pose = Pose(x=1.0, y=0.5, yaw=0.0)
         goal_pose = Pose(x=2.5, y=3.0, yaw=np.pi / 2.0)
-        target_location = self.test_world.get_entity_by_name("bedroom")
 
         robot = Robot(
             pose=init_pose,
@@ -113,24 +112,18 @@ class TestRobot:
         # Non-threaded option -- blocks
         robot.set_pose(init_pose)
         path = robot.plan_path(goal=goal_pose)
-        result = robot.follow_path(
-            path, target_location=target_location, use_thread=False
-        )
+        result = robot.follow_path(path, use_thread=False)
         assert result
 
         # Threaded option with blocking
         robot.set_pose(init_pose)
         path = robot.plan_path(goal=goal_pose)
-        result = robot.follow_path(
-            path, target_location=target_location, use_thread=True, blocking=True
-        )
+        result = robot.follow_path(path, use_thread=True, blocking=True)
 
         # Threaded option without blocking -- must check result
         robot.set_pose(init_pose)
         path = robot.plan_path(goal=goal_pose)
-        robot.follow_path(
-            path, target_location=target_location, use_thread=True, blocking=False
-        )
+        robot.follow_path(path, use_thread=True, blocking=False)
         assert robot.executing_nav
         while robot.executing_nav:
             time.sleep(0.1)

--- a/test/system/test_system.py
+++ b/test/system/test_system.py
@@ -54,10 +54,11 @@ class TestSystem:
         window.on_navigate_click()
 
         while not robot.executing_nav:
-            time.sleep(0.1)
+            time.sleep(0.2)
         while robot.executing_nav:
-            time.sleep(0.1)
+            time.sleep(0.2)
 
+        print(f"Robot location: {robot.location}")
         assert (
             robot.location == expected_location
             or robot.location in expected_location.children

--- a/test/system/test_system_world.yaml
+++ b/test/system/test_system_world.yaml
@@ -84,6 +84,8 @@ hallways:
     room_end: bathroom
     width: 0.7
     conn_method: auto
+    is_open: true
+    is_locked: false
 
   - room_start: bathroom
     room_end: bedroom
@@ -91,6 +93,8 @@ hallways:
     conn_method: angle
     conn_angle: 0.0
     offset: 0.8
+    is_open: true
+    is_locked: false
 
   - room_start: kitchen
     room_end: bedroom
@@ -100,6 +104,8 @@ hallways:
       - [1.0, 0.5]
       - [2.5, 0.5]
       - [2.5, 3.0]
+    is_open: true
+    is_locked: false
 
 
 # LOCATIONS: Can contain objects


### PR DESCRIPTION
This PR reduces duplication in the nav code that existed in both the GUI and the robot. Now it's all delegated to the robot, which has a `navigate()` method that contains `find_path()` and `follow_path()`.

Additionally, the `target_location` argument of the nav functions is gone, meaning it does not need to be specified a priori; the `World.get_location_from_pose()` method has been extended to also extract object spawn and hallway information.

I also found a few other UI simplifications along the way...