### PR TITLE
Support getting local robot observations in world state ROS service

### DIFF
--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -11,7 +11,7 @@ from .locations import ObjectSpawn
 from .objects import Object
 from ..manipulation.grasping import Grasp
 from ..planning.actions import ExecutionResult, ExecutionStatus
-from ..utils.knowledge import resolve_to_object, query_to_entity
+from ..utils.knowledge import query_to_entity
 from ..utils.polygon import sample_from_polygon, transform_polygon
 from ..utils.pose import Pose
 

--- a/pyrobosim_msgs/srv/RequestWorldState.srv
+++ b/pyrobosim_msgs/srv/RequestWorldState.srv
@@ -1,6 +1,11 @@
 # ROS service to request the world state
 
-# No request
+# Optional robot name.
+# If specified, gets the known world state of that robot.
+# If not specified, gets the full world state.
+string robot
+
 ---
-# Response contains a world state
+
+# The world state
 WorldState state

--- a/pyrobosim_ros/pyrobosim_ros/ros_interface.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_interface.py
@@ -450,6 +450,15 @@ class WorldROSWrapper(Node):
         """
         self.get_logger().info("Received world state request.")
 
+        # Determine whether to use a robot's local observations or the full world state.
+        if request.robot:
+            robot = self.world.get_robot_by_name(request.robot)
+            if not robot:
+                return response  # empty response
+            objects = robot.get_known_objects()
+        else:
+            objects = self.world.objects
+
         # Add the object and location states.
         for loc in self.world.locations:
             loc_msg = LocationState(
@@ -459,7 +468,7 @@ class WorldROSWrapper(Node):
                 pose=pose_to_ros(loc.pose),
             )
             response.state.locations.append(loc_msg)
-        for obj in self.world.objects:
+        for obj in objects:
             obj_msg = ObjectState(
                 name=obj.name,
                 category=obj.category,

--- a/pyrobosim_ros/test/test_ros_interface.py
+++ b/pyrobosim_ros/test/test_ros_interface.py
@@ -90,6 +90,7 @@ class TestRosInterface:
             RequestWorldState, "request_world_state"
         )
 
+        # Full world state.
         future = client.call_async(RequestWorldState.Request())
         start_time = time.time()
         while not future.done():
@@ -102,6 +103,28 @@ class TestRosInterface:
         assert len(result.state.robots) == 3
         assert len(result.state.locations) == 4
         assert len(result.state.objects) == 8
+
+        # Partial robot state.
+        # Since the world is not configured for partial observability, we make manual modifications to robot1.
+        world = TestRosInterface.ros_interface.world
+        robot1 = world.get_robot_by_name("robot1")
+        robot1.partial_observability = True
+        robot1.known_objects = set(
+            [world.get_object_by_name("apple0"), world.get_object_by_name("banana0")]
+        )
+
+        future = client.call_async(RequestWorldState.Request(robot="robot1"))
+        start_time = time.time()
+        while not future.done():
+            TestRosInterface.executor.spin_once(timeout_sec=0.1)
+            if time.time() - start_time > 2.0:
+                break
+
+        assert future.done()
+        result = future.result()
+        assert len(result.state.robots) == 3
+        assert len(result.state.locations) == 4
+        assert len(result.state.objects) == 2
 
         TestRosInterface.node.destroy_client(client)
 


### PR DESCRIPTION
Another small feature request from @oberacda for the ROS interface.

Now the `RequestWorldState` service can optionally accept a robot name to get its local observations. Right now, this only pertains to objects that the robot has not seen, if it has partial observability enabled..