### PR TITLE
Add specialized ROS action servers for path planning and following

### DIFF
--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -938,7 +938,7 @@ class Robot:
 
     def cancel_actions(self):
         """Cancels any currently running actions for the robot."""
-        if not (self.executing_action or self.executing_plan):
+        if not (self.executing_action or self.executing_plan or self.executing_nav):
             warnings.warn("There is no running action or plan to cancel.")
             return
 

--- a/pyrobosim/pyrobosim/gui/main.py
+++ b/pyrobosim/pyrobosim/gui/main.py
@@ -209,6 +209,8 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):
         self.pick_button.setEnabled(state)
         self.place_button.setEnabled(state)
         self.detect_button.setEnabled(state)
+        self.open_button.setEnabled(state)
+        self.close_button.setEnabled(state)
         self.rand_pose_button.setEnabled(state)
 
     ####################

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -379,6 +379,8 @@ class WorldCanvas(FigureCanvasQTAgg):
                     artist.remove()
                 self.path_planner_artists["path"] = path_planner_artists.get("path", [])
 
+            self.draw_and_sleep()
+
     def nav_animation_callback(self):
         """Timer callback function to animate navigating robots."""
         if not self.main_window.isVisible():

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -54,8 +54,6 @@ class NavRunner(QRunnable):
         robot.navigate(
             goal=self.goal,
             path=self.path,
-            use_thread=True,
-            blocking=True,
             realtime_factor=self.canvas.realtime_factor,
         )
 

--- a/pyrobosim_msgs/CMakeLists.txt
+++ b/pyrobosim_msgs/CMakeLists.txt
@@ -34,6 +34,8 @@ set(srv_files
 set(action_files
   "action/ExecuteTaskAction.action"
   "action/ExecuteTaskPlan.action"
+  "action/FollowPath.action"
+  "action/PlanPath.action"
 )
 
 rosidl_generate_interfaces(${PROJECT_NAME}

--- a/pyrobosim_msgs/action/FollowPath.action
+++ b/pyrobosim_msgs/action/FollowPath.action
@@ -1,0 +1,13 @@
+# ROS Action Definition for Path Following
+
+# Goal
+pyrobosim_msgs/Path path
+
+---
+
+# Result
+pyrobosim_msgs/ExecutionResult execution_result
+
+---
+
+# No Feedback

--- a/pyrobosim_msgs/action/PlanPath.action
+++ b/pyrobosim_msgs/action/PlanPath.action
@@ -1,0 +1,15 @@
+# ROS Action Definition for Path Planning
+
+# Goal
+string target_location
+geometry_msgs/Pose target_pose
+
+---
+
+# Result
+pyrobosim_msgs/ExecutionResult execution_result
+pyrobosim_msgs/Path path
+
+---
+
+# No Feedback

--- a/pyrobosim_ros/pyrobosim_ros/ros_interface.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_interface.py
@@ -13,11 +13,18 @@ import time
 from geometry_msgs.msg import Twist
 from pyrobosim.core.hallway import Hallway
 from pyrobosim.core.locations import Location
-from pyrobosim_msgs.action import ExecuteTaskAction, ExecuteTaskPlan
+from pyrobosim_msgs.action import (
+    ExecuteTaskAction,
+    ExecuteTaskPlan,
+    FollowPath,
+    PlanPath,
+)
 from pyrobosim_msgs.msg import ExecutionResult, RobotState, LocationState, ObjectState
 from pyrobosim_msgs.srv import RequestWorldState, SetLocationState
 from .ros_conversions import (
     execution_result_to_ros,
+    path_from_ros,
+    path_to_ros,
     pose_from_ros,
     pose_to_ros,
     ros_duration_to_float,
@@ -119,6 +126,8 @@ class WorldROSWrapper(Node):
         self.robot_command_subs = []
         self.robot_state_pubs = []
         self.robot_state_pub_threads = []
+        self.robot_plan_path_servers = []
+        self.robot_follow_path_servers = []
         self.latest_robot_cmds = {}
 
         # Start a dynamics timer
@@ -172,6 +181,7 @@ class WorldROSWrapper(Node):
         while wait_for_gui and not self.world.has_gui:
             self.get_logger().info("Waiting for GUI...")
             time.sleep(1.0)
+        self.get_logger().info("PyRoboSim ROS node ready!")
 
         if auto_spin:
             try:
@@ -213,6 +223,25 @@ class WorldROSWrapper(Node):
         self.robot_state_pubs.append(pub)
         self.robot_state_pub_threads.append(pub_timer)
 
+        # Specialized action servers for path planning and execution.
+        plan_path_server = ActionServer(
+            self,
+            PlanPath,
+            f"{robot.name}/plan_path",
+            execute_callback=partial(self.robot_path_plan_callback, robot=robot),
+            callback_group=ReentrantCallbackGroup(),
+        )
+        self.robot_plan_path_servers.append(plan_path_server)
+
+        follow_path_server = ActionServer(
+            self,
+            FollowPath,
+            f"{robot.name}/follow_path",
+            execute_callback=partial(self.robot_path_follow_callback, robot=robot),
+            callback_group=ReentrantCallbackGroup(),
+        )
+        self.robot_follow_path_servers.append(follow_path_server)
+
     def remove_robot_ros_interfaces(self, robot):
         """
         Removes ROS interfaces for a specific robot.
@@ -231,6 +260,12 @@ class WorldROSWrapper(Node):
                 pub_timer = self.robot_state_pub_threads.pop(idx)
                 pub_timer.destroy()
                 del pub_thread
+                plan_path_server = self.robot_plan_path_servers.pop(idx)
+                plan_path_server.destroy()
+                del plan_path_server
+                plan_follow_server = self.robot_follow_path_servers.pop(idx)
+                plan_follow_server.destroy()
+                del plan_follow_server
 
     def dynamics_callback(self):
         """
@@ -284,6 +319,8 @@ class WorldROSWrapper(Node):
 
         :param goal_handle: Task action goal handle to process.
         :type goal_handle: :class:`pyrobosim_msgs.action.ExecuteTaskAction.Goal`
+        :return: The action execution action result.
+        :rtype: :class:`pyrobosim_msgs.action.ExecuteTaskAction.Result`
         """
         robot = self.world.get_robot_by_name(goal_handle.request.action.robot)
         if not robot:
@@ -338,6 +375,8 @@ class WorldROSWrapper(Node):
 
         :param goal_handle: Task plan action goal handle to process.
         :type goal_handle: :class:`pyrobosim_msgs.action.ExecuteTaskPlan.Goal`
+        :return: The plan execution action result.
+        :rtype: :class:`pyrobosim_msgs.action.ExecuteTaskPlan.Result`
         """
         plan_msg = goal_handle.request.plan
         robot = self.world.get_robot_by_name(plan_msg.robot)
@@ -392,6 +431,57 @@ class WorldROSWrapper(Node):
             self.get_logger().info(f"Canceling plan for robot {robot.name}.")
             robot.cancel_actions()
         return CancelResponse.ACCEPT
+
+    def robot_path_plan_callback(self, goal_handle, robot=None):
+        """
+        Handle path planning action callback for a specific robot.
+
+        :param goal_handle: Path planning action goal handle to process.
+        :type goal_handle: :class:`pyrobosim_msgs.action.PlanPath.Goal`
+        :param robot: The robot instance corresponding to this request.
+        :type robot: :class:`pyrobosim.core.robot.Robot`
+        :return: The path planning action result.
+        :rtype: :class:`pyrobosim_msgs.action.PlanPath.Result`
+        """
+        goal = goal_handle.request.target_location or pose_from_ros(
+            goal_handle.request.target_pose
+        )
+
+        path = robot.plan_path(goal=goal)
+        goal_handle.succeed()
+
+        if path is None:
+            return PlanPath.Result(
+                execution_result=ExecutionResult(
+                    status=ExecutionResult.PLANNING_FAILURE,
+                    message="Path planning failed.",
+                )
+            )
+
+        return PlanPath.Result(
+            execution_result=ExecutionResult(status=ExecutionResult.SUCCESS),
+            path=path_to_ros(path),
+        )
+
+    def robot_path_follow_callback(self, goal_handle, robot=None):
+        """
+        Handle path following action callback for a specific robot.
+
+        :param goal_handle: Path following action goal handle to process.
+        :type goal_handle: :class:`pyrobosim_msgs.action.FollowPath.Goal`
+        :param robot: The robot instance corresponding to this request.
+        :type robot: :class:`pyrobosim.core.robot.Robot`
+        :return: The path following action result.
+        :rtype: :class:`pyrobosim_msgs.action.FollowPath.Result`
+        """
+        path = path_from_ros(goal_handle.request.path)
+
+        execution_result = robot.follow_path(path, blocking=True)
+        goal_handle.succeed()
+
+        return FollowPath.Result(
+            execution_result=execution_result_to_ros(execution_result)
+        )
 
     def is_robot_busy(self, robot):
         """

--- a/pyrobosim_ros/pyrobosim_ros/ros_interface.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_interface.py
@@ -479,12 +479,10 @@ class WorldROSWrapper(Node):
         :return: The path following action result.
         :rtype: :class:`pyrobosim_msgs.action.FollowPath.Result`
         """
+
+        # Follow path in a separate thread so we can check for cancellation in parallel.
         path = path_from_ros(goal_handle.request.path)
-        Thread(
-            target=robot.follow_path,
-            args=(path,),
-            kwargs={"use_thread": False, "blocking": True},
-        ).start()
+        Thread(target=robot.follow_path, args=(path,)).start()
 
         while robot.executing_nav and goal_handle.status != GoalStatus.STATUS_CANCELED:
             if goal_handle.is_cancel_requested:

--- a/pyrobosim_ros/pyrobosim_ros/ros_interface.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_interface.py
@@ -501,7 +501,7 @@ class WorldROSWrapper(Node):
         """
         Handle a cancel request for the robot path following action.
 
-        :param goal_handle: Path following action goal handle to process.
+        :param goal_handle: Path following action goal handle to cancel.
         :type goal_handle: :class:`pyrobosim_msgs.action.FollowPath.Goal`
         :param robot: The robot instance corresponding to this request.
         :type robot: :class:`pyrobosim.core.robot.Robot`

--- a/pyrobosim_ros/pyrobosim_ros/ros_interface.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_interface.py
@@ -478,6 +478,8 @@ class WorldROSWrapper(Node):
         path = path_from_ros(goal_handle.request.path)
 
         execution_result = robot.follow_path(path, blocking=True)
+        if self.world.has_gui:
+            self.world.gui.set_buttons_during_action(True)
         goal_handle.succeed()
 
         return FollowPath.Result(

--- a/pyrobosim_ros/pyrobosim_ros/ros_interface.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_interface.py
@@ -491,7 +491,7 @@ class WorldROSWrapper(Node):
 
         if self.world.has_gui:
             self.world.gui.set_buttons_during_action(True)
-        
+
         goal_handle.succeed()
         return FollowPath.Result(
             execution_result=execution_result_to_ros(robot.last_nav_result)

--- a/pyrobosim_ros/pyrobosim_ros/ros_interface.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_interface.py
@@ -53,6 +53,7 @@ class WorldROSWrapper(Node):
         This node will:
             * Publish states for each robot on ``<robot_name>/robot_state`` topics.
             * Subscribe to velocity commands for each robot on ``<robot_name>/cmd_vel`` topics.
+            * Allow path planning and following for each robot on ``<robot_name>/plan_path`` and ``<robot_name>/follow_path`` action servers, respectively.
             * Serve a ``request_world_state`` service to retrieve the world state for planning.
             * Serve a ``execute_action`` action server to run single actions on a robot.
             * Serve a ``execute_task_plan`` action server to run entire task plans on a robot.

--- a/test/core/test_robot.py
+++ b/test/core/test_robot.py
@@ -172,22 +172,9 @@ class TestRobot:
         # Non-threaded option -- blocks
         robot.set_pose(init_pose)
         path = robot.plan_path(goal=goal_pose)
-        result = robot.follow_path(path, use_thread=False)
-        assert result.status == ExecutionStatus.SUCCESS
+        result = robot.follow_path(path)
 
-        # Threaded option with blocking
-        robot.set_pose(init_pose)
-        path = robot.plan_path(goal=goal_pose)
-        result = robot.follow_path(path, use_thread=True, blocking=True)
         assert result.status == ExecutionStatus.SUCCESS
-
-        # Threaded option without blocking -- must check result
-        robot.set_pose(init_pose)
-        path = robot.plan_path(goal=goal_pose)
-        robot.follow_path(path, use_thread=True, blocking=False)
-        assert robot.executing_nav
-        while robot.executing_nav:
-            time.sleep(0.1)
         assert not robot.executing_nav
         assert robot.last_nav_result.is_success()
         pose = robot.get_pose()
@@ -238,7 +225,7 @@ class TestRobot:
 
         # Follow the path and check that it fails.
         with pytest.warns(UserWarning) as warn_info:
-            result = robot.follow_path(path, use_thread=False)
+            result = robot.follow_path(path)
         assert (
             warn_info[0].message.args[0]
             == "Remaining path is in collision. Aborting execution."
@@ -250,7 +237,7 @@ class TestRobot:
         for hallway in self.test_world.hallways:
             self.test_world.open_hallway(hallway)
         path = robot.plan_path(goal=goal_pose)
-        result = robot.follow_path(path, use_thread=False)
+        result = robot.follow_path(path)
         assert result.status == ExecutionStatus.SUCCESS
 
     def test_robot_manipulation(self):


### PR DESCRIPTION
This PR adds new action servers that perform path planning and following for individual robots.

* `<robot_name>/plan_path` performs path planning with the `pyrobosim_msgs.action.PlanPath` action.
  * This can accept either a target location name (string) or pose. 
* `<robot_name>/follow_path` perform path following with the `pyrobosim_msgs.action.FollowPath` action.
  * This accepts a path which you can directly grab from the result of the path planning action.
  * This action can be canceled if you want to abort path execution.

I was also finally able to remove unnecessary threading/blocking arguments to the `Robot.navigate()` and `Robot.follow_path()` methods.

Closes https://github.com/sea-bass/pyrobosim/issues/197