### PR TITLE
[WIP] Simplify path planner implementation 

### DIFF
--- a/pyrobosim/examples/demo_astar.py
+++ b/pyrobosim/examples/demo_astar.py
@@ -18,9 +18,7 @@ def demo_astar():
     """Creates an occupancy grid based A* planner and plans a path."""
     robot = world.robots[0]
     planner_config = {
-        "grid": OccupancyGrid.from_world(
-            world, resolution=0.05, inflation_radius=1.5 * robot.radius
-        ),
+        "robot": robot,
         "diagonal_motion": True,
         "heuristic": "euclidean",
         "compress_path": False,


### PR DESCRIPTION
This PR aims to simplify the design patterns used in the implementation of path planners.
In addition, this PR will also add `reset` methods to the planners where it is missing, to enable recomputing the `grid` or `roadmap` to account for dynamic state of the world such as door opening and closing.

TODO:

- [ ]  A-star
- [ ]  RRT
- [ ] PRM
- [ ] WorldGraph