### PR TITLE
Handle path planning failures correctly in action interface

### DIFF
--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -263,7 +263,7 @@ class Robot:
                     warnings.warn(
                         f"Could not resolve goal location query: {query_list}"
                     )
-                    return False
+                    return None
 
             goal_node = self.world.graph_node_from_entity(goal, robot=self)
             if goal_node is None:
@@ -394,10 +394,11 @@ class Robot:
                 self.executing_nav = False
                 message = "Failed to plan a path."
                 warnings.warn(message)
-                return ExecutionResult(
+                self.last_nav_result = ExecutionResult(
                     status=ExecutionStatus.PLANNING_FAILURE,
                     message=message,
                 )
+                return self.last_nav_result
         elif self.world and self.world.has_gui:
             show_graph = False
             self.world.gui.canvas.show_planner_and_path_signal.emit(

--- a/pyrobosim_ros/test/test_ros_interface.py
+++ b/pyrobosim_ros/test/test_ros_interface.py
@@ -18,6 +18,28 @@ from pyrobosim_msgs.srv import RequestWorldState, SetLocationState
 from pyrobosim_ros.ros_interface import WorldROSWrapper
 
 
+def execute_ros_action(
+    goal_future, spin_timeout=0.1, goal_timeout=1.0, result_timeout=30.0
+):
+    """Helper function to execute a ROS action and wait for a result."""
+    start_time = time.time()
+    while not goal_future.done():
+        TestRosInterface.executor.spin_once(timeout_sec=spin_timeout)
+        if time.time() - start_time > goal_timeout:
+            print("Timed out waiting for goal to be accepted.")
+            break
+    assert goal_future.done()
+
+    result_future = goal_future.result().get_result_async()
+    while not result_future.done():
+        TestRosInterface.executor.spin_once(timeout_sec=spin_timeout)
+        if time.time() - start_time > result_timeout:
+            print("Timed out waiting for result to be received.")
+            break
+
+    return result_future
+
+
 class TestRosInterface:
     @staticmethod
     @pytest.mark.dependency(name="test_start_ros_interface")
@@ -164,6 +186,37 @@ class TestRosInterface:
             TestRosInterface.node, ExecuteTaskAction, "execute_action"
         )
 
+        # This is an invalid action.
+        goal = ExecuteTaskAction.Goal()
+        goal.action = TaskAction(robot="robot0", type="nonexistent_action")
+        goal_future = action_client.send_goal_async(goal)
+        with pytest.warns(UserWarning):
+            result_future = execute_ros_action(goal_future)
+
+        assert result_future.done()
+        exec_result = result_future.result().result.execution_result
+        assert exec_result.status == ExecutionResult.INVALID_ACTION
+        assert (
+            exec_result.message == "[robot0] Invalid action type: nonexistent_action."
+        )
+
+        # This action has bad parameters.
+        goal = ExecuteTaskAction.Goal()
+        goal.action = TaskAction(
+            robot="robot0",
+            type="navigate",
+            target_location="counter42",
+        )
+        goal_future = action_client.send_goal_async(goal)
+        with pytest.warns(UserWarning):
+            result_future = execute_ros_action(goal_future)
+
+        assert result_future.done()
+        exec_result = result_future.result().result.execution_result
+        assert exec_result.status == ExecutionResult.PLANNING_FAILURE
+        assert exec_result.message == "Failed to plan a path."
+
+        # This action should succeed.
         goal = ExecuteTaskAction.Goal()
         goal.action = TaskAction(
             robot="robot0",
@@ -171,19 +224,7 @@ class TestRosInterface:
             target_location="my_desk",
         )
         goal_future = action_client.send_goal_async(goal)
-
-        start_time = time.time()
-        while not goal_future.done():
-            TestRosInterface.executor.spin_once(timeout_sec=0.1)
-            if time.time() - start_time > 1.0:
-                break
-        assert goal_future.done()
-
-        result_future = goal_future.result().get_result_async()
-        while not result_future.done():
-            TestRosInterface.executor.spin_once(timeout_sec=0.1)
-            if time.time() - start_time > 30.0:
-                break
+        result_future = execute_ros_action(goal_future)
 
         assert result_future.done()
         assert (
@@ -213,19 +254,7 @@ class TestRosInterface:
         ]
         goal = ExecuteTaskPlan.Goal(plan=TaskPlan(robot="robot0", actions=task_actions))
         goal_future = action_client.send_goal_async(goal)
-
-        start_time = time.time()
-        while not goal_future.done():
-            TestRosInterface.executor.spin_once(timeout_sec=0.1)
-            if time.time() - start_time > 1.0:
-                break
-        assert goal_future.done()
-
-        result_future = goal_future.result().get_result_async()
-        while not result_future.done():
-            TestRosInterface.executor.spin_once(timeout_sec=0.1)
-            if time.time() - start_time > 30.0:
-                break
+        result_future = execute_ros_action(goal_future)
 
         assert result_future.done()
         assert (

--- a/setup/setup_pyrobosim.bash
+++ b/setup/setup_pyrobosim.bash
@@ -5,7 +5,7 @@
 # User variables
 # Please modify these for your environment
 VIRTUALENV_FOLDER=~/python-virtualenvs/pyrobosim
-ROS_WORKSPACE=~/workspace/pyrobosim_ws
+ROS_WORKSPACE=~/pyrobosim_ws
 
 # Create a Python virtual environment
 [ ! -d "${VIRTUALENV_FOLDER}" ] && mkdir -p ${VIRTUALENV_FOLDER}

--- a/setup/setup_pyrobosim.bash
+++ b/setup/setup_pyrobosim.bash
@@ -5,7 +5,7 @@
 # User variables
 # Please modify these for your environment
 VIRTUALENV_FOLDER=~/python-virtualenvs/pyrobosim
-ROS_WORKSPACE=~/pyrobosim_ws
+ROS_WORKSPACE=~/workspace/pyrobosim_ws
 
 # Create a Python virtual environment
 [ ! -d "${VIRTUALENV_FOLDER}" ] && mkdir -p ${VIRTUALENV_FOLDER}


### PR DESCRIPTION
Fixes an issue highlighted by @oberacda (thank you!), in which path planning failures don't correctly pipe their status all the way up the ROS interface.

Also added tests for this case.

Closes https://github.com/sea-bass/pyrobosim/issues/229