### PR TITLE
Allow canceling actions and plans

### DIFF
--- a/pyrobosim_ros/launch/demo_commands.launch.py
+++ b/pyrobosim_ros/launch/demo_commands.launch.py
@@ -9,13 +9,13 @@ def generate_launch_description():
     # Arguments
     world_file_arg = DeclareLaunchArgument(
         "world_file",
-        default_value=TextSubstitution(text=""),
+        default_value="",
         description="YAML file name (should be in the pyrobosim/data folder). "
         + "If not specified, a world will be created programmatically.",
     )
     mode_arg = DeclareLaunchArgument(
         "mode",
-        default_value=TextSubstitution(text="plan"),
+        default_value="plan",
         description="Command mode (action or plan)",
     )
     action_delay_arg = DeclareLaunchArgument(
@@ -32,6 +32,11 @@ def generate_launch_description():
         "action_rng_seed",
         default_value="-1",
         description="The random number generator seed. Defaults to -1, or nondeterministic.",
+    )
+    send_cancel_arg = DeclareLaunchArgument(
+        "send_cancel",
+        default_value="False",
+        description="If True, cancels running actions after some time.",
     )
 
     # Nodes
@@ -53,6 +58,7 @@ def generate_launch_description():
                     "action_success_probability"
                 ),
                 "action_rng_seed": LaunchConfiguration("action_rng_seed"),
+                "send_cancel": LaunchConfiguration("send_cancel"),
             }
         ],
     )
@@ -64,6 +70,7 @@ def generate_launch_description():
             action_delay_arg,
             action_success_probability_arg,
             action_rng_seed_arg,
+            send_cancel_arg,
             world_node,
             command_node,
         ]

--- a/pyrobosim_ros/pyrobosim_ros/ros_interface.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_interface.py
@@ -351,7 +351,7 @@ class WorldROSWrapper(Node):
         """
         Handle cancellation for task plans.
 
-        :param goal_handle: Task action goal handle to process.
+        :param goal_handle: Task plan goal handle to process.
         :type goal_handle: :class:`pyrobosim_msgs.action.ExecuteTaskPlan.Goal`
         """
         robot = self.world.get_robot_by_name(goal_handle.request.plan.robot)


### PR DESCRIPTION
This PR allows canceling running actions and task plans, both with the Python API and ROS interface.

This is not supported from the GUI in this PR.

Closes #203 