### PR TITLE
Extend Open/Close actions to storage locations

### DIFF
--- a/docs/source/usage/robot_actions.rst
+++ b/docs/source/usage/robot_actions.rst
@@ -11,8 +11,8 @@ The actions currently supported are:
 * **Pick**: Picks up an object at the robot's current location.
 * **Place**: Places an object at the robot's current location.
 * **Detect**: Detects objects at the robot's current location. Refer to :ref:`partial_observability` for more details.
-* **Open**: Opens the robot's current location (currently, hallways are supported).
-* **Close**: Closes the robot's current location (currently, hallways are supported).
+* **Open**: Opens the robot's current location.
+* **Close**: Closes the robot's current location.
 
 
 Executing Actions and Plans

--- a/docs/source/yaml/location_schema.rst
+++ b/docs/source/yaml/location_schema.rst
@@ -26,6 +26,9 @@ The generic location schema, where ``<angle brackets>`` are placeholders, is:
            type: <footprint_type>
            <property>: <footprint_property>
      color: [<r>, <g>, <b>]
+     is_open: True
+     is_locked: False
+
 
 Examples
 --------

--- a/docs/source/yaml/world_schema.rst
+++ b/docs/source/yaml/world_schema.rst
@@ -65,8 +65,8 @@ The world schema looks as follows, where ``<angle brackets>`` are placeholders:
        width: <value>
        conn_method: <type>
        <conn_property>: <value>
-       is_open: true
-       is_locked: false
+       is_open: true  # Can only navigate through hallway if open
+       is_locked: false  # Can only open and close if unlocked
      - ...
      - ...
 
@@ -76,6 +76,8 @@ The world schema looks as follows, where ``<angle brackets>`` are placeholders:
        category: <loc_category>  # From location YAML file
        parent: <room_name>
        pose: [<x>, <y>, <z>, <yaw>]  # If not specified, will sample
+       is_open: true  # Can only pick, place, and detect if open
+       is_locked: true  # Can only open and close if unlocked
      - ...
      - ...
 

--- a/pyrobosim/pyrobosim/core/locations.py
+++ b/pyrobosim/pyrobosim/core/locations.py
@@ -32,7 +32,16 @@ class Location:
         """
         cls.metadata = EntityMetadata(filename)
 
-    def __init__(self, name=None, category=None, pose=None, parent=None, color=None):
+    def __init__(
+        self,
+        name=None,
+        category=None,
+        pose=None,
+        parent=None,
+        color=None,
+        is_open=True,
+        is_locked=False,
+    ):
         """
         Creates a location instance.
 
@@ -47,6 +56,10 @@ class Location:
         :param color: Visualization color as an (R, G, B) tuple in the range (0.0, 1.0).
             If using a category with a defined color, this parameter overrides the category color.
         :type color: (float, float, float), optional
+        :param is_open: If True, the location is open, otherwise it is closed.
+        :type is_open: bool, optional
+        :param is_locked: If True, the location is locked, meaning it cannot be opened or closed.
+        :type is_locked: bool, optional
         """
         # Validate input
         if parent is None:
@@ -58,6 +71,8 @@ class Location:
         self.name = name
         self.category = category
         self.parent = parent
+        self.is_open = is_open
+        self.is_locked = is_locked
 
         self.metadata = Location.metadata.get(self.category)
         if not self.metadata:
@@ -158,11 +173,11 @@ class Location:
         """Updates the visualization polygon for the location."""
         self.viz_patch = patch_from_polygon(
             self.polygon,
-            facecolor=None,
+            facecolor=None if self.is_open else self.viz_color,
             edgecolor=self.viz_color,
             linewidth=2,
-            fill=None,
-            alpha=0.75,
+            fill=not self.is_open,
+            alpha=0.5,
             zorder=2,
         )
 
@@ -285,6 +300,11 @@ class ObjectSpawn:
         else:
             x, y = pose[0], pose[1]
         return intersects_xy(self.polygon, x, y)
+
+    @property
+    def is_open(self):
+        """Property to check that an object spawn is open through its parent location."""
+        return self.parent.is_open
 
     def update_visualization_polygon(self):
         """Updates the visualization polygon for the object spawn."""

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -578,6 +578,136 @@ class World:
             return True
         return False
 
+    def open_location(self, location):
+        """
+        Opens a storage location.
+
+        :param location: Location object to open.
+        :type location: :class:`pyrobosim.core.locations.Location`
+        :return: An object describing the execution result.
+        :rtype: :class:`pyrobosim.planning.actions.ExecutionResult`
+        """
+        # Validate the input
+        if not location in self.locations:
+            message = "Invalid location specified."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
+
+        if location.is_open:
+            message = f"{location} is already open."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
+
+        if location.is_locked:
+            message = f"{location} is locked."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
+
+        location.is_open = True
+        location.update_visualization_polygon()
+        if self.has_gui:
+            self.gui.canvas.show_locations()
+            self.gui.canvas.draw_and_sleep()
+        return ExecutionResult(status=ExecutionStatus.SUCCESS)
+
+    def close_location(self, location):
+        """
+        Close a storage location.
+
+        :param location: Location object to close.
+        :type location: :class:`pyrobosim.core.locations.Location`
+        :return: An object describing the execution result.
+        :rtype: :class:`pyrobosim.planning.actions.ExecutionResult`
+        """
+        # Validate the input
+        if not location in self.locations:
+            message = "Invalid location specified."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
+
+        if not location.is_open:
+            message = f"{location} is already closed."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
+
+        if location.is_locked:
+            message = f"{location} is locked."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
+
+        location.is_open = False
+        location.update_visualization_polygon()
+        if self.has_gui:
+            self.gui.canvas.show_locations()
+            self.gui.canvas.draw_and_sleep()
+        return ExecutionResult(status=ExecutionStatus.SUCCESS)
+
+    def lock_location(self, location):
+        """
+        Locks a storage location.
+
+        :param location: Location object to lock.
+        :type location: :class:`pyrobosim.core.locations.Location`
+        :return: An object describing the execution result.
+        :rtype: :class:`pyrobosim.planning.actions.ExecutionResult`
+        """
+        # Validate the input
+        if not location in self.locations:
+            message = "Invalid location specified."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
+
+        if location.is_locked:
+            message = f"{location} is already locked."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
+
+        location.is_locked = True
+        return ExecutionResult(status=ExecutionStatus.SUCCESS)
+
+    def unlock_location(self, location):
+        """
+        Unlocks a storage location.
+
+        :param location: Location object to unlock.
+        :type location: :class:`pyrobosim.core.locations.Location`
+        :return: An object describing the execution result.
+        :rtype: :class:`pyrobosim.planning.actions.ExecutionResult`
+        """
+        # Validate the input
+        if not location in self.locations:
+            message = "Invalid location specified."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
+
+        if not location.is_locked:
+            message = f"{location} is already unlocked."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
+
+        location.is_locked = False
+        return ExecutionResult(status=ExecutionStatus.SUCCESS)
+
     def add_object(self, **object_config):
         r"""
         Adds an object to a specific location.

--- a/pyrobosim/pyrobosim/data/pddlstream_simple_world.yaml
+++ b/pyrobosim/pyrobosim/data/pddlstream_simple_world.yaml
@@ -116,14 +116,20 @@ locations:
   - category: table
     parent: kitchen
     pose: [0.85, -0.5, 0.0, -1.57]
+    is_open: True
+    is_locked: True
 
   - category: desk
     parent: bedroom
     pose: [3.15, 3.65, 0.0, 0.0]
+    is_open: True
+    is_locked: False
 
   - category: counter
     parent: bathroom
     pose: [-2.45, 2.5, 0.0, 1.767]
+    is_open: True
+    is_locked: True
 
 
 # OBJECTS: Can be picked, placed, and moved by robot

--- a/pyrobosim/pyrobosim/data/test_world.yaml
+++ b/pyrobosim/pyrobosim/data/test_world.yaml
@@ -127,21 +127,29 @@ locations:
     category: table
     parent: kitchen
     pose: [0.85, -0.5, 0.0, -1.57]
+    is_open: True
+    is_locked: True
 
   - name: my_desk
     category: desk
     parent: bedroom
     pose: [3.15, 3.65, 0.0, 0.0]
+    is_open: True
+    is_locked: False
 
   - name: counter0
     category: counter
     parent: bathroom
     pose: [-2.45, 2.5, 0.0, 1.767]
+    is_open: True
+    is_locked: True
 
   - name: trash
     category: trash_can
     parent: kitchen
     pose: [0.9, 1.1, 0.0, 1.57]
+    is_open: False
+    is_locked: False
 
 
 # OBJECTS: Can be picked, placed, and moved by robot

--- a/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
+++ b/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
@@ -137,21 +137,29 @@ locations:
     category: table
     parent: kitchen
     pose: [0.85, -0.5, 0.0, -1.57]
+    is_open: True
+    is_locked: True
 
   - name: my_desk
     category: desk
     parent: bedroom
     pose: [3.15, 3.65, 0.0, 0.0]
+    is_open: True
+    is_locked: False
 
   - name: counter0
     category: counter
     parent: bathroom
     pose: [-2.45, 2.5, 0.0, 1.767]
+    is_open: True
+    is_locked: True
 
   - name: trash
     category: trash_can
     parent: kitchen
     pose: [0.9, 1.1, 0.0, 1.57]
+    is_open: False
+    is_locked: False
 
 
 # OBJECTS: Can be picked, placed, and moved by robot

--- a/pyrobosim/pyrobosim/gui/main.py
+++ b/pyrobosim/pyrobosim/gui/main.py
@@ -181,14 +181,14 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):
         """Update the state of buttons based on the state of the robot."""
         robot = self.get_current_robot()
         if robot:
-            at_object_spawn = robot.at_object_spawn()
+            at_open_object_spawn = robot.at_object_spawn() and robot.location.is_open
             can_pick = robot.manipulated_object is None
             can_open_close = robot.at_openable_location() and can_pick
 
             self.nav_button.setEnabled(not robot.is_moving())
-            self.pick_button.setEnabled(can_pick and at_object_spawn)
-            self.place_button.setEnabled((not can_pick) and at_object_spawn)
-            self.detect_button.setEnabled(at_object_spawn)
+            self.pick_button.setEnabled(can_pick and at_open_object_spawn)
+            self.place_button.setEnabled((not can_pick) and at_open_object_spawn)
+            self.detect_button.setEnabled(at_open_object_spawn)
             self.open_button.setEnabled(can_open_close and not robot.location.is_open)
             self.close_button.setEnabled(can_open_close and robot.location.is_open)
 

--- a/pyrobosim_ros/pyrobosim_ros/ros_interface.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_interface.py
@@ -11,7 +11,7 @@ import time
 
 from geometry_msgs.msg import Twist
 from pyrobosim.core.hallway import Hallway
-from pyrobosim.core.locations import ObjectSpawn
+from pyrobosim.core.locations import Location
 from pyrobosim_msgs.action import ExecuteTaskAction, ExecuteTaskPlan
 from pyrobosim_msgs.msg import ExecutionResult, RobotState, LocationState, ObjectState
 from pyrobosim_msgs.srv import RequestWorldState, SetLocationState
@@ -464,14 +464,13 @@ class WorldROSWrapper(Node):
             response.result.message = message
             return response
 
-        if isinstance(entity, ObjectSpawn):
+        if isinstance(entity, Location):
             # Try open or close the location if its status needs to be toggled.
-            location = entity.parent
             if request.open != entity.is_open:
                 if request.open:
-                    result = self.world.open_location(location)
+                    result = self.world.open_location(entity)
                 else:
-                    result = self.world.close_hallway(location)
+                    result = self.world.close_location(entity)
 
                 if not result.is_success():
                     response.result = execution_result_to_ros(result)
@@ -480,9 +479,9 @@ class WorldROSWrapper(Node):
             # Try lock or unlock the location if its status needs to be toggled.
             if request.lock != entity.is_locked:
                 if request.lock:
-                    result = self.world.lock_hallway(location)
+                    result = self.world.lock_location(entity)
                 else:
-                    result = self.world.unlock_hallway(location)
+                    result = self.world.unlock_location(entity)
 
                 if not result.is_success():
                     response.result = execution_result_to_ros(result)

--- a/test/core/test_hallway.py
+++ b/test/core/test_hallway.py
@@ -161,11 +161,3 @@ class TestHallway:
         assert result.is_success()
         assert hallway.is_open
         assert not hallway.is_locked
-
-        # Opening again should not work due to already being open
-        with pytest.warns(UserWarning):
-            result = self.test_world.open_hallway(hallway)
-        assert result.status == ExecutionStatus.PRECONDITION_FAILURE
-        assert result.message == "Hallway: hall_room_start_room_end is already open."
-        assert hallway.is_open
-        assert not hallway.is_locked

--- a/test/core/test_world.py
+++ b/test/core/test_world.py
@@ -1,5 +1,5 @@
 """
-Unit tests for core world modeling
+Unit tests for core world modeling.
 """
 
 import os
@@ -9,7 +9,7 @@ import numpy as np
 from pyrobosim.core import Hallway, Object, World
 from pyrobosim.utils.pose import Pose
 
-from pyrobosim.utils.general import get_data_folder, InvalidEntityCategoryException
+from pyrobosim.utils.general import get_data_folder
 
 
 class TestWorldModeling:

--- a/test/system/test_system.py
+++ b/test/system/test_system.py
@@ -126,20 +126,20 @@ class TestSystem:
         """
         Test open and close UI actions.
         """
-        start_end_room_queries = [("kitchen", "bathroom"), ("bedroom", "bathroom")]
+        location_queries = ["hall_kitchen_bathroom", "my_desk"]
 
         window = self.app.main_window
         world = self.app.world
 
-        for room_start, room_end in start_end_room_queries:
+        for location_name in location_queries:
             # Navigate to hallway location
-            hallway = world.get_hallways_from_rooms(room_start, room_end)[0]
-            self.nav_helper(hallway.name)
+            location = world.get_entity_by_name(location_name)
+            self.nav_helper(location.name)
 
-            # Close the hallway and verify that it's closed.
+            # Close the location and verify that it's closed.
             window.on_close_click()
-            assert not hallway.is_open
+            assert not location.is_open
 
-            # Open the hallway and verify that it's open.
+            # Open the location and verify that it's open.
             window.on_open_click()
-            assert hallway.is_open
+            assert location.is_open

--- a/test/system/test_system_world.yaml
+++ b/test/system/test_system_world.yaml
@@ -115,16 +115,22 @@ locations:
     category: table
     parent: kitchen
     pose: [0.85, -0.5, 0.0, -1.57]
+    is_open: true
+    is_locked: true
 
   - name: my_desk
     category: desk
     parent: bedroom
     pose: [3.15, 3.65, 0.0, 0.0]
+    is_open: true
+    is_locked: false
 
   - name: counter0
     category: counter
     parent: bathroom
     pose: [-2.45, 2.5, 0.0, 1.767]
+    is_open: true
+    is_locked: true
 
 
 # OBJECTS: Can be picked, placed, and moved by robot


### PR DESCRIPTION
This PR extends the Open/Close actions from just Hallway objects to also Location objects.

I don't like how much duplication there is between these 2 types of objects... but I'm inclined to handle that later.

https://github.com/user-attachments/assets/79438f20-5d5a-4ad5-b804-ec7476cf1208

Closes #208 