### PR TITLE
Show path in GUI when the path is given beforehand + unify query to entity support in GUI vs. non-GUI actions

### DIFF
--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -440,12 +440,12 @@ class Robot:
         else:
             obj = self.world.get_object_by_name(obj_query)
             if not obj and isinstance(obj_query, str):
-                obj = resolve_to_object(
+                obj = query_to_entity(
                     self.world,
-                    category=obj_query,
-                    location=loc,
-                    resolution_strategy="nearest",
+                    obj_query,
+                    mode="object",
                     robot=self,
+                    resolution_strategy="nearest",
                 )
             if not obj:
                 message = f"Found no object {obj_query} to pick."

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -739,8 +739,13 @@ class Robot:
             self.executing_nav = True
             path = action.path if action.path.num_poses > 0 else None
             if self.world.has_gui:
+                if not isinstance(action.target_location, str):
+                    target_location_name = action.target_location.name
+                else:
+                    target_location_name = action.target_location
+
                 self.world.gui.canvas.navigate_signal.emit(
-                    self, action.target_location, path
+                    self, target_location_name, path
                 )
                 while self.executing_nav:
                     time.sleep(0.5)  # Delay to wait for navigation

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -256,7 +256,10 @@ class Robot:
 
         path = self.path_planner.plan(start, goal)
         if self.world and self.world.has_gui:
-            self.world.gui.canvas.show_planner_and_path_signal.emit(self, path)
+            show_graph = True
+            self.world.gui.canvas.show_planner_and_path_signal.emit(
+                self, show_graph, path
+            )
         return path
 
     def follow_path(
@@ -378,6 +381,11 @@ class Robot:
                     status=ExecutionStatus.PLANNING_FAILURE,
                     message=message,
                 )
+        elif self.world and self.world.has_gui:
+            show_graph = False
+            self.world.gui.canvas.show_planner_and_path_signal.emit(
+                self, show_graph, path
+            )
 
         return self.follow_path(
             path,

--- a/pyrobosim/pyrobosim/gui/main.py
+++ b/pyrobosim/pyrobosim/gui/main.py
@@ -259,19 +259,9 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):
         if robot and robot.executing_action:
             return
 
-        query_list = [elem for elem in self.goal_textbox.text().split(" ") if elem]
-        loc = query_to_entity(
-            self.world,
-            query_list,
-            mode="location",
-            robot=robot,
-            resolution_strategy="nearest",
-        )
-        if not loc:
-            return
-
+        loc = self.goal_textbox.text()
         print(f"[{robot.name}] Navigating to {loc}")
-        self.canvas.navigate(robot, loc)
+        self.canvas.navigate_signal.emit(robot, loc, None)
 
     def on_pick_click(self):
         """Callback to pick an object."""

--- a/pyrobosim/pyrobosim/gui/main.py
+++ b/pyrobosim/pyrobosim/gui/main.py
@@ -10,7 +10,6 @@ from matplotlib.backends.qt_compat import QtCore
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT
 
 from .world_canvas import WorldCanvas
-from ..utils.knowledge import query_to_entity
 
 
 def start_gui(world):
@@ -260,26 +259,17 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):
             return
 
         loc = self.goal_textbox.text()
-        print(f"[{robot.name}] Navigating to {loc}")
-        self.canvas.navigate_signal.emit(robot, loc, None)
+        if loc:
+            print(f"[{robot.name}] Navigating to {loc}")
+            self.canvas.navigate_signal.emit(robot, loc, None)
 
     def on_pick_click(self):
         """Callback to pick an object."""
         robot = self.get_current_robot()
         if robot:
-            loc = robot.location
-            query_list = [elem for elem in self.goal_textbox.text().split(" ") if elem]
-            if loc:
-                query_list.append(loc.name)
-            obj = query_to_entity(
-                self.world,
-                query_list,
-                mode="object",
-                robot=robot,
-                resolution_strategy="nearest",
-            )
+            obj = self.goal_textbox.text()
             if obj:
-                print(f"[{robot.name}] Picking {obj.name}")
+                print(f"[{robot.name}] Picking {obj}")
                 self.canvas.pick_object(robot, obj)
                 self.update_button_state()
 

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -524,6 +524,7 @@ class WorldCanvas(FigureCanvasQTAgg):
         success = robot.place_object(pose=pose)
         self.axes.add_patch(obj.viz_patch)
         self.obj_patches.append(obj.viz_patch)
+        self.update_object_plot(obj)
         self.show_world_state(robot)
         self.draw_signal.emit()
         return success

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -95,7 +95,7 @@ class WorldCanvas(FigureCanvasQTAgg):
     show_robots_signal = Signal()
     """ Signal for showing robots without threading errors. """
 
-    show_planner_and_path_signal = Signal(Robot, Path)
+    show_planner_and_path_signal = Signal(Robot, bool, Path)
     """ Signal for showing planners and paths without threading errors. """
 
     def __init__(
@@ -339,7 +339,7 @@ class WorldCanvas(FigureCanvasQTAgg):
             self.fig.canvas.flush_events()
             time.sleep(0.005)
 
-    def show_planner_and_path(self, robot=None, path=None):
+    def show_planner_and_path(self, robot=None, show_graph=True, path=None):
         """
         Plot the path planner and latest path, if specified.
         This planner could be global (property of the world)
@@ -347,32 +347,33 @@ class WorldCanvas(FigureCanvasQTAgg):
 
         :param robot: If set to a Robot instance, uses that robot for display.
         :type robot: :class:`pyrobosim.core.robot.Robot`, optional
+        :param show_graph: If True, shows the path planner's latest graph(s).
+        :type show_graph: bool
         :param path: Path to goal location, defaults to None.
         :type path: :class:`pyrobosim.utils.motion.Path`, optional
         """
+        if not robot:
+            warnings.warn("No robot found")
+            return
+
         # Since removing artists while drawing can cause issues,
         # this function should also lock drawing.
         with self.draw_lock:
-            if not robot:
-                warnings.warn("No robot found")
-            else:
-                color = robot.color if robot is not None else "m"
-                if robot.path_planner:
-                    path_planner_artists = robot.path_planner.plot(
-                        self.axes, path=path, path_color=color
-                    )
+            color = robot.color if robot is not None else "m"
+            if robot.path_planner:
+                path_planner_artists = robot.path_planner.plot(
+                    self.axes, show_graph=show_graph, path=path, path_color=color
+                )
 
-                    for artist in self.path_planner_artists["graph"]:
-                        artist.remove()
-                    self.path_planner_artists["graph"] = path_planner_artists.get(
-                        "graph", []
-                    )
+                for artist in self.path_planner_artists["graph"]:
+                    artist.remove()
+                self.path_planner_artists["graph"] = path_planner_artists.get(
+                    "graph", []
+                )
 
-                    for artist in self.path_planner_artists["path"]:
-                        artist.remove()
-                    self.path_planner_artists["path"] = path_planner_artists.get(
-                        "path", []
-                    )
+                for artist in self.path_planner_artists["path"]:
+                    artist.remove()
+                self.path_planner_artists["path"] = path_planner_artists.get("path", [])
 
     def nav_animation_callback(self):
         """Timer callback function to animate navigating robots."""

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -83,6 +83,9 @@ class WorldCanvas(FigureCanvasQTAgg):
     draw_signal = Signal()
     """ Signal for drawing without threading errors. """
 
+    navigate_signal = Signal(Robot, str, Path)
+    """ Signal for starting a navigation task without threading errors. """
+
     show_hallways_signal = Signal()
     """ Signal for showing hallways without threading errors. """
 
@@ -153,6 +156,7 @@ class WorldCanvas(FigureCanvasQTAgg):
 
         # Connect signals
         self.draw_signal.connect(self.draw_and_sleep)
+        self.navigate_signal.connect(self.navigate)
         self.show_hallways_signal.connect(self.show_hallways)
         self.show_locations_signal.connect(self.show_locations)
         self.show_objects_signal.connect(self.show_objects)

--- a/pyrobosim/pyrobosim/navigation/path_planner.py
+++ b/pyrobosim/pyrobosim/navigation/path_planner.py
@@ -62,12 +62,14 @@ class PathPlanner:
         self.latest_path = self.planner.plan(start, goal)
         return self.latest_path
 
-    def plot(self, axes, path=None, path_color="m"):
+    def plot(self, axes, show_graph=True, path=None, path_color="m"):
         """
         Plots the planned path on a specified set of axes.
 
         :param axes: The axes on which to draw.
         :type axes: :class:`matplotlib.axes.Axes`
+        :param show_graph: If True, shows the path planner's latest graph(s).
+        :type show_graph: bool
         :param path: Path to display, defaults to None.
         :type path: :class:`pyrobosim.utils.motion.Path`, optional
         :param path_color: Color of the path, as an RGB tuple or string.
@@ -77,7 +79,9 @@ class PathPlanner:
         :rtype: list[:class:`matplotlib.artist.Artist`]
         """
 
-        return self.planner.plot(axes, path=path, path_color=path_color)
+        return self.planner.plot(
+            axes, show_graph=show_graph, path=path, path_color=path_color
+        )
 
     def show(self):
         """Displays the planned path on the GUI."""

--- a/pyrobosim/pyrobosim/navigation/planner_base.py
+++ b/pyrobosim/pyrobosim/navigation/planner_base.py
@@ -64,6 +64,8 @@ class PathPlannerBase:
 
         :param axes: The axes on which to draw.
         :type axes: :class:`matplotlib.axes.Axes`
+        :param show_graph: If True, shows the path planner's latest graph(s).
+        :type show_graph: bool
         :param path: Path to display, defaults to None. If none, uses the `latest_path` attribute.
         :type path: :class:`pyrobosim.utils.motion.Path`, optional
         :param path_color: Color of the path, as an RGB tuple or string.

--- a/pyrobosim/pyrobosim/utils/knowledge.py
+++ b/pyrobosim/pyrobosim/utils/knowledge.py
@@ -61,8 +61,9 @@ def query_to_entity(world, query_list, mode, resolution_strategy="first", robot=
 
     :param world: World model.
     :type world: :class:`pyrobosim.core.world.World`
-    :param query_list: List of query terms (e.g., "kitchen table apple")
-    :type query_list: list[str]
+    :param query_list: List of query terms (e.g., "kitchen table apple").
+        These can be specified as a list of strings, or as a single space-separated string.
+    :type query_list: str or list[str]
     :param mode: Can be either "location" or "object".
     :type mode: str
     :param resolution_strategy: Resolution strategy to apply (see :func:`apply_resolution_strategy`)
@@ -79,6 +80,12 @@ def query_to_entity(world, query_list, mode, resolution_strategy="first", robot=
     named_location = None
     loc_category = None
     obj_category = None
+
+    # Process the input and convert it to a list.
+    if query_list is None:
+        query_list = []
+    elif isinstance(query_list, str):
+        query_list = [elem for elem in query_list.split(" ") if elem]
 
     if robot is None:
         possible_objects = world.get_objects()

--- a/pyrobosim/pyrobosim/utils/knowledge.py
+++ b/pyrobosim/pyrobosim/utils/knowledge.py
@@ -138,7 +138,13 @@ def query_to_entity(world, query_list, mode, resolution_strategy="first", robot=
             return None
 
     # Special case: A room is selected purely by name
-    if room and not named_location and not loc_category and not obj_category:
+    if (
+        mode == "location"
+        and room
+        and not named_location
+        and not loc_category
+        and not obj_category
+    ):
         return world.get_room_by_name(room)
 
     # If a named location is given, check that have an object category and filter by that.
@@ -165,6 +171,9 @@ def query_to_entity(world, query_list, mode, resolution_strategy="first", robot=
                 return obj_candidate
             elif mode == "location":
                 return obj_candidate.parent
+
+    if mode == "object" and loc_category is None and robot:
+        loc_category = robot.location.name
 
     # Resolve a location from any other query
     if obj_category or mode == "object":

--- a/test/system/test_system.py
+++ b/test/system/test_system.py
@@ -45,7 +45,7 @@ class TestSystem:
         robot = window.get_current_robot()
         expected_location = query_to_entity(
             world,
-            nav_query.split(" "),
+            nav_query,
             mode="location",
             robot=robot,
             resolution_strategy="nearest",

--- a/test/utils/test_knowledge_utils.py
+++ b/test/utils/test_knowledge_utils.py
@@ -108,23 +108,23 @@ def test_query_to_entity():
 
     # Query entities based on locations and categories
     query = "kitchen table apple"
-    entity = query_to_entity(test_world, query.split(), "location")
+    entity = query_to_entity(test_world, query, "location")
     assert entity.name == "table0_tabletop"
-    entity = query_to_entity(test_world, query.split(), "object")
+    entity = query_to_entity(test_world, query, "object")
     assert entity.name == "gala"
     query = "kitchen table"
-    entity = query_to_entity(test_world, query.split(), "location")
+    entity = query_to_entity(test_world, query, "location")
     assert entity.name == "table0"
 
     # if we query to a random object on the kitchen table, its parent category should be table
-    entity = query_to_entity(test_world, query.split(), "object", "random")
+    entity = query_to_entity(test_world, query, "object", "random")
     assert entity.parent.category == "table"
 
     # nearest object on the kitchen table should be the apple or banana, depending on randomness
     robot = Robot(name="test_robot")
     test_world.add_robot(robot, pose=Pose(x=1.0, y=0.5))
     query = "kitchen table"
-    entity = query_to_entity(test_world, query.split(), "object", "nearest", robot)
+    entity = query_to_entity(test_world, query, "object", "nearest", robot)
     assert (
         entity.category in ["apple", "banana"]
         and entity.parent.category == "table"
@@ -133,7 +133,7 @@ def test_query_to_entity():
 
     # we want the nearest apple on the kitchen table, should no longer return the banana even though it is the nearest object
     query = "kitchen table apple"
-    entity = query_to_entity(test_world, query.split(), "object", "nearest", robot)
+    entity = query_to_entity(test_world, query, "object", "nearest", robot)
     assert entity.name == "gala"
 
     # things that should warn
@@ -141,13 +141,13 @@ def test_query_to_entity():
     # search for nonexistent object in real location
     for mode in ["object", "location"]:
         with pytest.warns(UserWarning):
-            entity = query_to_entity(test_world, query.split(), mode)
+            entity = query_to_entity(test_world, query, mode)
 
     # search for absolute garbage
     query = "fake fake fake"
     for mode in ["object", "location"]:
         with pytest.warns(UserWarning):
-            entity = query_to_entity(test_world, query.split(), mode)
+            entity = query_to_entity(test_world, query, mode)
 
 
 def test_resolve_to_location():


### PR DESCRIPTION
I realized when running the PDDLStream examples that the navigation path was not being displayed if the path was already given (i.e., planning doesn't happen at the time of executing the "navigate" action).

This probably was a problem introduced in https://github.com/sea-bass/pyrobosim/pull/202

This PR fixes that.

---

I also moved some query resolution / knowledge code that was in the UI to the regular robot actions, uncovering some kinks in those utilities, and fixed those as well.