### PR TITLE
Require PySide6 6.4.0 or greater

### DIFF
--- a/pyrobosim/setup.py
+++ b/pyrobosim/setup.py
@@ -23,7 +23,7 @@ install_requires = [
     "matplotlib",
     "numpy",
     "pycollada",
-    "PySide6",
+    "PySide6>=6.4.0",
     "PyYAML",
     "shapely>=2.0.1",
     "scipy",


### PR DESCRIPTION
Based on https://github.com/sea-bass/pyrobosim/issues/236, I am putting a minimum version on this package.

I've confirmed that this minimum version is available in Python 3.8, so it's not overly restrictive.