### PR TITLE
Simulate delays and failures when executing actions

### DIFF
--- a/docs/source/usage/robot_actions.rst
+++ b/docs/source/usage/robot_actions.rst
@@ -1,10 +1,11 @@
 Robot Actions
 =============
+
 ``pyrobosim`` enables you to command your robot to take high-level actions.
 
 The actions currently supported are:
 
-* **Move**: Uses a path planner to navigate to a specific location. Refer to :ref:`path_planners` for more details.
+* **Navigate**: Uses a path planner to navigate to a specific location. Refer to :ref:`path_planners` for more details.
 * **Pick**: Picks up an object at the robot's current location.
 * **Place**: Places an object at the robot's current location.
 * **Detect**: Detects objects at the robot's current location. Refer to :ref:`partial_observability` for more details.
@@ -17,18 +18,102 @@ Actions can be triggered in a variety of ways:
 * Using a robot's ``execute_action()`` method.
 * (If using ROS), sending a goal to the ``/execute_action`` ROS action server.
 
+For example, a default action execution code block may look like this:
+
+.. code-block:: python
+
+    from pyrobosim.planning.actions import TaskAction
+
+    action = TaskAction(
+        "navigate",
+        source_location="kitchen",
+        target_location="my_desk",
+    )
+    robot.execute_action(action)
+
 You can also command a robot with a *plan*, which is a sequences of actions:
 
 * Using a robot's ``execute_plan()`` method.
 * (If using ROS), sending a goal to the ``/execute_task_plan`` ROS action server.
 
-Plans can also be automatically generated with :ref:`_task_and_motion_planning`.
+.. code-block:: python
+
+    from pyrobosim.planning.actions import TaskAction, TaskPlan
+
+    actions = [
+        TaskAction(
+            "navigate",
+            source_location="kitchen",
+            target_location="my_desk",
+        ),
+        TaskAction("detect", object="apple"),
+        TaskAction("pick", object="apple"),
+        TaskAction("place", "object", "apple"),
+        TaskAction(
+            "navigate",
+            source_location="my_desk",
+            target_location="hall_kitchen_bedroom",
+        ),
+        TaskAction("close", target_location="hall_kitchen_bedroom"),
+        TaskAction("open", target_location="hall_kitchen_bedroom"),
+    ]
+    plan = TaskPlan(actions=actions)
+    result, num_completed = robot.execute_plan(plan)
+
+Plans can also be automatically generated with :ref:`task_and_motion_planning`.
+
+The ROS 2 interface also supports sending actions and plans, with the ``pyrobosim_msgs.action.ExecuteTaskAction`` and ``pyrobosim.action.ExecuteTaskPlan`` actions, respectively.
+You can try it out with the following example.
+
+::
+
+    ros2 launch pyrobosim_ros demo_commands.launch.py mode:=action
+    ros2 launch pyrobosim_ros demo_commands.launch.py mode:=plan
+
+
+.. _simulating_action_execution:
+
+Simulating Action Execution
+---------------------------
+
+By default, all robots can execute their actions perfectly.
+However, actions can still fail due to planning errors or because they are infeasible (e.g, picking an object while holding another).
+
+You can use the action's *execution options* to modify the behavior of your robot to simulate delays or failures.
+For example,
+
+.. code-block:: python
+
+    from pyrobosim.planning.actions import ExecutionOptions, TaskAction
+
+    action = TaskAction(
+        "navigate",
+        source_location="kitchen",
+        target_location="my_desk",
+        execution_options=ExecutionOptions(
+            delay=0.1,
+            success_probability=0.5,
+            rng_seed=1234,
+        ),
+    )
+    robot.execute_action(action)
+
+Of particular interest is the ``rng_seed`` options which can be used to control determinism of simulated failures.
+If you leave this option at its default value (``None``), the failures will be nondeterministic, but explicitly setting the seed can provide reproducible action failure results.
+
+The ROS 2 interface to actions also supports execution options via the ``pyrobosim_msgs.msg.ActionExecutionOptions`` message, which is a field of the ``pyrobosim_msgs.msg.TaskAction`` message.
+You can show this
+
+::
+
+    ros2 launch pyrobosim_ros demo_commands.launch.py mode:=plan action_delay:=0.1 action_success_probablity:=0.5 action_rng_seed:=1234
 
 
 .. _partial_observability:
 
 Partial Observability
 ---------------------
+
 By default, all robots have full knowledge of all the objects in the world.
 
 A common use case for design robot behaviors is that a robot instead starts with limited or no knowledge of objects.

--- a/docs/source/usage/robot_actions.rst
+++ b/docs/source/usage/robot_actions.rst
@@ -102,11 +102,13 @@ Of particular interest is the ``rng_seed`` options which can be used to control 
 If you leave this option at its default value (``None``), the failures will be nondeterministic, but explicitly setting the seed can provide reproducible action failure results.
 
 The ROS 2 interface to actions also supports execution options via the ``pyrobosim_msgs.msg.ActionExecutionOptions`` message, which is a field of the ``pyrobosim_msgs.msg.TaskAction`` message.
-You can show this
+You can try this out by setting more launch parameters in the same example:
 
 ::
 
     ros2 launch pyrobosim_ros demo_commands.launch.py mode:=plan action_delay:=0.1 action_success_probablity:=0.5 action_rng_seed:=1234
+
+**NOTE:** These capabilities are not yet available from the GUI.
 
 
 .. _partial_observability:

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -96,12 +96,14 @@ class Robot:
         self.grasp_generator = grasp_generator
         self.last_grasp_selection = None
 
-        # World interaction properties
-        self.world = None
+        # Action execution options
         self.current_action = None
         self.executing_action = False
         self.current_plan = None
         self.executing_plan = False
+
+        # World interaction properties
+        self.world = None
         self.location = None
         self.manipulated_object = None
         self.partial_observability = partial_observability
@@ -606,7 +608,12 @@ class Robot:
         if self.world.has_gui:
             self.world.gui.set_buttons_during_action(False)
 
-        if action.type == "navigate":
+        # Simulate action-agnostic properties such as delays or failure probabilities.
+        if not action.should_succeed():
+            print("Simulated action failure.")
+            success = False
+
+        elif action.type == "navigate":
             self.executing_nav = True
             path = action.path if action.path.num_poses > 0 else None
             if self.world.has_gui:

--- a/pyrobosim/pyrobosim/planning/actions.py
+++ b/pyrobosim/pyrobosim/planning/actions.py
@@ -24,6 +24,7 @@ class ExecutionOptions:
         self.delay = delay
         self.success_probability = success_probability
         self.rng_seed = rng_seed
+        self.rng = np.random.default_rng(seed=rng_seed)
 
 
 class TaskAction:
@@ -89,8 +90,10 @@ class TaskAction:
         """
         if self.execution_options:
             time.sleep(self.execution_options.delay)
-            rng = np.random.default_rng(seed=self.execution_options.rng_seed)
-            return rng.random() <= self.execution_options.success_probability
+            return (
+                self.execution_options.rng.random()
+                <= self.execution_options.success_probability
+            )
         return True
 
     def __repr__(self):

--- a/pyrobosim_msgs/CMakeLists.txt
+++ b/pyrobosim_msgs/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(geometry_msgs REQUIRED)
 
 # Generate custom interfaces
 set(msg_files
+  "msg/ActionExecutionOptions.msg"
   "msg/GoalPredicate.msg"
   "msg/GoalSpecification.msg"
   "msg/LocationState.msg"

--- a/pyrobosim_msgs/msg/ActionExecutionOptions.msg
+++ b/pyrobosim_msgs/msg/ActionExecutionOptions.msg
@@ -1,0 +1,11 @@
+# Action Execution Options ROS Message
+
+# Simulated delay time, in seconds
+float64 delay 0.0
+
+# Simulated success probability, in the range (0, 1)
+float64 success_probability 1.0
+
+# Random Number Generation seed.
+# Set to -1 for nondeterministic actions
+int64 rng_seed -1

--- a/pyrobosim_msgs/msg/TaskAction.msg
+++ b/pyrobosim_msgs/msg/TaskAction.msg
@@ -1,6 +1,6 @@
 # Task Action ROS Message
 
-# Main Action information
+# Main action information
 string robot
 string type
 string object
@@ -10,6 +10,9 @@ string target_location
 
 # Action cost (from the output of a planner)
 float32 cost
+
+# Action execution options (e.g., delay and success probability)
+ActionExecutionOptions execution_options
 
 # Other parameters
 bool has_pose

--- a/pyrobosim_ros/launch/demo_commands.launch.py
+++ b/pyrobosim_ros/launch/demo_commands.launch.py
@@ -18,6 +18,21 @@ def generate_launch_description():
         default_value=TextSubstitution(text="plan"),
         description="Command mode (action or plan)",
     )
+    action_delay_arg = DeclareLaunchArgument(
+        "action_delay",
+        default_value="0.0",
+        description="The action delay, in seconds",
+    )
+    action_success_probability_arg = DeclareLaunchArgument(
+        "action_success_probability",
+        default_value="1.0",
+        description="The action success probability, in the range (0, 1)",
+    )
+    action_rng_seed_arg = DeclareLaunchArgument(
+        "action_rng_seed",
+        default_value="-1",
+        description="The random number generator seed. Defaults to -1, or nondeterministic.",
+    )
 
     # Nodes
     world_node = Node(
@@ -30,7 +45,26 @@ def generate_launch_description():
         package="pyrobosim_ros",
         executable="demo_commands.py",
         name="demo_commands",
-        parameters=[{"mode": LaunchConfiguration("mode")}],
+        parameters=[
+            {
+                "mode": LaunchConfiguration("mode"),
+                "action_delay": LaunchConfiguration("action_delay"),
+                "action_success_probability": LaunchConfiguration(
+                    "action_success_probability"
+                ),
+                "action_rng_seed": LaunchConfiguration("action_rng_seed"),
+            }
+        ],
     )
 
-    return LaunchDescription([world_file_arg, mode_arg, world_node, command_node])
+    return LaunchDescription(
+        [
+            world_file_arg,
+            mode_arg,
+            action_delay_arg,
+            action_success_probability_arg,
+            action_rng_seed_arg,
+            world_node,
+            command_node,
+        ]
+    )

--- a/pyrobosim_ros/pyrobosim_ros/ros_conversions.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_conversions.py
@@ -148,6 +148,15 @@ def task_action_from_ros(msg):
         pose=pose_from_ros(msg.pose) if msg.has_pose else None,
         path=path_from_ros(msg.path),
         cost=msg.cost,
+        execution_options=acts.ExecutionOptions(
+            delay=msg.execution_options.delay,
+            success_probability=msg.execution_options.success_probability,
+            rng_seed=(
+                msg.execution_options.rng_seed
+                if msg.execution_options.rng_seed >= 0
+                else None
+            ),
+        ),
     )
 
 
@@ -175,6 +184,12 @@ def task_action_to_ros(act):
     act_msg.path = path_to_ros(act.path)
     if act.cost:
         act_msg.cost = float(act.cost)
+    if act.execution_options:
+        act_msg.execution_options = ros_msgs.ActionExecutionOptions(
+            delay=act.execution_options.delay,
+            success_probability=act.execution_options.success_probability,
+            rng_seed=act.execution_options.rng_seed or -1,
+        )
 
     return act_msg
 

--- a/pyrobosim_ros/pyrobosim_ros/ros_interface.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_interface.py
@@ -289,6 +289,7 @@ class WorldROSWrapper(Node):
         robot_action = task_action_from_ros(goal_handle.request.action)
         self.get_logger().info(f"Executing action with robot {robot.name}...")
         success = robot.execute_action(robot_action)
+        self.get_logger().info(f"Action finished with success: {success}")
 
         # Package up the result
         goal_handle.succeed()
@@ -321,6 +322,9 @@ class WorldROSWrapper(Node):
         self.get_logger().info(f"Executing task plan with robot {robot.name}...")
         robot_plan = task_plan_from_ros(goal_handle.request.plan)
         success, num_completed = robot.execute_plan(robot_plan)
+        self.get_logger().info(
+            f"Plan finished with success: {success} (completed {num_completed}/{robot_plan.size()} actions)"
+        )
 
         # Package up the result
         goal_handle.succeed()

--- a/pyrobosim_ros/test/test_ros_conversions.py
+++ b/pyrobosim_ros/test/test_ros_conversions.py
@@ -83,6 +83,7 @@ def test_task_action_conversion():
         pose=Pose(x=1.0, y=2.0, z=3.0, q=[1.0, 0.0, 0.0, 0.0]),
         path=Path(),
         cost=42.0,
+        execution_options=None,
     )
 
     # Convert to a ROS message
@@ -103,6 +104,9 @@ def test_task_action_conversion():
     assert ros_action.pose.orientation.y == pytest.approx(orig_action.pose.q[2])
     assert ros_action.pose.orientation.z == pytest.approx(orig_action.pose.q[3])
     assert len(ros_action.path.poses) == orig_action.path.num_poses
+    assert ros_action.execution_options.delay == 0.0
+    assert ros_action.execution_options.success_probability == 1.0
+    assert ros_action.execution_options.rng_seed == -1
 
     # Convert back to a pyrobosim task action
     new_action = task_action_from_ros(ros_action)
@@ -119,6 +123,9 @@ def test_task_action_conversion():
     assert new_action.pose.z == pytest.approx(orig_action.pose.z)
     assert new_action.pose.q == pytest.approx(orig_action.pose.q)
     assert new_action.path.num_poses == orig_action.path.num_poses
+    assert new_action.execution_options.delay == 0.0
+    assert new_action.execution_options.success_probability == 1.0
+    assert new_action.execution_options.rng_seed is None
 
 
 def test_task_plan_conversion():
@@ -141,6 +148,11 @@ def test_task_plan_conversion():
             target_location="desk0",
             path=nav_path,
             cost=0.75,
+            execution_options=acts.ExecutionOptions(
+                delay=0.2,
+                success_probability=0.5,
+                rng_seed=1234,
+            ),
         ),
         acts.TaskAction(
             "place", object="apple", target_location="desk0", pose=place_pose, cost=0.5
@@ -156,7 +168,7 @@ def test_task_plan_conversion():
         assert orig_action.type == ros_action.type
     assert ros_plan.cost == pytest.approx(orig_plan.total_cost)
 
-    # Convert back to a pyrobosim task action
+    # Convert back to a pyrobosim task plan
     new_plan = task_plan_from_ros(ros_plan)
     assert new_plan.robot == orig_plan.robot
     assert len(new_plan.actions) == len(orig_plan.actions)

--- a/test/planning/test_task_objects.py
+++ b/test/planning/test_task_objects.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from pyrobosim.planning.actions import TaskAction, TaskPlan
+from pyrobosim.planning.actions import ExecutionOptions, TaskAction, TaskPlan
 from pyrobosim.utils.motion import Path
 from pyrobosim.utils.pose import Pose
 
@@ -23,6 +23,7 @@ def test_task_action_default_args():
     assert action.pose is None
     assert isinstance(action.path, Path)
     assert action.path.num_poses == 0
+    assert action.execution_options is None
 
 
 def test_task_action_nondefault_args():
@@ -32,6 +33,7 @@ def test_task_action_nondefault_args():
         Pose(x=0.5, y=1.0, yaw=1.5),
         Pose(x=1.0, y=2.0, yaw=3.0),
     ]
+    opts = ExecutionOptions()
 
     action = TaskAction(
         "Pick",
@@ -43,6 +45,7 @@ def test_task_action_nondefault_args():
         pose=test_poses[-1],
         path=Path(poses=test_poses),
         cost=42.0,
+        execution_options=opts,
     )
 
     assert action.type == "pick"  # Should be converted to lower case
@@ -54,6 +57,7 @@ def test_task_action_nondefault_args():
     assert action.target_location == "counter0_right"
     assert action.pose == test_poses[-1]
     assert action.path == Path(poses=test_poses)
+    assert action.execution_options == opts
 
 
 def test_task_plan_default_args():


### PR DESCRIPTION
This PR allows simulating action delays and failures, including a settable RNG seed for reproducibility.

Right now, this works for both the Python API and ROS interface, but not directly from the GUI.

Closes #177 