### PR TITLE
Add execution status to actions and plans

### DIFF
--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -18,7 +18,7 @@ Worlds in ``pyrobosim`` consist of a hierarchy of polygonal *entities*, includin
 
 This is all represented in a 2.5D environment (SE(2) pose with vertical (Z) height).
 However, full 3D poses are representable as well.
-For more information, refer to the :doc:`Geometry Conventions </usage/geometry_conventions>` section.
+For more information, refer to the :ref:`geometry_conventions` section.
 
 .. image:: media/world_entities.png
     :align: center
@@ -30,19 +30,16 @@ For more information, refer to the :doc:`Geometry Conventions </usage/geometry_c
 Actions
 -------
 
-Within the world, we can spawn a robot that can perform a set of *actions*, such as:
-
-* **Navigate** to a particular entity or pose.
-* **Pick** an object from a specific location.
-* **Place** an object at a specific location and pose.
+Within the world, we can spawn a robot that can perform a set of *actions*, such as navigating, picking and placing.
+To learn more, refer to :ref:`robot_actions`.
 
 These actions can be specified individually, or a sequence of actions (or a *plan*).
 Actions or plans can be commanded directly (e.g., "go to the table and pick up an apple")
-or as part of a *task and motion planning* framework that accepts a task specification
+or as part of a :ref:`task_and_motion_planning` framework that accepts a task specification
 (e.g., "all apples should be on the kitchen table") and outputs a plan that, when executed,
 satisfies the specification.
 
-For example, here is a robot performing a **navigate** action from the kitchen to the desk
+For example, here is a robot performing a **Navigate** action from the kitchen to the desk
 in our simple test world.
 
 .. image:: media/example_navigate.png

--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -19,7 +19,7 @@ However, note that this will not include any of the ROS 2 or Task and Motion Pla
 Local Setup
 -----------
 
-If using ROS 2, clone this repo in a valid `colcon workspace <https://docs.ros.org/en/humble/Tutorials/Workspace/Creating-A-Workspace.html>`_.
+If using ROS 2, clone this repo in a valid `ROS 2 workspace <https://docs.ros.org/en/jazzy/Tutorials/Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace.html>`_.
 Otherwise, if running standalone, clone it wherever you would like.
 
 To set up your Python virtual environment, configure and run
@@ -45,6 +45,13 @@ As documented in the above script, we recommend making a bash function in your `
     pyrobosim() {
        source /path/to/pyrobosim/setup/source_pyrobosim.bash
     }
+
+.. note::
+    The ``setup_pyrobosim_bash`` script will create a configuration file named ``pyrobosim.env`` in the repo root folder.
+    This file is read by the ``source_pyrobosim.bash`` script to start up the environment.
+
+    You can edit this file manually if you're comfortable with how these settings work.
+    Otherwise, we recommend rerunning ``setup_pyrobosim.bash`` and following the prompts if you want to make changes to your setup.
 
 
 Docker Setup
@@ -84,4 +91,4 @@ You can also start a new Terminal and go into the same container as follows.
     # ros2 launch pyrobosim_ros demo.py
 
 The source code on your host machine is mounted as a volume,
-so you can make modifications on your host and rebuild the Colcon workspace inside the container.
+so you can make modifications on your host and rebuild the ROS 2 workspace inside the container.

--- a/docs/source/usage/basic_usage.rst
+++ b/docs/source/usage/basic_usage.rst
@@ -91,7 +91,7 @@ Refer to the :doc:`YAML Schemas </yaml/index>` documentation for more informatio
 
 Exporting Worlds to Gazebo
 --------------------------
-To export worlds to Gazebo, there is a :doc:`WorldGazeboExporter </generated/pyrobosim.core.gazebo.WorldGazeboExporter>` utility:
+To export worlds to Gazebo, there is a :py:class:`pyrobosim.core.gazebo.WorldGazeboExporter` utility:
 
 Standalone:
 

--- a/docs/source/usage/geometry_conventions.rst
+++ b/docs/source/usage/geometry_conventions.rst
@@ -1,3 +1,5 @@
+.. _geometry_conventions:
+
 Geometry Conventions
 ====================
 
@@ -5,7 +7,7 @@ Geometry Conventions
 For simplicity, if you are representing poses in 2D, you can use the yaw angle (Z Euler angle), but we recommend using quaternions for generic 3D pose calculations and for interfacing with ROS.
 
 The Euler angle convention is extrinsic XYZ (roll = X, pitch = Y, yaw = Z) in radians.
-Quaternions use the order convention [qw, qx, qy, qz].
-There is more documentation in the :doc:`Pose </generated/pyrobosim.utils.pose.Pose>` source code.
+Quaternions use the order convention ``[qw, qx, qy, qz]``.
+There is more documentation in the :py:class:`pyrobosim.utils.pose.Pose` source code.
 
-When ROS 2 is connected to pyrobosim, the reference frame is `map`.
+When ROS 2 is connected to pyrobosim, the reference frame is ``map``.

--- a/docs/source/usage/path_planners.rst
+++ b/docs/source/usage/path_planners.rst
@@ -22,9 +22,9 @@ A specific implementation can be selected by providing the relevant parameters i
 
 Available planner types and their available implementations can be found below :
 
-- "astar" : :py:mod:`pyrobosim.navigation.a_star`
-- "prm" : :py:mod:`pyrobosim.navigation.prm`
-- "rrt" : :py:mod:`pyrobosim.navigation.rrt`
+- ``"astar"`` : :py:mod:`pyrobosim.navigation.a_star`
+- ``"prm"`` : :py:mod:`pyrobosim.navigation.prm`
+- ``"rrt"`` : :py:mod:`pyrobosim.navigation.rrt`
 
 
 Adding New Planners
@@ -82,5 +82,5 @@ For example, to add a new planner type called ``NewPlanner``:
 
 .. note::
 
-    Planner implementations that need to display graphs should provide a `get_graphs()` method and set the `graphs` attribute of `PathPlannerBase` like in
+    Planner implementations that need to display graphs should provide a ``get_graphs()`` method and set the ``graphs`` attribute of ``PathPlannerBase`` like in
     :py:func:`pyrobosim.navigation.rrt.RRTPlannerPolygon.get_graphs` and :py:func:`pyrobosim.navigation.rrt.RRTPlanner.plan`.

--- a/docs/source/usage/robot_actions.rst
+++ b/docs/source/usage/robot_actions.rst
@@ -1,3 +1,5 @@
+.. _robot_actions:
+
 Robot Actions
 =============
 
@@ -12,10 +14,14 @@ The actions currently supported are:
 * **Open**: Opens the robot's current location (currently, hallways are supported).
 * **Close**: Closes the robot's current location (currently, hallways are supported).
 
-Actions can be triggered in a variety of ways:
+
+Executing Actions and Plans
+---------------------------
+
+Actions can be executed in a variety of ways:
 
 * Through the buttons on the GUI.
-* Using a robot's ``execute_action()`` method.
+* Using a robot's :py:meth:`pyrobosim.core.robot.Robot.execute_action` method.
 * (If using ROS), sending a goal to the ``/execute_action`` ROS action server.
 
 For example, a default action execution code block may look like this:
@@ -33,7 +39,7 @@ For example, a default action execution code block may look like this:
 
 You can also command a robot with a *plan*, which is a sequences of actions:
 
-* Using a robot's ``execute_plan()`` method.
+* Using a robot's :py:meth:`pyrobosim.core.robot.Robot.execute_plan` method.
 * (If using ROS), sending a goal to the ``/execute_task_plan`` ROS action server.
 
 .. code-block:: python
@@ -62,13 +68,22 @@ You can also command a robot with a *plan*, which is a sequences of actions:
 
 Plans can also be automatically generated with :ref:`task_and_motion_planning`.
 
-The ROS 2 interface also supports sending actions and plans, with the ``pyrobosim_msgs.action.ExecuteTaskAction`` and ``pyrobosim.action.ExecuteTaskPlan`` actions, respectively.
+Both actions and plans return an :py:class:`pyrobosim.planning.actions.ExecutionResult` object that contains:
+
+* An :py:class:`pyrobosim.planning.actions.ExecutionStatus` enumeration containing common status such as ``SUCCESS``, ``PLANNING_FAILURE``, and ``EXECUTION_FAILURE``.
+* An optional string describing the result.
+
+You can cancel actions and plans that are executing on a robot using its :py:meth:`pyrobosim.core.robot.Robot.cancel_actions` method.
+
+The ROS 2 interface also supports sending and canceling actions and plans, with the ``pyrobosim_msgs.action.ExecuteTaskAction`` and ``pyrobosim.action.ExecuteTaskPlan`` actions, respectively.
 You can try it out with the following example.
 
 ::
 
-    ros2 launch pyrobosim_ros demo_commands.launch.py mode:=action
-    ros2 launch pyrobosim_ros demo_commands.launch.py mode:=plan
+    ros2 launch pyrobosim_ros demo_commands.launch.py mode:=action send_cancel:=false
+    ros2 launch pyrobosim_ros demo_commands.launch.py mode:=plan send_cancel:=false
+
+Similarly to the Python API, these ROS 2 action definitions embed their status in a message field of type ``pyrobosim_msgs.msg.ExecutionResult``.
 
 
 .. _simulating_action_execution:
@@ -122,7 +137,7 @@ A common use case for design robot behaviors is that a robot instead starts with
 In these cases, the robot must explicitly go to a location and use an object detector to find new objects to add to their world model.
 
 You can model this in ``pyrobosim`` by instantiating robot objects with the ``partial_observability`` option set to ``True``.
-Then, you can use the **detect** action to find objects at the robot's current location.
+Then, you can use the **Detect** action to find objects at the robot's current location.
 
 To test this, you can run the following example.
 

--- a/docs/source/usage/tamp.rst
+++ b/docs/source/usage/tamp.rst
@@ -10,7 +10,7 @@ If you did not already install PDDLStream, ensure you do so with this script, th
 
 ::
 
-    ./setup/setup_pddlstream.bash
+    ./setup/configure_pddlstream.bash
     source ./setup/source_pyrobosim.bash
 
 
@@ -22,11 +22,11 @@ demo with continuous action parameters.
 
 The current example list is:
 
-* ``01_simple`` - Simple domain with purely discrete actions
-* ``02_derived`` - Purely discrete actions, but uses *derived predicates* for more complex goals
-* ``03_nav_stream`` - Samples navigation poses and motion plan instances
-* ``04_nav_manip_stream`` - Samples navigation poses, motion plans, and collision-free object placement instances
-* ``05_nav_grasp_stream`` - Samples navigation poses and motion plans, grasp plans, and collision-free object placement instances
+* ``01_simple`` - Simple domain with purely discrete actions.
+* ``02_derived`` - Purely discrete actions, but uses *derived predicates* for more complex goals.
+* ``03_nav_stream`` - Samples navigation poses and motion plan instances.
+* ``04_nav_manip_stream`` - Samples navigation poses, motion plans, and collision-free object placement instances.
+* ``05_nav_grasp_stream`` - Samples navigation poses, motion plans, grasp plans, and collision-free object placement instances.
 
 These PDDL domain and stream description files can be found in the ``pyrobosim/pyrobosim/data/pddlstream/domains`` folder.
 

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -10,6 +10,7 @@ from .hallway import Hallway
 from .locations import ObjectSpawn
 from .objects import Object
 from ..manipulation.grasping import Grasp
+from ..planning.actions import ExecutionResult, ExecutionStatus
 from ..utils.knowledge import resolve_to_object
 from ..utils.polygon import sample_from_polygon, transform_polygon
 from ..utils.pose import Pose
@@ -88,7 +89,7 @@ class Robot:
 
         # Navigation properties
         self.executing_nav = False
-        self.last_nav_successful = False
+        self.last_nav_status = ExecutionStatus.UNKNOWN
         self.set_path_planner(path_planner)
         self.set_path_executor(path_executor)
 
@@ -275,47 +276,65 @@ class Robot:
         :type use_thread: bool
         :param blocking: If path executes in a new thread, set to True to block
             and wait for the thread to complete before returning.
-        :return: True if path following is successful, or the path following
-            thread is successfully started.
-        :rtype: bool
+        :return: An object describing the execution result.
+        :rtype: :class:`pyrobosim.planning.actions.ExecutionResult`
         """
-        self.last_nav_successful = False
+        self.last_nav_status = ExecutionStatus.UNKNOWN
 
         if path is None:
-            warnings.warn("No path to execute.")
             self.executing_nav = False
-            return False
+            message = "No path to execute."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE,
+                message=message,
+            )
         if self.path_executor is None:
-            warnings.warn("No path executor. Cannot follow path.")
             self.executing_nav = False
-            return False
+            message = "No path executor. Cannot follow path."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE,
+                message=message,
+            )
 
         if path.num_poses == 0:
-            self.last_nav_successful = True
-            success = True
+            # Trivial case where the path is empty.
+            result = ExecutionResult(status=ExecutionStatus.SUCCESS)
+            self.last_nav_status = result.status
         elif use_thread:
-            # Start a thread with the path execution
+            # Start a thread with the path execution.
             self.nav_thread = threading.Thread(
                 target=self.path_executor.execute, args=(path, realtime_factor)
             )
             self.nav_thread.start()
             if blocking:
-                # Check that the robot made it to its goal pose at the end of execution.
                 self.nav_thread.join()
-                success = self.get_pose().is_approx(path.poses[-1])
+                result = ExecutionResult(status=self.last_nav_status)
             else:
-                # Cannot check in the non-blocking case, so we just assume success.
-                success = True
+                # Assume success, but check the postconditions later.
+                result = ExecutionResult(status=ExecutionStatus.SUCCESS)
         else:
             # Execute in this thread and check that the robot made it to its goal pose.
-            success = self.path_executor.execute(path, realtime_factor)
-            success |= self.get_pose().is_approx(path.poses[-1])
+            result = self.path_executor.execute(path, realtime_factor)
+
+        # Check that the robot made it to its goal pose at the end of execution.
+        at_goal_pose = self.get_pose().is_approx(path.poses[-1])
+        if (
+            not (use_thread and not blocking)
+            and result.is_success()
+            and not at_goal_pose
+        ):
+            result = ExecutionResult(
+                status=ExecutionStatus.POSTCONDITION_FAILURE,
+                message="Robot is not at its intended target pose.",
+            )
 
         # Update the robot state if successful.
         if self.world:
             self.location = self.world.get_location_from_pose(self.get_pose())
-        self.last_nav_successful = success
-        return success
+        self.last_nav_status = result.status
+        return result
 
     def navigate(
         self,
@@ -344,17 +363,20 @@ class Robot:
         :type use_thread: bool
         :param blocking: If path executes in a new thread, set to True to block
             and wait for the thread to complete before returning.
-        :return: True if path following is successful, or the path following
-            thread is successfully started.
-        :rtype: bool
+        :return: An object describing the execution result.
+        :rtype: :class:`pyrobosim.planning.actions.ExecutionResult`
         """
         if path is None:
             path = self.plan_path(start, goal)
             if path is None or path.num_poses == 0:
-                warnings.warn("Failed to plan a path.")
                 self.executing_nav = False
-                self.last_nav_successful = False
-                return False
+                self.last_nav_status = ExecutionStatus.UNKNOWN
+                message = "Failed to plan a path."
+                warnings.warn(message)
+                return ExecutionResult(
+                    status=ExecutionStatus.PLANNING_FAILURE,
+                    message=message,
+                )
 
         return self.follow_path(
             path,
@@ -371,14 +393,17 @@ class Robot:
         :type obj_query: str
         :param grasp_pose: A pose describing how to manipulate the object.
         :type grasp_pose: :class:`pyrobosim.utils.pose.Pose`, optional
-        :return: True if picking succeeds, else False.
-        :rtype: bool
+        :return: An object describing the execution result.
+        :rtype: :class:`pyrobosim.planning.actions.ExecutionResult`
         """
         # Validate input
         if self.manipulated_object is not None:
             obj_name = self.manipulated_object.name
-            warnings.warn(f"Robot is already holding {obj_name}.")
-            return False
+            message = f"Robot is already holding {obj_name}."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
 
         # Get object
         loc = self.location
@@ -397,16 +422,19 @@ class Robot:
                     robot=self,
                 )
             if not obj:
-                warnings.warn(f"Found no object {obj_query} to pick.")
-                return False
+                message = f"Found no object {obj_query} to pick."
+                warnings.warn(message)
+                return ExecutionResult(
+                    status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+                )
 
         # Validate the robot location
         if obj.parent != loc:
-            warnings.warn(
-                f"{obj.name} is at {obj.parent.name} and robot "
-                + f"is at {loc.name}. Cannot pick."
+            message = f"{obj.name} is at {obj.parent.name} and robot is at {loc.name}. Cannot pick."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
             )
-            return False
 
         # If a grasp generator has been specified and no explicit grasp has been provided,
         # generate grasps here.
@@ -433,8 +461,11 @@ class Robot:
             )
 
             if len(grasps) == 0:
-                warnings.warn(f"Could not generate valid grasps. Cannot pick.")
-                return False
+                message = f"Could not generate valid grasps. Cannot pick."
+                warnings.warn(message)
+                return ExecutionResult(
+                    status=ExecutionStatus.PLANNING_FAILURE, message=message
+                )
             else:
                 # TODO: For now, just pick a random grasp.
                 self.last_grasp_selection = np.random.choice(grasps)
@@ -443,7 +474,7 @@ class Robot:
 
         # Denote the target object as the manipulated object
         self._attach_object(obj)
-        return True
+        return ExecutionResult(status=ExecutionStatus.SUCCESS)
 
     def place_object(self, pose=None):
         """
@@ -451,21 +482,27 @@ class Robot:
 
         :param pose: Placement pose (if not specified, will be sampled).
         :type pose: :class:`pyrobosim.utils.pose.Pose`, optional
-        :return: True if placement succeeds, else False.
-        :rtype: bool
+        :return: An object describing the execution result.
+        :rtype: :class:`pyrobosim.planning.actions.ExecutionResult`
         """
         # Validate input
         if self.manipulated_object is None:
-            warnings.warn("No manipulated object. Cannot place.")
-            return False
+            message = "No manipulated object. Cannot place."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
 
         # Validate the robot location
         loc = self.location
         if isinstance(loc, str):
             loc = self.world.get_entity_by_name(self.location)
         if not isinstance(loc, ObjectSpawn):
-            warnings.warn(f"{loc} is not an object spawn. Cannot place object.")
-            return False
+            message = f"{loc} is not an object spawn. Cannot place object."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
 
         # Place the object somewhere in the current location
         is_valid_pose = False
@@ -486,8 +523,11 @@ class Robot:
                     pose = pose_sample
                     break
             if not is_valid_pose:
-                warnings.warn(f"Could not sample a placement position at {loc.name}")
-                return False
+                message = f"Could not sample a placement position at {loc.name}"
+                warnings.warn(message)
+                return ExecutionResult(
+                    status=ExecutionStatus.PLANNING_FAILURE, message=message
+                )
         else:
             # If a pose was specified, collision check it
             poly = transform_polygon(poly, pose)
@@ -497,8 +537,11 @@ class Robot:
                     other_obj.collision_polygon
                 )
             if not is_valid_pose:
-                warnings.warn(f"Pose in collision or not in location {loc.name}.")
-                return False
+                message = f"Pose in collision or not in location {loc.name}."
+                warnings.warn(message)
+                return ExecutionResult(
+                    status=ExecutionStatus.PLANNING_FAILURE, message=message
+                )
 
         if is_valid_pose:
             self.manipulated_object.parent = loc
@@ -506,7 +549,7 @@ class Robot:
             self.manipulated_object.create_polygons()
             loc.children.append(self.manipulated_object)
             self.manipulated_object = None
-            return True
+            return ExecutionResult(status=ExecutionStatus.SUCCESS)
 
     def detect_objects(self, target_object=None):
         """
@@ -516,81 +559,108 @@ class Robot:
             If None, the action succeeds regardless of which object is found.
             Otherwise, the action succeeds only if the target object is found.
         :type target_object: str
-        :return: True if detection succeeds, else False.
-        :rtype: bool
+        :return: An object describing the execution result.
+        :rtype: :class:`pyrobosim.planning.actions.ExecutionResult`
         """
         self.last_detected_objects = []
 
         if not self.at_object_spawn():
-            warnings.warn(f"Robot is not at an object spawn. Cannot detect objects.")
-            return False
+            message = f"Robot is not at an object spawn. Cannot detect objects."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
 
         # Add all the objects at the current robot's location.
         for obj in self.location.children:
             self.known_objects.add(obj)
 
         # If a target object was specified, look for a matching instance.
-        # We should only return True if one such instance was found.
+        # We should only return SUCCESS if one such instance was found.
         if target_object is None:
             self.last_detected_objects = self.location.children
-            return True
+            return ExecutionResult(status=ExecutionStatus.SUCCESS)
         else:
             self.last_detected_objects = [
                 obj
                 for obj in self.location.children
                 if obj.name == target_object or obj.category == target_object
             ]
-            return len(self.last_detected_objects) > 0
+            if len(self.last_detected_objects) > 0:
+                return ExecutionResult(status=ExecutionStatus.SUCCESS)
+            else:
+                return ExecutionResult(
+                    status=ExecutionStatus.EXECUTION_FAILURE,
+                    message=f"Failed to detect any objects matching the query '{target_object}'.",
+                )
 
     def open_location(self):
         """
         Opens the robot's current location, if available.
 
-        :return: True if opening the location succeeds, else False.
-        :rtype: bool
+        :return: An object describing the execution result.
+        :rtype: :class:`pyrobosim.planning.actions.ExecutionResult`
         """
         if self.location is None:
-            warnings.warn("Robot location is not set. Cannot open.")
-            return False
+            message = "Robot location is not set. Cannot open."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
 
         if self.manipulated_object is not None:
-            warnings.warn("Robot is holding an object. Cannot open.")
-            return False
+            message = "Robot is holding an object. Cannot open."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
 
         if not self.at_openable_location():
-            warnings.warn("Robot is not at an openable location.")
-            return False
+            message = "Robot is not at an openable location."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
 
         if isinstance(self.location, Hallway):
             return self.world.open_hallway(self.location)
 
         # This should not happen
-        return False
+        return ExecutionResult(status=ExecutionResult.UNKNOWN)
 
     def close_location(self):
         """
         Closes the robot's current location, if available.
 
-        :return: True if closing the location succeeds, else False.
-        :rtype: bool
+        :return: An object describing the execution result.
+        :rtype: :class:`pyrobosim.planning.actions.ExecutionResult`
         """
         if self.location is None:
-            warnings.warn("Robot location is not set. Cannot close.")
-            return False
+            message = "Robot location is not set. Cannot close."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
 
         if self.manipulated_object is not None:
-            warnings.warn("Robot is holding an object. Cannot close.")
-            return False
+            message = "Robot is holding an object. Cannot close."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
 
         if not self.at_openable_location():
-            warnings.warn("Robot is not at a closeable location.")
-            return False
+            message = "Robot is not at a closeable location."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
 
         if isinstance(self.location, Hallway):
             return self.world.close_hallway(self.location, ignore_robots=[self])
 
         # This should not happen
-        return False
+        return ExecutionResult(status=ExecutionResult.UNKNOWN)
 
     def execute_action(self, action, blocking=False):
         """
@@ -601,8 +671,8 @@ class Robot:
         :type action: :class:`pyrobosim.planning.actions.TaskAction`
         :param blocking: True to block execution until the action is complete.
         :type blocking: bool, optional
-        :return: True if the action succeeds, or False otherwise.
-        :rtype: bool
+        :return: An object describing the execution result.
+        :rtype: :class:`pyrobosim.planning.actions.ExecutionResult`
         """
         self.executing_action = True
         self.current_action = action
@@ -611,8 +681,11 @@ class Robot:
 
         # Simulate action-agnostic properties such as delays or failure probabilities.
         if not action.should_succeed():
-            print("Simulated action failure.")
-            success = False
+            message = f"[{self.name}] Simulated action failure."
+            print(message)
+            result = ExecutionResult(
+                status=ExecutionStatus.EXECUTION_FAILURE, message=message
+            )
 
         elif action.type == "navigate":
             self.executing_nav = True
@@ -621,9 +694,9 @@ class Robot:
                 self.world.gui.canvas.navigate(self, action.target_location, path)
                 while self.executing_nav:
                     time.sleep(0.5)  # Delay to wait for navigation
-                success = self.last_nav_successful
+                result = ExecutionResult(status=self.last_nav_status)
             else:
-                success = self.navigate(
+                result = self.navigate(
                     goal=action.target_location,
                     path=path,
                     realtime_factor=1.0,
@@ -634,47 +707,50 @@ class Robot:
 
         elif action.type == "pick":
             if self.world.has_gui:
-                success = self.world.gui.canvas.pick_object(
+                result = self.world.gui.canvas.pick_object(
                     self, action.object, action.pose
                 )
             else:
-                success = self.pick_object(action.object, action.pose)
+                result = self.pick_object(action.object, action.pose)
 
         elif action.type == "place":
             if self.world.has_gui:
-                success = self.world.gui.canvas.place_object(self, action.pose)
+                result = self.world.gui.canvas.place_object(self, action.pose)
             else:
-                success = self.place_object(action.pose)
+                result = self.place_object(action.pose)
 
         elif action.type == "detect":
             if self.world.has_gui:
-                success = self.world.gui.canvas.detect_objects(self, action.object)
+                result = self.world.gui.canvas.detect_objects(self, action.object)
             else:
-                success = self.detect_objects(action.object)
+                result = self.detect_objects(action.object)
 
         elif action.type == "open":
             if self.world.has_gui:
-                success = self.world.gui.canvas.open_location(self)
+                result = self.world.gui.canvas.open_location(self)
             else:
-                success = self.open_location()
+                result = self.open_location()
 
         elif action.type == "close":
             if self.world.has_gui:
-                success = self.world.gui.canvas.close_location(self)
+                result = self.world.gui.canvas.close_location(self)
             else:
-                success = self.close_location()
+                result = self.close_location()
 
         else:
-            warnings.warn(f"[{self.name}] Invalid action type: {action.type}.")
-            success = False
+            message = f"[{self.name}] Invalid action type: {action.type}."
+            warnings.warn(message)
+            result = ExecutionResult(
+                status=ExecutionStatus.INVALID_ACTION, message=message
+            )
 
         if self.world.has_gui:
             self.world.gui.set_buttons_during_action(True)
-        print(f"[{self.name}] Action completed with success: {success}")
+        print(f"[{self.name}] Action completed with result: {result.status.name}")
         if blocking:
             self.current_action = None
             self.executing_action = False
-        return success
+        return result
 
     def cancel_actions(self):
         """Cancels any currently running actions for the robot."""
@@ -685,7 +761,7 @@ class Robot:
         self.canceling_execution = True
         if self.executing_nav and self.path_executor is not None:
             print(f"[{self.name}] Canceling path execution...")
-            self.path_executor.abort_execution = True
+            self.path_executor.cancel_execution = True
 
     def execute_plan(self, plan, delay=0.5):
         """
@@ -696,12 +772,16 @@ class Robot:
         :type plan: :class:`pyrobosim.planning.actions.TaskPlan`
         :param delay: Artificial delay between actions for visualization.
         :type delay: float, optional
-        :return: A tuple containing a boolean for whether the plan succeeded, and the number of completed actions.
-        :rtype: tuple(bool, int)
+        :return: A tuple containing an execution result and the number of actions completed.
+        :rtype: tuple[:class:`pyrobosim.planning.actions.ExecutionResult`, int]
         """
         if plan is None:
-            warnings.warn(f"[{self.name}] Plan is None. Returning.")
-            return False
+            message = f"[{self.name}] Plan is None. Returning."
+            warnings.warn(message)
+            return (
+                ExecutionResult(status=ExecutionStatus.INVALID_ACTION, message=message),
+                0,
+            )
 
         self.executing_plan = True
         self.current_plan = plan
@@ -710,19 +790,22 @@ class Robot:
         if self.world.has_gui:
             self.world.gui.set_buttons_during_action(False)
 
-        success = True
+        result = ExecutionResult(status=ExecutionStatus.SUCCESS)
         num_completed = 0
         num_acts = len(plan.actions)
         for n, act_msg in enumerate(plan.actions):
             if self.canceling_execution:
-                print(f"[{self.name}] Canceled plan execution.")
-                success = False
                 self.canceling_execution = False
+                message = f"[{self.name}] Canceled plan execution."
+                print(message)
+                result = ExecutionResult(
+                    status=ExecutionStatus.CANCELED, message=message
+                )
                 break
 
             print(f"[{self.name}] Executing action {act_msg.type} [{n+1}/{num_acts}]")
-            success = self.execute_action(act_msg, blocking=True)
-            if not success:
+            result = self.execute_action(act_msg, blocking=True)
+            if not result.is_success():
                 print(
                     f"[{self.name}] Task plan failed to execute on action {n+1}/{num_acts}"
                 )
@@ -733,10 +816,10 @@ class Robot:
         if self.world.has_gui:
             self.world.gui.set_buttons_during_action(True)
 
-        print(f"[{self.name}] Task plan completed with success: {success}")
+        print(f"[{self.name}] Task plan completed with status: {result.status.name}")
         self.executing_plan = False
         self.current_plan = None
-        return success, num_completed
+        return result, num_completed
 
     def __repr__(self):
         """Returns printable string."""

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -9,6 +9,7 @@ from .locations import Location, ObjectSpawn
 from .objects import Object
 from .room import Room
 from .robot import Robot
+from ..planning.actions import ExecutionResult, ExecutionStatus
 from ..utils.general import InvalidEntityCategoryException
 from ..utils.pose import Pose
 from ..utils.knowledge import (
@@ -289,27 +290,36 @@ class World:
 
         :param hallway: Hallway object to open.
         :type hallway: :class:`pyrobosim.core.hallway.Hallway`
-        :return: True if the hallway was successfully opened, else False.
-        :rtype: bool
+        :return: An object describing the execution result.
+        :rtype: :class:`pyrobosim.planning.actions.ExecutionResult`
         """
         # Validate the input
         if not hallway in self.hallways:
-            warnings.warn("Invalid hallway specified.")
-            return False
+            message = "Invalid hallway specified."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
 
         if hallway.is_open:
-            warnings.warn(f"{hallway} is already open.")
-            return False
+            message = f"{hallway} is already open."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
 
         if hallway.is_locked:
-            warnings.warn(f"{hallway} is locked.")
-            return False
+            message = f"{hallway} is locked."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
 
         hallway.is_open = True
         if self.has_gui:
             self.gui.canvas.show_hallways()
             self.gui.canvas.draw_and_sleep()
-        return True
+        return ExecutionResult(status=ExecutionStatus.SUCCESS)
 
     def close_hallway(self, hallway, ignore_robots=[]):
         """
@@ -319,32 +329,44 @@ class World:
         :type hallway: :class:`pyrobosim.core.hallway.Hallway`
         :param ignore_robots: List of robots to ignore, for example the robot closing the hallway.
         :type ignore_robots: list[:class:`pyrobosim.core.robot.Robot`]
-        :return: True if the hallway was successfully closed, else False.
-        :rtype: bool
+        :return: An object describing the execution result.
+        :rtype: :class:`pyrobosim.planning.actions.ExecutionResult`
         """
         # Validate the input
         if not hallway in self.hallways:
-            warnings.warn("Invalid hallway specified.")
-            return False
+            message = "Invalid hallway specified."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
 
         if not hallway.is_open:
-            warnings.warn(f"{hallway} is already closed.")
-            return False
+            message = f"{hallway} is already closed."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
 
         if hallway.is_locked:
-            warnings.warn(f"{hallway} is locked.")
-            return False
+            message = f"{hallway} is locked."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
 
         for robot in [r for r in self.robots if r not in ignore_robots]:
             if hallway.is_collision_free(robot.get_pose()):
-                warnings.warn(f"Robot {robot.name} is in {hallway}. Cannot close.")
-                return False
+                message = f"Robot {robot.name} is in {hallway}. Cannot close."
+                warnings.warn(message)
+                return ExecutionResult(
+                    status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+                )
 
         hallway.is_open = False
         if self.has_gui:
             self.gui.canvas.show_hallways()
             self.gui.canvas.draw_and_sleep()
-        return True
+        return ExecutionResult(status=ExecutionStatus.SUCCESS)
 
     def lock_hallway(self, hallway):
         """
@@ -352,20 +374,26 @@ class World:
 
         :param hallway: Hallway object to lock.
         :type hallway: :class:`pyrobosim.core.hallway.Hallway`
-        :return: True if the hallway was successfully locked, else False.
-        :rtype: bool
+        :return: An object describing the execution result.
+        :rtype: :class:`pyrobosim.planning.actions.ExecutionResult`
         """
         # Validate the input
         if not hallway in self.hallways:
-            warnings.warn("Invalid hallway specified.")
-            return False
+            message = "Invalid hallway specified."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
 
         if hallway.is_locked:
-            warnings.warn(f"{hallway} is already locked.")
-            return False
+            message = f"{hallway} is already locked."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
 
         hallway.is_locked = True
-        return True
+        return ExecutionResult(status=ExecutionStatus.SUCCESS)
 
     def unlock_hallway(self, hallway):
         """
@@ -373,20 +401,26 @@ class World:
 
         :param hallway: Hallway object to unlock.
         :type hallway: :class:`pyrobosim.core.hallway.Hallway`
-        :return: True if the hallway was successfully unlocked, else False.
-        :rtype: bool
+        :return: An object describing the execution result.
+        :rtype: :class:`pyrobosim.planning.actions.ExecutionResult`
         """
         # Validate the input
         if not hallway in self.hallways:
-            warnings.warn("Invalid hallway specified.")
-            return False
+            message = "Invalid hallway specified."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
 
         if not hallway.is_locked:
-            warnings.warn(f"{hallway} is already unlocked.")
-            return False
+            message = f"{hallway} is already unlocked."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
 
         hallway.is_locked = False
-        return True
+        return ExecutionResult(status=ExecutionStatus.SUCCESS)
 
     def add_location(self, **location_config):
         r"""

--- a/pyrobosim/pyrobosim/navigation/execution.py
+++ b/pyrobosim/pyrobosim/navigation/execution.py
@@ -133,11 +133,11 @@ class ConstantVelocityExecutor:
 
         # Finalize path execution.
         time.sleep(0.1)  # To ensure background threads get the end of the path.
-        self.robot.last_nav_status = status
+        self.robot.last_nav_result = ExecutionResult(status=status, message=message)
         self.robot.executing_nav = False
         self.robot.executing_action = False
         self.robot.current_action = None
-        return ExecutionResult(status=status, message=message)
+        return self.robot.last_nav_result
 
     def validate_remaining_path(self):
         """

--- a/pyrobosim/pyrobosim/navigation/execution.py
+++ b/pyrobosim/pyrobosim/navigation/execution.py
@@ -4,6 +4,7 @@ import time
 import threading
 import warnings
 
+from ..planning.actions import ExecutionResult, ExecutionStatus
 from ..utils.motion import Path
 from ..utils.trajectory import get_constant_speed_trajectory, interpolate_trajectory
 
@@ -52,7 +53,8 @@ class ConstantVelocityExecutor:
 
         # Execution state
         self.current_traj_time = 0.0
-        self.abort_execution = False
+        self.abort_execution = False  # Flag to abort internally
+        self.cancel_execution = False  # Flag to cancel from user
 
     def execute(self, path, realtime_factor=1.0):
         """
@@ -63,15 +65,23 @@ class ConstantVelocityExecutor:
         :param realtime_factor: A multiplier on the execution time relative to
             real time, defaults to 1.0.
         :type realtime_factor: float, optional
-        :return: True if execution is complete, else False.
-        :rtype: bool
+        :return: An object describing the execution result.
+        :rtype: :class:`pyrobosim.planning.actions.ExecutionResult`
         """
         if self.robot is None:
-            warnings.warn("No robot attached to execute the trajectory.")
-            return False
+            message = "No robot attached to execute the trajectory."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE,
+                message=message,
+            )
         elif path.num_poses < 2:
-            warnings.warn("Not enough waypoints in path to execute.")
-            return False
+            message = "Not enough waypoints in path to execute."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE,
+                message=message,
+            )
 
         self.robot.executing_nav = True
         self.current_traj_time = 0.0
@@ -93,7 +103,8 @@ class ConstantVelocityExecutor:
             self.validation_timer.start()
 
         # Execute the trajectory.
-        success = True
+        status = ExecutionStatus.SUCCESS
+        message = ""
         sleep_time = self.dt / realtime_factor
         is_holding_object = self.robot.manipulated_object is not None
         for i in range(traj_interp.num_points()):
@@ -105,22 +116,28 @@ class ConstantVelocityExecutor:
                 self.robot.manipulated_object.set_pose(cur_pose)
 
             if self.abort_execution:
-                warnings.warn("Trajectory execution aborted.")
-                success = False
+                if self.validate_during_execution:
+                    self.validation_timer.join()
+                message = "Trajectory execution aborted."
+                warnings.warn(message)
+                status = ExecutionStatus.EXECUTION_FAILURE
+                break
+            if self.cancel_execution:
+                self.cancel_execution = False
+                message = "Trajectory execution canceled by user."
+                warnings.warn(message)
+                status = ExecutionStatus.CANCELED
                 break
 
             time.sleep(max(0, sleep_time - (time.time() - start_time)))
 
         # Finalize path execution.
         time.sleep(0.1)  # To ensure background threads get the end of the path.
-        self.abort_execution = True
-        if self.validate_during_execution:
-            self.validation_timer.join()
+        self.robot.last_nav_status = status
         self.robot.executing_nav = False
-        self.robot.last_nav_successful = success
         self.robot.executing_action = False
         self.robot.current_action = None
-        return self.robot.last_nav_successful
+        return ExecutionResult(status=status, message=message)
 
     def validate_remaining_path(self):
         """

--- a/pyrobosim/pyrobosim/planning/actions.py
+++ b/pyrobosim/pyrobosim/planning/actions.py
@@ -1,5 +1,6 @@
 """ Defines actions for task and motion planning. """
 
+from enum import IntEnum
 import numpy as np
 import time
 
@@ -25,6 +26,63 @@ class ExecutionOptions:
         self.success_probability = success_probability
         self.rng_seed = rng_seed
         self.rng = np.random.default_rng(seed=rng_seed)
+
+
+class ExecutionStatus(IntEnum):
+    """Enumeration for action or plan execution status."""
+
+    UNKNOWN = -1
+
+    # Action executed successfully.
+    SUCCESS = 0
+
+    # Preconditions not sufficient to execute the action.
+    # For example, the action was to pick an object but there was no object visible.
+    PRECONDITION_FAILURE = 1
+
+    # Planning failed, for example a path planner or grasp planner did not produce a solution.
+    PLANNING_FAILURE = 2
+
+    # Preconditions were met and planning succeeded, but execution failed.
+    EXECUTION_FAILURE = 3
+
+    # Execution succeeded, but post-execution validation failed.
+    POSTCONDITION_FAILURE = 4
+
+    # Invalid action type.
+    INVALID_ACTION = 5
+
+    # The action was canceled by a user or upstream program.
+    CANCELED = 6
+
+
+class ExecutionResult:
+    """Contains the result of executing actions or plans."""
+
+    def __init__(self, status=ExecutionStatus.UNKNOWN, message=None):
+        """
+        Creates a new execution result instance.
+
+        :param status: The resulting status code. Defaults to UNKNOWN.
+        :type status: :class:`pyrobosim.planning.actions.ExecutionStatus`
+        :param message: An optional message describing the result.
+        :type message: str
+        """
+        self.status = status
+        self.message = message
+
+    def is_success(self):
+        """
+        Helper function to determine if an execution result is successful.
+
+        :return: True if successful, otherwise False.
+        :rtype: bool
+        """
+        return self.status == ExecutionStatus.SUCCESS
+
+    def __repr__(self):
+        """Returns printable string."""
+        return f"Execution status: {self.status.name}"
 
 
 class TaskAction:

--- a/pyrobosim_msgs/CMakeLists.txt
+++ b/pyrobosim_msgs/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(geometry_msgs REQUIRED)
 # Generate custom interfaces
 set(msg_files
   "msg/ActionExecutionOptions.msg"
+  "msg/ExecutionResult.msg"
   "msg/GoalPredicate.msg"
   "msg/GoalSpecification.msg"
   "msg/LocationState.msg"

--- a/pyrobosim_msgs/action/ExecuteTaskAction.action
+++ b/pyrobosim_msgs/action/ExecuteTaskAction.action
@@ -6,7 +6,7 @@ pyrobosim_msgs/TaskAction action
 ---
 
 # Result
-bool success
+pyrobosim_msgs/ExecutionResult execution_result
 
 ---
 

--- a/pyrobosim_msgs/action/ExecuteTaskPlan.action
+++ b/pyrobosim_msgs/action/ExecuteTaskPlan.action
@@ -6,7 +6,7 @@ pyrobosim_msgs/TaskPlan plan
 ---
 
 # Result
-bool success
+pyrobosim_msgs/ExecutionResult execution_result
 int64 num_completed
 int64 num_total
 

--- a/pyrobosim_msgs/msg/ExecutionResult.msg
+++ b/pyrobosim_msgs/msg/ExecutionResult.msg
@@ -1,0 +1,37 @@
+# Execution Result ROS Message
+
+########################################
+# Constant values for the status codes #
+########################################
+int32 UNKNOWN=-1
+
+# Action executed successfully.
+int32 SUCCESS=0
+
+# Preconditions not sufficient to execute the action.
+# For example, the action was to pick an object but there was no object visible.
+int32 PRECONDITION_FAILURE=1
+
+# Planning failed, for example a path planner or grasp planner did not produce a solution.
+int32 PLANNING_FAILURE=2
+
+# Preconditions were met and planning succeeded, but execution failed.
+int32 EXECUTION_FAILURE=3
+
+# Execution succeeded, but post-execution validation failed.
+int32 POSTCONDITION_FAILURE=4
+
+# Invalid action type.
+int32 INVALID_ACTION=5
+
+# The action was canceled by a user or upstream program.
+int32 CANCELED=6
+
+##################
+# Message Fields #
+##################
+# The status code.
+int32 status -1
+
+# A message describing the result.
+string message

--- a/pyrobosim_ros/pyrobosim_ros/ros_conversions.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_conversions.py
@@ -234,3 +234,33 @@ def ros_duration_to_float(ros_duration):
     :type: float
     """
     return 1.0e-9 * ros_duration.nanoseconds
+
+
+def execution_result_to_ros(result):
+    """
+    Converts an execution result object to its corresponding ROS message.
+
+    :param result: The execution result object.
+    :type result: :class:`pyrobosim.planning.actions.ExecutionResult`
+    :return: The equivalent ROS message.
+    :rtype: :class:`pyrobosim_msgs.msg.ExecutionResult`
+    """
+    return ros_msgs.ExecutionResult(
+        status=getattr(acts.ExecutionStatus, result.status.name),
+        message=result.message or "",
+    )
+
+
+def execution_result_from_ros(msg):
+    """
+    Converts an execution result ROS message to its corresponding object.
+
+    :param result: The execution result ROS message.
+    :type result: :class:`pyrobosim_msgs.msg.ExecutionResult`
+    :return: The equivalent native PyRoboSim object.
+    :rtype: :class:`pyrobosim.planning.actions.ExecutionResult`
+    """
+    return acts.ExecutionResult(
+        status=getattr(ros_msgs.ExecutionResult, msg.status.name),
+        message=msg.message or None,
+    )

--- a/test/core/test_hallway.py
+++ b/test/core/test_hallway.py
@@ -7,6 +7,7 @@ Tests for hallway creation in pyrobosim.
 import pytest
 
 from pyrobosim.core import Hallway, World
+from pyrobosim.planning.actions import ExecutionStatus
 
 
 class TestHallway:
@@ -96,91 +97,75 @@ class TestHallway:
         assert not hallway.is_locked
 
         # When trying to open the hallway, it should say it's already open.
-        with pytest.warns(UserWarning) as warn_info:
+        with pytest.warns(UserWarning):
             result = self.test_world.open_hallway(hallway)
-        assert (
-            warn_info[0].message.args[0]
-            == "Hallway: hall_room_start_room_end is already open."
-        )
-        assert not result
+        assert result.status == ExecutionStatus.PRECONDITION_FAILURE
+        assert result.message == "Hallway: hall_room_start_room_end is already open."
         assert hallway.is_open
         assert not hallway.is_locked
 
         # Closing should work
         result = self.test_world.close_hallway(hallway)
-        assert result
+        assert result.is_success()
         assert not hallway.is_open
         assert not hallway.is_locked
 
         # Locking should work
         result = self.test_world.lock_hallway(hallway)
-        assert result
+        assert result.is_success()
         assert not hallway.is_open
         assert hallway.is_locked
 
         # Opening should not work due to being locked
-        with pytest.warns(UserWarning) as warn_info:
+        with pytest.warns(UserWarning):
             result = self.test_world.open_hallway(hallway)
-        assert (
-            warn_info[0].message.args[0]
-            == "Hallway: hall_room_start_room_end is locked."
-        )
-        assert not result
+        assert result.status == ExecutionStatus.PRECONDITION_FAILURE
+        assert result.message == "Hallway: hall_room_start_room_end is locked."
         assert not hallway.is_open
         assert hallway.is_locked
 
         # Closing should not work due to already being closed
-        with pytest.warns(UserWarning) as warn_info:
+        with pytest.warns(UserWarning):
             result = self.test_world.close_hallway(hallway)
-        assert (
-            warn_info[0].message.args[0]
-            == "Hallway: hall_room_start_room_end is already closed."
-        )
-        assert not result
+        assert result.status == ExecutionStatus.PRECONDITION_FAILURE
+        assert result.message == "Hallway: hall_room_start_room_end is already closed."
         assert not hallway.is_open
         assert hallway.is_locked
 
         # Locking should not work due to already being locked
-        with pytest.warns(UserWarning) as warn_info:
+        with pytest.warns(UserWarning):
             result = self.test_world.lock_hallway(hallway)
-        assert (
-            warn_info[0].message.args[0]
-            == "Hallway: hall_room_start_room_end is already locked."
-        )
-        assert not result
+        assert result.status == ExecutionStatus.PRECONDITION_FAILURE
+        assert result.message == "Hallway: hall_room_start_room_end is already locked."
         assert not hallway.is_open
         assert hallway.is_locked
 
         # Unlocking should work
         result = self.test_world.unlock_hallway(hallway)
-        assert result
+        assert result.is_success()
         assert not hallway.is_open
         assert not hallway.is_locked
 
         # Unlocking should not work due to already being unlocked
-        with pytest.warns(UserWarning) as warn_info:
+        with pytest.warns(UserWarning):
             result = self.test_world.unlock_hallway(hallway)
+        assert result.status == ExecutionStatus.PRECONDITION_FAILURE
         assert (
-            warn_info[0].message.args[0]
-            == "Hallway: hall_room_start_room_end is already unlocked."
+            result.message == "Hallway: hall_room_start_room_end is already unlocked."
         )
-        assert not result
         assert not hallway.is_open
         assert not hallway.is_locked
 
         # Opening should work
         result = self.test_world.open_hallway(hallway)
-        assert result
+        assert result.is_success()
         assert hallway.is_open
         assert not hallway.is_locked
 
         # Opening again should not work due to already being open
-        with pytest.warns(UserWarning) as warn_info:
+        with pytest.warns(UserWarning):
             result = self.test_world.open_hallway(hallway)
-        assert (
-            warn_info[0].message.args[0]
-            == "Hallway: hall_room_start_room_end is already open."
-        )
-        assert not result
+        assert result.status == ExecutionStatus.PRECONDITION_FAILURE
+        assert result.message == "Hallway: hall_room_start_room_end is already open."
         assert hallway.is_open
         assert not hallway.is_locked

--- a/test/core/test_robot.py
+++ b/test/core/test_robot.py
@@ -155,7 +155,7 @@ class TestRobot:
         while robot.executing_nav:
             time.sleep(0.1)
         assert not robot.executing_nav
-        assert robot.last_nav_status == ExecutionStatus.SUCCESS
+        assert robot.last_nav_result.is_success()
         pose = robot.get_pose()
         assert pose.x == pytest.approx(goal_pose.x)
         assert pose.y == pytest.approx(goal_pose.y)

--- a/test/system/test_system.py
+++ b/test/system/test_system.py
@@ -11,6 +11,7 @@ import time
 
 from pyrobosim.core import WorldYamlLoader
 from pyrobosim.gui import PyRoboSimGUI
+from pyrobosim.planning.actions import ExecutionStatus
 from pyrobosim.utils.knowledge import query_to_entity
 
 
@@ -59,7 +60,7 @@ class TestSystem:
             time.sleep(0.2)
         robot.location = world.get_location_from_pose(robot.get_pose())
 
-        assert robot.last_nav_successful
+        assert robot.last_nav_status == ExecutionStatus.SUCCESS
         assert (
             robot.location == expected_location
             or robot.location in expected_location.children

--- a/test/system/test_system.py
+++ b/test/system/test_system.py
@@ -60,7 +60,7 @@ class TestSystem:
             time.sleep(0.2)
         robot.location = world.get_location_from_pose(robot.get_pose())
 
-        assert robot.last_nav_status == ExecutionStatus.SUCCESS
+        assert robot.last_nav_status.is_success()
         assert (
             robot.location == expected_location
             or robot.location in expected_location.children

--- a/test/system/test_system.py
+++ b/test/system/test_system.py
@@ -74,6 +74,7 @@ class TestSystem:
         nav_queries = [
             "bathroom",
             "bedroom desk",
+            "hall_kitchen_bathroom",
             "counter0_right",
             "kitchen apple",
         ]

--- a/test/system/test_system.py
+++ b/test/system/test_system.py
@@ -60,7 +60,7 @@ class TestSystem:
             time.sleep(0.2)
         robot.location = world.get_location_from_pose(robot.get_pose())
 
-        assert robot.last_nav_status.is_success()
+        assert robot.last_nav_result.is_success()
         assert (
             robot.location == expected_location
             or robot.location in expected_location.children


### PR DESCRIPTION
This PR switches action/plan execution from returning a binary success/failure to using a full `ExecutionStatus` object with different status codes and optional messages.

The ROS interface is also affected by the same, adding a new `pyrobosim_msgs.msg.ExecutionStatus` message type. This is a field in the result of both action interfaces.

Closes #185 