### PR TITLE
Simulate robot battery usage and charging

### DIFF
--- a/docs/source/usage/robot_actions.rst
+++ b/docs/source/usage/robot_actions.rst
@@ -94,7 +94,7 @@ Simulating Action Execution
 By default, all robots can execute their actions perfectly.
 However, actions can still fail due to planning errors or because they are infeasible (e.g, picking an object while holding another).
 
-You can use the action's *execution options* to modify the behavior of your robot to simulate delays or failures.
+You can use the action's *execution options* to modify the behavior of your robot to simulate delays, failures, or battery consumption.
 For example,
 
 .. code-block:: python
@@ -104,14 +104,18 @@ For example,
 
     robot = Robot(
         name="robot0",
+        initial_battery_level=100.0,
         action_execution_options = {
             "navigate": ExecutionOptions(
-                delay=0.1,
                 success_probability=0.5,
-                rng_seed=1234
+                rng_seed=1234,
+                battery_usage=1.0,
             ),
-            "pick": ExecutionOptions(delay=1.0),
-            "place": ExecutionOptions(success_probability=0.75),
+            "pick": ExecutionOptions(
+                delay=1.0,
+                success_probability=0.75,
+                battery_usage=5.0
+            ),
         },
     )
 

--- a/docs/source/yaml/location_schema.rst
+++ b/docs/source/yaml/location_schema.rst
@@ -28,6 +28,7 @@ The generic location schema, where ``<angle brackets>`` are placeholders, is:
      color: [<r>, <g>, <b>]
      is_open: True
      is_locked: False
+     is_charger: False
 
 
 Examples

--- a/docs/source/yaml/world_schema.rst
+++ b/docs/source/yaml/world_schema.rst
@@ -24,6 +24,7 @@ The world schema looks as follows, where ``<angle brackets>`` are placeholders:
        height: <value>  # Robot height
        location: <loc_name>  # Initial location
        pose: [<x>, <y>, <z>, <yaw>]  # Initial pose, if not specified will sample
+       initial_battery_level: 50.0
        # Dynamics limits
        max_linear_velocity: <value>
        max_angular_velocity: <value>
@@ -44,12 +45,15 @@ The world schema looks as follows, where ``<angle brackets>`` are placeholders:
        action_execution_options:
          navigate:
            delay: 0.1
-           success_probability: 0.5
-           rng_seed: 1234
+           success_probability: 0.9
+           rng_seed: 42
+           battery_usage: 1.0
          pick:
            delay: 1.0
+           battery_usage: 5.0
          place:
            success_probability: 0.75
+           battery_usage: 5.0
      - ...
      - ...
 
@@ -88,6 +92,7 @@ The world schema looks as follows, where ``<angle brackets>`` are placeholders:
        pose: [<x>, <y>, <z>, <yaw>]  # If not specified, will sample
        is_open: true  # Can only pick, place, and detect if open
        is_locked: true  # Can only open and close if unlocked
+       is_charger: false  # Robots can charge at this location
      - ...
      - ...
 

--- a/pyrobosim/pyrobosim/core/locations.py
+++ b/pyrobosim/pyrobosim/core/locations.py
@@ -41,6 +41,7 @@ class Location:
         color=None,
         is_open=True,
         is_locked=False,
+        is_charger=False,
     ):
         """
         Creates a location instance.
@@ -60,6 +61,8 @@ class Location:
         :type is_open: bool, optional
         :param is_locked: If True, the location is locked, meaning it cannot be opened or closed.
         :type is_locked: bool, optional
+        :param is_charger: If True, the robot charges its battery at this location.
+        :type is_charger: bool, optional
         """
         # Validate input
         if parent is None:
@@ -73,6 +76,7 @@ class Location:
         self.parent = parent
         self.is_open = is_open
         self.is_locked = is_locked
+        self.is_charger = is_charger
 
         self.metadata = Location.metadata.get(self.category)
         if not self.metadata:

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -1014,8 +1014,9 @@ class Robot:
 
     def print_details(self):
         """Prints string with details."""
-        details_str = f"Robot: {self.name}, ID={self.id}"
+        details_str = f"Robot: {self.name}"
         details_str += f"\n\t{self.get_pose()}"
+        details_str += f"\n\tBattery: {self.battery_level:.2f}%"
         if self.partial_observability:
             details_str += "\n\tPartial observability enabled"
         print(details_str)

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -372,7 +372,10 @@ class Robot:
             )
         if self.world:
             self.location = self.world.get_location_from_pose(self.get_pose())
-            if isinstance(self.location, ObjectSpawn) and self.location.parent.is_charger:
+            if (
+                isinstance(self.location, ObjectSpawn)
+                and self.location.parent.is_charger
+            ):
                 print(f"[{self.name}] Battery charged at {self.location.name}!")
                 self.battery_level = 100.0
         self.last_nav_result = result

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -850,15 +850,13 @@ class Robot:
         # This should not happen
         return ExecutionResult(status=ExecutionResult.UNKNOWN)
 
-    def execute_action(self, action, blocking=False):
+    def execute_action(self, action):
         """
         Executes an action, specified as a
         :class:`pyrobosim.planning.actions.TaskAction` object.
 
         :param action: Action to execute.
         :type action: :class:`pyrobosim.planning.actions.TaskAction`
-        :param blocking: True to block execution until the action is complete.
-        :type blocking: bool, optional
         :return: An object describing the execution result.
         :rtype: :class:`pyrobosim.planning.actions.ExecutionResult`
         """
@@ -879,7 +877,7 @@ class Robot:
                 self.world.gui.canvas.navigate_signal.emit(
                     self, target_location_name, path
                 )
-                while blocking and self.executing_nav:
+                while self.executing_nav:
                     time.sleep(0.5)  # Delay to wait for navigation
                 result = self.last_nav_result
             else:
@@ -888,7 +886,7 @@ class Robot:
                     path=path,
                     realtime_factor=1.0,
                     use_thread=True,
-                    blocking=blocking,
+                    blocking=True,
                 )
             self.executing_nav = False
 
@@ -934,9 +932,8 @@ class Robot:
         if self.world.has_gui:
             self.world.gui.set_buttons_during_action(True)
         print(f"[{self.name}] Action completed with result: {result.status.name}")
-        if blocking:
-            self.current_action = None
-            self.executing_action = False
+        self.current_action = None
+        self.executing_action = False
         return result
 
     def cancel_actions(self):
@@ -991,7 +988,7 @@ class Robot:
                 break
 
             print(f"[{self.name}] Executing action {act_msg.type} [{n+1}/{num_acts}]")
-            result = self.execute_action(act_msg, blocking=True)
+            result = self.execute_action(act_msg)
             if not result.is_success():
                 print(
                     f"[{self.name}] Task plan failed to execute on action {n+1}/{num_acts}"

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -35,6 +35,7 @@ class Robot:
         grasp_generator=None,
         partial_observability=False,
         action_execution_options={},
+        initial_battery_level=100.0,
     ):
         """
         Creates a robot instance.
@@ -71,6 +72,8 @@ class Robot:
         :param action_execution_options: A dictionary of action names and their execution options.
             This defines properties such as delays and nondeterminism.
         :type action_execution_options: dict[str, :class:`pyrobosim.planning.actions.ExecutionOptions`]
+        :param initial_battery_level: The initial battery charge, from 0 to 100.
+        :type initial_battery_level: float
         """
         # Basic properties
         self.name = name
@@ -108,6 +111,7 @@ class Robot:
         self.current_plan = None
         self.executing_plan = False
         self.canceling_execution = False
+        self.battery_level = initial_battery_level
 
         # World interaction properties
         self.world = None
@@ -357,9 +361,17 @@ class Robot:
                 message="Robot is not at its intended target pose.",
             )
 
-        # Update the robot state if successful.
+        # Update the robot state.
         if self.world:
             self.location = self.world.get_location_from_pose(self.get_pose())
+        exec_options = self.action_execution_options.get("navigate")
+        if exec_options:
+            self.battery_level = max(
+                0.0,
+                self.battery_level
+                - exec_options.battery_usage
+                * self.path_executor.current_distance_traveled,
+            )
         self.last_nav_result = result
         return result
 
@@ -393,6 +405,14 @@ class Robot:
         :return: An object describing the execution result.
         :rtype: :class:`pyrobosim.planning.actions.ExecutionResult`
         """
+        if self.battery_level <= 0.0:
+            message = "Out of battery. Cannot navigate."
+            warnings.warn(message)
+            self.last_nav_result = ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
+            return self.last_nav_result
+
         if path is None:
             path = self.plan_path(start, goal)
             if path is None or path.num_poses == 0:
@@ -409,6 +429,17 @@ class Robot:
             self.world.gui.canvas.show_planner_and_path_signal.emit(
                 self, show_graph, path
             )
+
+        # Simulate execution options.
+        exec_options = self.action_execution_options.get("navigate")
+        if exec_options:
+            if not exec_options.should_succeed():
+                message = f"[{self.name}] Simulated navigation failure."
+                print(message)
+                self.last_nav_result = ExecutionResult(
+                    status=ExecutionStatus.EXECUTION_FAILURE, message=message
+                )
+                return self.last_nav_result
 
         return self.follow_path(
             path,
@@ -473,6 +504,12 @@ class Robot:
             return ExecutionResult(
                 status=ExecutionStatus.PRECONDITION_FAILURE, message=message
             )
+        if self.battery_level <= 0.0:
+            message = "Out of battery. Cannot pick."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
 
         # If a grasp generator has been specified and no explicit grasp has been provided,
         # generate grasps here.
@@ -510,6 +547,19 @@ class Robot:
         if self.last_grasp_selection is not None:
             print(f"Selected {self.last_grasp_selection}")
 
+        # Simulate execution options.
+        exec_options = self.action_execution_options.get("pick")
+        if exec_options:
+            self.battery_level = max(
+                0.0, self.battery_level - exec_options.battery_usage
+            )
+            if not exec_options.should_succeed():
+                message = f"[{self.name}] Simulated pick failure."
+                print(message)
+                return ExecutionResult(
+                    status=ExecutionStatus.EXECUTION_FAILURE, message=message
+                )
+
         # Denote the target object as the manipulated object
         self._attach_object(obj)
         return ExecutionResult(status=ExecutionStatus.SUCCESS)
@@ -543,6 +593,12 @@ class Robot:
             )
         if not loc.is_open:
             message = f"{loc.parent.name} is not open. Cannot place object."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
+        if self.battery_level <= 0.0:
+            message = "Out of battery. Cannot place."
             warnings.warn(message)
             return ExecutionResult(
                 status=ExecutionStatus.PRECONDITION_FAILURE, message=message
@@ -587,13 +643,25 @@ class Robot:
                     status=ExecutionStatus.PLANNING_FAILURE, message=message
                 )
 
-        if is_valid_pose:
-            self.manipulated_object.parent = loc
-            self.manipulated_object.set_pose(pose)
-            self.manipulated_object.create_polygons()
-            loc.children.append(self.manipulated_object)
-            self.manipulated_object = None
-            return ExecutionResult(status=ExecutionStatus.SUCCESS)
+        # Simulate execution options.
+        exec_options = self.action_execution_options.get("place")
+        if exec_options:
+            self.battery_level = max(
+                0.0, self.battery_level - exec_options.battery_usage
+            )
+            if not exec_options.should_succeed():
+                message = f"[{self.name}] Simulated place failure."
+                print(message)
+                return ExecutionResult(
+                    status=ExecutionStatus.EXECUTION_FAILURE, message=message
+                )
+
+        self.manipulated_object.parent = loc
+        self.manipulated_object.set_pose(pose)
+        self.manipulated_object.create_polygons()
+        loc.children.append(self.manipulated_object)
+        self.manipulated_object = None
+        return ExecutionResult(status=ExecutionStatus.SUCCESS)
 
     def detect_objects(self, target_object=None):
         """
@@ -620,6 +688,26 @@ class Robot:
             return ExecutionResult(
                 status=ExecutionStatus.PRECONDITION_FAILURE, message=message
             )
+
+        if self.battery_level <= 0.0:
+            message = "Out of battery. Cannot detect objects."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
+
+        # Simulate execution options.
+        exec_options = self.action_execution_options.get("detect")
+        if exec_options:
+            self.battery_level = max(
+                0.0, self.battery_level - exec_options.battery_usage
+            )
+            if not exec_options.should_succeed():
+                message = f"[{self.name}] Simulated detection failure."
+                print(message)
+                return ExecutionResult(
+                    status=ExecutionStatus.EXECUTION_FAILURE, message=message
+                )
 
         # Add all the objects at the current robot's location.
         for obj in self.location.children:
@@ -672,6 +760,26 @@ class Robot:
                 status=ExecutionStatus.PRECONDITION_FAILURE, message=message
             )
 
+        if self.battery_level <= 0.0:
+            message = "Out of battery. Cannot open location."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
+
+        # Simulate execution options.
+        exec_options = self.action_execution_options.get("open")
+        if exec_options:
+            self.battery_level = max(
+                0.0, self.battery_level - exec_options.battery_usage
+            )
+            if not exec_options.should_succeed():
+                message = f"[{self.name}] Simulated opening failure."
+                print(message)
+                return ExecutionResult(
+                    status=ExecutionStatus.EXECUTION_FAILURE, message=message
+                )
+
         if isinstance(self.location, ObjectSpawn):
             return self.world.open_location(self.location.parent)
         elif isinstance(self.location, Hallway):
@@ -708,6 +816,26 @@ class Robot:
                 status=ExecutionStatus.PRECONDITION_FAILURE, message=message
             )
 
+        if self.battery_level <= 0.0:
+            message = "Out of battery. Cannot close location."
+            warnings.warn(message)
+            return ExecutionResult(
+                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+            )
+
+        # Simulate execution options.
+        exec_options = self.action_execution_options.get("close")
+        if exec_options:
+            self.battery_level = max(
+                0.0, self.battery_level - exec_options.battery_usage
+            )
+            if not exec_options.should_succeed():
+                message = f"[{self.name}] Simulated closing failure."
+                print(message)
+                return ExecutionResult(
+                    status=ExecutionStatus.EXECUTION_FAILURE, message=message
+                )
+
         if isinstance(self.location, ObjectSpawn):
             return self.world.close_location(self.location.parent)
         elif isinstance(self.location, Hallway):
@@ -733,16 +861,7 @@ class Robot:
         if self.world.has_gui:
             self.world.gui.set_buttons_during_action(False)
 
-        # Simulate action-agnostic properties such as delays or failure probabilities.
-        execution_options = self.action_execution_options.get(action.type)
-        if execution_options and not execution_options.should_succeed():
-            message = f"[{self.name}] Simulated action failure."
-            print(message)
-            result = ExecutionResult(
-                status=ExecutionStatus.EXECUTION_FAILURE, message=message
-            )
-
-        elif action.type == "navigate":
+        if action.type == "navigate":
             self.executing_nav = True
             path = action.path if action.path.num_poses > 0 else None
             if self.world.has_gui:

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -362,8 +362,6 @@ class Robot:
             )
 
         # Update the robot state.
-        if self.world:
-            self.location = self.world.get_location_from_pose(self.get_pose())
         exec_options = self.action_execution_options.get("navigate")
         if exec_options:
             self.battery_level = max(
@@ -372,6 +370,11 @@ class Robot:
                 - exec_options.battery_usage
                 * self.path_executor.current_distance_traveled,
             )
+        if self.world:
+            self.location = self.world.get_location_from_pose(self.get_pose())
+            if isinstance(self.location, ObjectSpawn) and self.location.parent.is_charger:
+                print(f"[{self.name}] Battery charged at {self.location.name}!")
+                self.battery_level = 100.0
         self.last_nav_result = result
         return result
 

--- a/pyrobosim/pyrobosim/core/yaml_utils.py
+++ b/pyrobosim/pyrobosim/core/yaml_utils.py
@@ -131,6 +131,7 @@ class WorldYamlLoader:
                 grasp_generator=self.get_grasp_generator(robot_data),
                 partial_observability=robot_data.get("partial_observability", False),
                 action_execution_options=self.get_action_execution_options(robot_data),
+                initial_battery_level=robot_data.get("initial_battery_level", 100.0),
             )
 
             loc = robot_data["location"] if "location" in robot_data else None

--- a/pyrobosim/pyrobosim/data/example_location_data.yaml
+++ b/pyrobosim/pyrobosim/data/example_location_data.yaml
@@ -83,3 +83,24 @@ trash_can:
     - [0.5, 0.0, 3.14]
     - [-0.5, 0.0, 0.0]
   color: [0, 0.35, 0.2]
+
+
+charger:
+  footprint:
+    type: polygon
+    coords:
+      - [-0.3, -0.15]
+      - [0.3, -0.15]
+      - [0.3, 0.15]
+      - [-0.3, 0.15]
+    height: 0.1
+  locations:
+    - name: "dock"
+      footprint:
+        type: parent
+      nav_poses:
+        - [0, -0.35, 1.57]
+        - [-0.5, 0, 0]
+        - [0, 0.35, -1.57]
+        - [0.5, 0, 3.14]
+  color: [0.4, 0.4, 0]

--- a/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
+++ b/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
@@ -67,15 +67,26 @@ robots:
     # Simulate properties of actions
     action_execution_options:
       navigate:
+        rng_seed: 1234
         success_probability: 0.9
+        battery_usage: 0.5
       pick:
         delay: 1.0
         success_probability: 0.75
+        battery_usage: 5.0
       place:
         delay: 0.5
+        success_probability: 0.75
+        battery_usage: 5.0
+      open:
         success_probability: 0.5
-        rng_seed: 1234
-
+        battery_usage: 5.0
+      close:
+        success_probability: 0.5
+        battery_usage: 5.0
+      detect:
+        success_probability: 0.8
+        battery_usage: 2.0
 
 # ROOMS: Polygonal regions that can contain object locations
 rooms:

--- a/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
+++ b/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
@@ -183,6 +183,14 @@ locations:
     is_open: False
     is_locked: False
 
+  - name: charger
+    category: charger
+    parent: bedroom
+    pose: [3.15, 2.7, 0.0, 0.0]
+    is_open: False
+    is_locked: True
+    is_charger: True
+
 
 # OBJECTS: Can be picked, placed, and moved by robot
 objects:

--- a/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
+++ b/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
@@ -65,9 +65,10 @@ robots:
       diagonal_motion: true
       compress_path: false
     # Simulate properties of actions
+    initial_battery_level: 100.0
     action_execution_options:
       navigate:
-        rng_seed: 1234
+        rng_seed: 42
         success_probability: 0.9
         battery_usage: 0.5
       pick:

--- a/pyrobosim/pyrobosim/gui/main.py
+++ b/pyrobosim/pyrobosim/gui/main.py
@@ -268,10 +268,9 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):
         robot = self.get_current_robot()
         if robot:
             obj = self.goal_textbox.text()
-            if obj:
-                print(f"[{robot.name}] Picking {obj}")
-                self.canvas.pick_object(robot, obj)
-                self.update_button_state()
+            print(f"[{robot.name}] Picking {obj}")
+            self.canvas.pick_object(robot, obj)
+            self.update_button_state()
 
     def on_place_click(self):
         """Callback to place an object."""

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -440,7 +440,7 @@ class WorldCanvas(FigureCanvasQTAgg):
             if robot.manipulated_object is not None:
                 title_bits.append(f"Holding: {robot.manipulated_object.name}")
 
-            battery_str = f"Battery {robot.battery_level:.2f}%"
+            battery_str = f"Battery: {robot.battery_level:.2f}%"
             title_str = f"[{robot.name}] " + battery_str + "\n" + ", ".join(title_bits)
             self.axes.set_title(title_str)
 

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -439,7 +439,9 @@ class WorldCanvas(FigureCanvasQTAgg):
                 title_bits.append(f"Location: {robot_loc}")
             if robot.manipulated_object is not None:
                 title_bits.append(f"Holding: {robot.manipulated_object.name}")
-            title_str = f"[{robot.name}] " + ", ".join(title_bits)
+
+            battery_str = f"Battery {robot.battery_level:.2f}%"
+            title_str = f"[{robot.name}] " + battery_str + "\n" + ", ".join(title_bits)
             self.axes.set_title(title_str)
 
     def update_object_plot(self, obj):

--- a/pyrobosim/pyrobosim/navigation/execution.py
+++ b/pyrobosim/pyrobosim/navigation/execution.py
@@ -53,6 +53,7 @@ class ConstantVelocityExecutor:
 
         # Execution state
         self.current_traj_time = 0.0
+        self.current_distance_traveled = 0.0
         self.abort_execution = False  # Flag to abort internally
         self.cancel_execution = False  # Flag to cancel from user
 
@@ -85,6 +86,7 @@ class ConstantVelocityExecutor:
 
         self.robot.executing_nav = True
         self.current_traj_time = 0.0
+        self.current_distance_traveled = 0.0
         self.abort_execution = False
 
         # Convert the path to an interpolated trajectory.
@@ -107,6 +109,7 @@ class ConstantVelocityExecutor:
         message = ""
         sleep_time = self.dt / realtime_factor
         is_holding_object = self.robot.manipulated_object is not None
+        prev_pose = traj_interp.poses[0]
         for i in range(traj_interp.num_points()):
             start_time = time.time()
             cur_pose = traj_interp.poses[i]
@@ -129,6 +132,8 @@ class ConstantVelocityExecutor:
                 status = ExecutionStatus.CANCELED
                 break
 
+            self.current_distance_traveled += cur_pose.get_linear_distance(prev_pose)
+            prev_pose = cur_pose
             time.sleep(max(0, sleep_time - (time.time() - start_time)))
 
         # Finalize path execution.

--- a/pyrobosim/pyrobosim/planning/actions.py
+++ b/pyrobosim/pyrobosim/planning/actions.py
@@ -10,7 +10,9 @@ from ..utils.motion import Path
 class ExecutionOptions:
     """Options for executing actions in simulation."""
 
-    def __init__(self, delay=0.0, success_probability=1.0, rng_seed=None):
+    def __init__(
+        self, delay=0.0, success_probability=1.0, rng_seed=None, battery_usage=0.0
+    ):
         """
         Creates a new set of action execution options.
 
@@ -21,11 +23,17 @@ class ExecutionOptions:
         :param rng_seed: The seed to use for random number generation.
             Defaults to None, but can be changed for determinism.
         :type rng_seed: int, optional
+        :param battery_usage: Amount of battery reduction from running the action.
+            Note that some actions apply this as a fixed reductions, and others apply it
+            per some unit of measure (for example, battery per distance moved).
+            Must be greater than 0.
+        :type battery_usage: float
         """
         self.delay = delay
         self.success_probability = success_probability
         self.rng_seed = rng_seed
         self.rng = np.random.default_rng(seed=rng_seed)
+        self.battery_usage = battery_usage
 
     def should_succeed(self):
         """

--- a/pyrobosim_msgs/msg/RobotState.msg
+++ b/pyrobosim_msgs/msg/RobotState.msg
@@ -5,6 +5,7 @@ string name
 
 # Continuous state
 geometry_msgs/Pose pose
+float64 battery_level
 
 # Discrete state
 bool executing_action

--- a/pyrobosim_ros/pyrobosim_ros/ros_interface.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_interface.py
@@ -416,6 +416,7 @@ class WorldROSWrapper(Node):
         """
         state_msg = RobotState(name=robot.name)
         state_msg.pose = pose_to_ros(robot.get_pose())
+        state_msg.battery_level = robot.battery_level
         state_msg.executing_action = robot.executing_action
         if robot.manipulated_object is not None:
             state_msg.holding_object = True

--- a/pyrobosim_ros/pyrobosim_ros/ros_interface.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_interface.py
@@ -308,7 +308,7 @@ class WorldROSWrapper(Node):
         # Execute the action
         robot_action = task_action_from_ros(goal_handle.request.action)
         self.get_logger().info(f"Executing action with robot {robot.name}...")
-        execution_result = robot.execute_action(robot_action, blocking=True)
+        execution_result = robot.execute_action(robot_action)
         self.get_logger().info(
             f"Action finished with status: {execution_result.status.name}"
         )

--- a/pyrobosim_ros/test/test_ros_interface.py
+++ b/pyrobosim_ros/test/test_ros_interface.py
@@ -123,7 +123,7 @@ class TestRosInterface:
         assert future.done()
         result = future.result()
         assert len(result.state.robots) == 3
-        assert len(result.state.locations) == 4
+        assert len(result.state.locations) == 5
         assert len(result.state.objects) == 8
 
         # Partial robot state.
@@ -145,7 +145,7 @@ class TestRosInterface:
         assert future.done()
         result = future.result()
         assert len(result.state.robots) == 3
-        assert len(result.state.locations) == 4
+        assert len(result.state.locations) == 5
         assert len(result.state.objects) == 2
 
         TestRosInterface.node.destroy_client(client)

--- a/test/core/test_robot.py
+++ b/test/core/test_robot.py
@@ -48,7 +48,7 @@ class TestRobot:
         ]
         return TaskPlan(actions=actions)
 
-    def test_create_robot_default_args(self):
+    def test_create_robot_default_args(self, capsys):
         """Check that a robot can be created with all default arguments."""
         robot = Robot()
 
@@ -65,8 +65,19 @@ class TestRobot:
         assert robot.path_executor == None
         assert robot.grasp_generator == None
         assert robot.world == None
+        assert not robot.partial_observability
+        assert robot.battery_level == 100.0
 
-    def test_create_robot_nondefault_args(self):
+        robot.print_details()
+        out, _ = capsys.readouterr()
+        expected_details_str = (
+            "Robot: robot\n"
+            + "\tPose: [x=0.00, y=0.00, z=0.00, qw=1.000, qx=0.000, qy=-0.000, qz=0.000]\n"
+            + "\tBattery: 100.00%\n"
+        )
+        assert out == expected_details_str
+
+    def test_create_robot_nondefault_args(self, capsys):
         """Check that a robot can be created with nondefault arguments."""
         robot = Robot(
             name="test_robot",
@@ -74,6 +85,8 @@ class TestRobot:
             radius=0.1,
             height=0.15,
             color=(0.5, 0.5, 0.5),
+            partial_observability=True,
+            initial_battery_level=50.0,
         )
 
         assert robot.name == "test_robot"
@@ -85,6 +98,18 @@ class TestRobot:
         assert robot.radius == pytest.approx(0.1)
         assert robot.height == pytest.approx(0.15)
         assert robot.color == pytest.approx((0.5, 0.5, 0.5))
+        assert robot.partial_observability
+        assert robot.battery_level == 50.0
+
+        robot.print_details()
+        out, _ = capsys.readouterr()
+        expected_details_str = (
+            "Robot: test_robot\n"
+            + "\tPose: [x=1.00, y=2.00, z=0.00, qw=0.707, qx=0.000, qy=-0.000, qz=0.707]\n"
+            + "\tBattery: 50.00%\n"
+            "\tPartial observability enabled\n"
+        )
+        assert out == expected_details_str
 
     def test_robot_bad_name(self):
         """Check that a robot with an invalid name raises an exception."""
@@ -121,6 +146,15 @@ class TestRobot:
             path = robot.plan_path()
         assert path is None
         assert warn_info[0].message.args[0] == "Did not specify a goal. Returning None."
+
+        # Provide no path planner
+        robot.path_planner = None
+        with pytest.warns(UserWarning) as warn_info:
+            path = robot.plan_path()
+        assert path is None
+        assert (
+            warn_info[0].message.args[0] == "No path planner attached to robot robot."
+        )
 
     def test_robot_path_executor(self):
         """Check that path executors can be used from a robot."""
@@ -160,6 +194,18 @@ class TestRobot:
         assert pose.x == pytest.approx(goal_pose.x)
         assert pose.y == pytest.approx(goal_pose.y)
         assert pose.q == pytest.approx(goal_pose.q)
+
+        # Provide no path and no path executor.
+        with pytest.warns(UserWarning):
+            result = robot.follow_path(None)
+        assert result.status == ExecutionStatus.PRECONDITION_FAILURE
+        assert result.message == "No path to execute."
+
+        robot.path_executor = None
+        with pytest.warns(UserWarning):
+            result = robot.follow_path(path)
+        assert result.status == ExecutionStatus.PRECONDITION_FAILURE
+        assert result.message == "No path executor. Cannot follow path."
 
     def test_robot_nav_validation(self):
         """Check that the robot can abort execution with runtime collision validation."""
@@ -212,6 +258,10 @@ class TestRobot:
         # Spawn the robot near the kitchen table
         robot = Robot(
             pose=Pose(x=1.0, y=0.5, yaw=0.0),
+            action_execution_options={
+                "pick": ExecutionOptions(battery_usage=5.0),
+                "place": ExecutionOptions(battery_usage=10.0),
+            },
         )
         robot.world = self.test_world
         robot.location = self.test_world.get_entity_by_name("table0_tabletop")
@@ -231,10 +281,19 @@ class TestRobot:
             == "apple0 is at my_desk_desktop and robot is at table0_tabletop. Cannot pick."
         )
 
-        # Pick up the apple on the kitchen table (named "gala")
+        # Pick up the apple on the kitchen table (named "gala").
+        # Trying on empty battery should fail.
+        robot.battery_level = 0.0
+        with pytest.warns(UserWarning):
+            result = robot.pick_object("apple")
+        assert result.status == ExecutionStatus.PRECONDITION_FAILURE
+        assert result.message == "Out of battery. Cannot pick."
+
+        robot.battery_level = 100.0
         result = robot.pick_object("apple")
         assert result.status == ExecutionStatus.SUCCESS
         assert robot.manipulated_object == self.test_world.get_entity_by_name("gala")
+        assert robot.battery_level == pytest.approx(95.0)
 
         # Try pick up another object, which should fail since the robot is holding something.
         with pytest.warns(UserWarning):
@@ -253,10 +312,19 @@ class TestRobot:
         )
 
         # Try place the object at a valid location.
+        # Trying on empty battery should fail.
         robot.location = self.test_world.get_entity_by_name("table0_tabletop")
+        robot.battery_level = 0.0
+        with pytest.warns(UserWarning):
+            result = robot.place_object()
+        assert result.status == ExecutionStatus.PRECONDITION_FAILURE
+        assert result.message == "Out of battery. Cannot place."
+
+        robot.battery_level = 100.0
         result = robot.place_object()
         assert result.status == ExecutionStatus.SUCCESS
         assert robot.manipulated_object is None
+        assert robot.battery_level == pytest.approx(90.0)
 
         # Try place an object, which should fail since the robot is holding nothing.
         with pytest.warns(UserWarning):
@@ -295,6 +363,7 @@ class TestRobot:
         # Spawn the robot near the kitchen table
         robot = Robot(
             pose=Pose(x=1.0, y=0.5, yaw=0.0),
+            action_execution_options={"detect": ExecutionOptions(battery_usage=1.0)},
         )
         robot.world = self.test_world
 
@@ -311,11 +380,21 @@ class TestRobot:
         result = robot.detect_objects()
         assert result.status == ExecutionStatus.SUCCESS
         assert len(robot.last_detected_objects) == 2
+        assert robot.battery_level == pytest.approx(99.0)
+
+        # Trying on empty battery should fail.
+        robot.battery_level = 0.0
+        with pytest.warns(UserWarning):
+            result = robot.detect_objects()
+        assert result.status == ExecutionStatus.PRECONDITION_FAILURE
+        assert result.message == "Out of battery. Cannot detect objects."
+        robot.battery_level = 100.0
 
         # Filtering by category should also affect results.
-        robot.detect_objects("apple")
+        result = robot.detect_objects("apple")
         assert result.status == ExecutionStatus.SUCCESS
         len(robot.last_detected_objects) == 1
+        assert robot.battery_level == pytest.approx(99.0)
 
         result = robot.detect_objects("water")
         assert result.status == ExecutionStatus.EXECUTION_FAILURE
@@ -338,6 +417,10 @@ class TestRobot:
         """Check that the robot can open or close hallways."""
         robot = Robot(
             pose=Pose(x=1.0, y=0.5, yaw=0.0),
+            action_execution_options={
+                "open": ExecutionOptions(battery_usage=20.0),
+                "close": ExecutionOptions(battery_usage=25.0),
+            },
         )
         robot.world = self.test_world
 
@@ -359,16 +442,38 @@ class TestRobot:
         assert result.status == ExecutionStatus.PRECONDITION_FAILURE
         assert result.message == "Robot is not at an openable location."
 
-        with pytest.warns(UserWarning) as warn_info:
+        with pytest.warns(UserWarning):
             result = robot.close_location()
         assert result.status == ExecutionStatus.PRECONDITION_FAILURE
         assert result.message == "Robot is not at a closeable location."
 
-        # Set the location to an openable location, which should work.
+        # Set the location to an openable location.
         hallway = self.test_world.get_hallways_from_rooms("kitchen", "bedroom")[0]
         robot.location = hallway
+
+        # Trying to close on empty battery should fail.
+        robot.battery_level = 0.0
+        with pytest.warns(UserWarning):
+            result = robot.close_location()
+        assert result.status == ExecutionStatus.PRECONDITION_FAILURE
+        assert result.message == "Out of battery. Cannot close location."
+
+        # Trying to close with battery should succeed.
+        robot.battery_level = 100.0
         assert robot.close_location().is_success()
+        assert robot.battery_level == pytest.approx(75.0)
+
+        # Trying to open empty battery should fail.
+        robot.battery_level = 0.0
+        with pytest.warns(UserWarning):
+            result = robot.open_location()
+        assert result.status == ExecutionStatus.PRECONDITION_FAILURE
+        assert result.message == "Out of battery. Cannot open location."
+
+        # Trying to open with battery should succeed.
+        robot.battery_level = 100.0
         assert robot.open_location().is_success()
+        assert robot.battery_level == pytest.approx(80.0)
 
         # Set a manipulated object, which will stop open/close from succeeding.
         robot.manipulated_object = self.test_world.get_object_by_name("banana0")
@@ -402,6 +507,7 @@ class TestRobot:
             pose=init_pose,
             path_planner=PathPlanner("world_graph", world=self.test_world),
             path_executor=ConstantVelocityExecutor(linear_velocity=5.0, dt=0.1),
+            action_execution_options={"navigate": ExecutionOptions(battery_usage=1.0)},
         )
         robot.location = "kitchen"
         robot.world = self.test_world
@@ -414,9 +520,11 @@ class TestRobot:
         # Blocking action
         result = robot.execute_action(action, blocking=True)
         assert result.is_success()
+        assert robot.battery_level < 100.0
 
-        # Non-blocking action
+        # Non-blocking action (battery will not update in this case)
         robot.set_pose(init_pose)
+        robot.location = "kitchen"
         result = robot.execute_action(action, blocking=False)
         assert result.is_success()
         assert robot.executing_action
@@ -454,9 +562,12 @@ class TestRobot:
             path_planner=PathPlanner("world_graph", world=self.test_world),
             path_executor=ConstantVelocityExecutor(linear_velocity=5.0, dt=0.1),
             action_execution_options=action_execution_options,
+            initial_battery_level=80.0,
         )
         robot.location = "kitchen"
         robot.world = self.test_world
+        my_desk = self.test_world.get_location_by_name("my_desk")
+        my_desk.is_charger = True  # Make into a charger to test charging capabilities.
         action = TaskAction(
             "navigate",
             source_location="kitchen",
@@ -467,8 +578,17 @@ class TestRobot:
         result = robot.execute_action(action, blocking=True)
         assert result.status == ExecutionStatus.EXECUTION_FAILURE
         assert result.message == "[robot] Simulated navigation failure."
+        assert robot.battery_level == pytest.approx(80.0)
+
         assert robot.execute_action(action, blocking=True).is_success()
-        assert robot.battery_level < 100.0
+        assert robot.battery_level == pytest.approx(100.0)
+
+        # Navigating on empty battery should fail.
+        robot.battery_level = 0.0
+        with pytest.warns(UserWarning):
+            result = robot.execute_action(action, blocking=True)
+        assert result.status == ExecutionStatus.PRECONDITION_FAILURE
+        assert result.message == "Out of battery. Cannot navigate."
 
     def test_execute_action_cancel(self):
         """Tests that actions can be canceled during execution."""

--- a/test/core/test_robot.py
+++ b/test/core/test_robot.py
@@ -446,6 +446,7 @@ class TestRobot:
                 delay=0.1,
                 success_probability=0.5,
                 rng_seed=1234,
+                battery_usage=1.0,
             ),
         }
         robot = Robot(
@@ -465,8 +466,9 @@ class TestRobot:
         # The action should fail the first time but succeed the second time.
         result = robot.execute_action(action, blocking=True)
         assert result.status == ExecutionStatus.EXECUTION_FAILURE
-        assert result.message == "[robot] Simulated action failure."
+        assert result.message == "[robot] Simulated navigation failure."
         assert robot.execute_action(action, blocking=True).is_success()
+        assert robot.battery_level < 100.0
 
     def test_execute_action_cancel(self):
         """Tests that actions can be canceled during execution."""

--- a/test/core/test_yaml_utils.py
+++ b/test/core/test_yaml_utils.py
@@ -382,6 +382,7 @@ class TestWorldYamlLoading:
                             "rng_seed": 1234,
                         },
                     },
+                    "initial_battery_level": 50.0,
                 },
             ],
         }
@@ -398,6 +399,7 @@ class TestWorldYamlLoading:
         assert robot0.grasp_generator is None
         assert not robot0.partial_observability
         assert robot0.action_execution_options == {}
+        assert robot0.battery_level == 100.0
 
         robot1 = loader.world.robots[1]
         assert robot1.name == "test_robot"
@@ -408,6 +410,7 @@ class TestWorldYamlLoading:
         assert np.all(robot1.dynamics.vel_limits == np.array([1.0, 1.0, 3.0]))
         assert np.all(robot1.dynamics.accel_limits == np.array([2.0, 2.0, 6.0]))
         assert robot1.partial_observability
+        assert robot1.battery_level == 50.0
 
         path_planner = robot1.path_planner
         assert isinstance(path_planner, PathPlanner)


### PR DESCRIPTION
This PR adds battery level to robots, as well as the option to simulate battery usage per action.

As a side effect, this PR also correctly applies action execution options from manually interacting with the GUI, which was not previously available.

![image](https://github.com/user-attachments/assets/69afd855-4142-457f-bb9f-5454809c2270)

Closes https://github.com/sea-bass/pyrobosim/issues/230