### PR TITLE
Add ROS service to set location state

### DIFF
--- a/pyrobosim_msgs/CMakeLists.txt
+++ b/pyrobosim_msgs/CMakeLists.txt
@@ -29,6 +29,7 @@ set(msg_files
 
 set(srv_files
   "srv/RequestWorldState.srv"
+  "srv/SetLocationState.srv"
 )
 
 set(action_files

--- a/pyrobosim_msgs/srv/RequestWorldState.srv
+++ b/pyrobosim_msgs/srv/RequestWorldState.srv
@@ -2,5 +2,5 @@
 
 # No request
 ---
-# Response contains a world sttae
+# Response contains a world state
 WorldState state

--- a/pyrobosim_msgs/srv/SetLocationState.srv
+++ b/pyrobosim_msgs/srv/SetLocationState.srv
@@ -1,0 +1,10 @@
+# ROS service to set the state of a location
+
+# Request
+string location_name
+bool open
+bool lock
+
+---
+# Response
+ExecutionResult result


### PR DESCRIPTION
This PR adds a new `/set_location_state` service to the ROS interface to open, close, lock, and unlock locations.

Right now, only Hallways are supported, but more will eventually be tracked by #208.

To test, you can run commands like these:

```
ros2 launch pyrobosim_ros demo.launch.py

ros2 service call /set_location_state pyrobosim_msgs/srv/SetLocationState \
  "{location_name: hall_kitchen_bathroom, open: false, lock: false}"
```

Closes #213 