### PR TITLE
 Add UI button to toggle collision polygon display (issue #200) 

### DIFF
--- a/pyrobosim/pyrobosim/gui/main.py
+++ b/pyrobosim/pyrobosim/gui/main.py
@@ -151,17 +151,17 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):
         self.close_button = QtWidgets.QPushButton("Close")
         self.close_button.clicked.connect(self.on_close_click)
         self.action_layout.addWidget(self.close_button, 1, 2)
-        self.toggle_collision_polygons_checkbox = QtWidgets.QCheckBox(
-            "Collision Polygons"
-        )
-        self.toggle_collision_polygons_checkbox.clicked.connect(self.on_toggle_click)
-        self.action_layout.addWidget(self.toggle_collision_polygons_checkbox, 2, 0)
 
         # World layout (Matplotlib affordances)
         self.world_layout = QtWidgets.QVBoxLayout()
         self.nav_toolbar = NavigationToolbar2QT(self.canvas, self)
         self.addToolBar(QtCore.Qt.BottomToolBarArea, self.nav_toolbar)
         self.world_layout.addWidget(self.canvas)
+        self.toggle_collision_polygons_checkbox = QtWidgets.QCheckBox(
+            "Show collision polygons"
+        )
+        self.toggle_collision_polygons_checkbox.clicked.connect(self.on_collision_polygon_toggle_click)
+        self.world_layout.addWidget(self.toggle_collision_polygons_checkbox)
 
         # Main layout
         self.main_layout = QtWidgets.QVBoxLayout(self.main_widget)
@@ -312,10 +312,7 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):
             self.canvas.close_location(robot)
             self.update_button_state()
 
-    def on_toggle_click(self):
+    def on_collision_polygon_toggle_click(self):
         """Callback to toggle collision polygons."""
-        robot = self.get_current_robot()
-        if robot and robot.location:
-            print(f"[{robot.name}] Toggling collision polygons")
-            self.canvas.toggle_collision_polygons()
-            self.update_button_state()
+        self.canvas.toggle_collision_polygons()
+        self.canvas.draw_signal.emit()

--- a/pyrobosim/pyrobosim/gui/main.py
+++ b/pyrobosim/pyrobosim/gui/main.py
@@ -160,7 +160,9 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):
         self.toggle_collision_polygons_checkbox = QtWidgets.QCheckBox(
             "Show collision polygons"
         )
-        self.toggle_collision_polygons_checkbox.clicked.connect(self.on_collision_polygon_toggle_click)
+        self.toggle_collision_polygons_checkbox.clicked.connect(
+            self.on_collision_polygon_toggle_click
+        )
         self.world_layout.addWidget(self.toggle_collision_polygons_checkbox)
 
         # Main layout

--- a/pyrobosim/pyrobosim/gui/main.py
+++ b/pyrobosim/pyrobosim/gui/main.py
@@ -151,6 +151,9 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):
         self.close_button = QtWidgets.QPushButton("Close")
         self.close_button.clicked.connect(self.on_close_click)
         self.action_layout.addWidget(self.close_button, 1, 2)
+        self.toggle_collision_polygons_checkbox = QtWidgets.QCheckBox("Collision Polygons")
+        self.toggle_collision_polygons_checkbox.clicked.connect(self.on_toggle_click)
+        self.action_layout.addWidget(self.toggle_collision_polygons_checkbox, 2, 0)
 
         # World layout (Matplotlib affordances)
         self.world_layout = QtWidgets.QVBoxLayout()
@@ -303,4 +306,12 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):
         if robot and robot.location:
             print(f"[{robot.name}] Closing {robot.location}")
             self.canvas.close_location(robot)
+            self.update_button_state()
+
+    def on_toggle_click(self):
+        """Callback to toggle collision polygons."""
+        robot = self.get_current_robot()
+        if robot and robot.location:
+            print(f"[{robot.name}] Toggling collision polygons")
+            self.canvas.toggle_collision_polygons()
             self.update_button_state()

--- a/pyrobosim/pyrobosim/gui/main.py
+++ b/pyrobosim/pyrobosim/gui/main.py
@@ -151,7 +151,9 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):
         self.close_button = QtWidgets.QPushButton("Close")
         self.close_button.clicked.connect(self.on_close_click)
         self.action_layout.addWidget(self.close_button, 1, 2)
-        self.toggle_collision_polygons_checkbox = QtWidgets.QCheckBox("Collision Polygons")
+        self.toggle_collision_polygons_checkbox = QtWidgets.QCheckBox(
+            "Collision Polygons"
+        )
         self.toggle_collision_polygons_checkbox.clicked.connect(self.on_toggle_click)
         self.action_layout.addWidget(self.toggle_collision_polygons_checkbox, 2, 0)
 

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -150,8 +150,6 @@ class WorldCanvas(FigureCanvasQTAgg):
         self.location_patches = []
         self.location_texts = []
         self.path_planner_artists = {"graph": [], "path": []}
-
-        # Debug displays (TODO: Should be available from GUI).
         self.show_collision_polygons = False
 
         # Connect signals
@@ -174,6 +172,8 @@ class WorldCanvas(FigureCanvasQTAgg):
             self.nav_animator.start(sleep_time_msec)
 
     def toggle_collision_polygons(self):
+        """Shows/hides collision polygons."""
+        print("Disabling collision polygons" if self.show_collision_polygons else "Enabling collision polygons")
         self.show_collision_polygons = not self.show_collision_polygons
         self.show_hallways()
         self.show_rooms()

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -173,7 +173,11 @@ class WorldCanvas(FigureCanvasQTAgg):
 
     def toggle_collision_polygons(self):
         """Shows/hides collision polygons."""
-        print("Disabling collision polygons" if self.show_collision_polygons else "Enabling collision polygons")
+        print(
+            "Disabling collision polygons"
+            if self.show_collision_polygons
+            else "Enabling collision polygons"
+        )
         self.show_collision_polygons = not self.show_collision_polygons
         self.show_hallways()
         self.show_rooms()

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -253,7 +253,7 @@ class WorldCanvas(FigureCanvasQTAgg):
                 room.remove()
 
             self.room_patches = [room.viz_patch for room in self.world.rooms]
-            
+
             for room in self.world.rooms:
                 self.axes.add_patch(room.viz_patch)
                 self.axes.text(

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -9,6 +9,7 @@ from matplotlib.figure import Figure
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg
 from matplotlib.pyplot import Circle
 from matplotlib.transforms import Affine2D
+from matplotlib.artist import Artist
 from PySide6.QtCore import QRunnable, QThreadPool, QTimer, Signal
 
 from pyrobosim.core.robot import Robot
@@ -147,6 +148,7 @@ class WorldCanvas(FigureCanvasQTAgg):
         self.obj_patches = []
         self.obj_texts = []
         self.hallway_patches = []
+        self.room_patches = []
         self.location_patches = []
         self.location_texts = []
         self.path_planner_artists = {"graph": [], "path": []}
@@ -172,6 +174,11 @@ class WorldCanvas(FigureCanvasQTAgg):
             self.nav_animator = QTimer()
             self.nav_animator.timeout.connect(self.nav_animation_callback)
             self.nav_animator.start(sleep_time_msec)
+
+    def toggle_collision_polygons(self):
+        self.show_collision_polygons = not self.show_collision_polygons
+        self.show_hallways()
+        self.show_rooms()
 
     def show_robots(self):
         """Draws robots as circles with heading lines for visualization."""
@@ -241,6 +248,31 @@ class WorldCanvas(FigureCanvasQTAgg):
                     self.axes.add_patch(coll_patch)
                     self.hallway_patches.append(coll_patch)
 
+    def show_rooms(self):
+        """Draws rooms in the world."""
+        with self.draw_lock:
+            for room in self.room_patches:
+                room.remove()
+
+            self.room_patches = [room.viz_patch for room in self.world.rooms]
+            
+            for room in self.world.rooms:
+                self.axes.add_patch(room.viz_patch)
+                self.axes.text(
+                    room.centroid[0],
+                    room.centroid[1],
+                    room.name,
+                    color=room.viz_color,
+                    fontsize=12,
+                    ha="center",
+                    va="top",
+                    clip_on=True,
+                )
+                if self.show_collision_polygons:
+                    coll_patch = room.get_collision_patch()
+                    self.axes.add_patch(coll_patch)
+                    self.room_patches.append(coll_patch)
+
     def show_locations(self):
         """Draws locations and object spawns in the world."""
         with self.draw_lock:
@@ -309,21 +341,7 @@ class WorldCanvas(FigureCanvasQTAgg):
         Displays all entities in the world (robots, rooms, objects, etc.).
         """
         # Entities in the world.
-        self.room_patches = [room.viz_patch for room in self.world.rooms]
-        for room in self.world.rooms:
-            self.axes.add_patch(room.viz_patch)
-            self.axes.text(
-                room.centroid[0],
-                room.centroid[1],
-                room.name,
-                color=room.viz_color,
-                fontsize=12,
-                ha="center",
-                va="top",
-                clip_on=True,
-            )
-            if self.show_collision_polygons:
-                self.axes.add_patch(room.get_collision_patch())
+        self.show_rooms()
         self.show_hallways()
         self.show_locations()
         self.show_objects()

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -9,7 +9,6 @@ from matplotlib.figure import Figure
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg
 from matplotlib.pyplot import Circle
 from matplotlib.transforms import Affine2D
-from matplotlib.artist import Artist
 from PySide6.QtCore import QRunnable, QThreadPool, QTimer, Signal
 
 from pyrobosim.core.robot import Robot

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -173,12 +173,12 @@ class WorldCanvas(FigureCanvasQTAgg):
 
     def toggle_collision_polygons(self):
         """Shows/hides collision polygons."""
-        print(
-            "Disabling collision polygons"
-            if self.show_collision_polygons
-            else "Enabling collision polygons"
-        )
         self.show_collision_polygons = not self.show_collision_polygons
+        print(
+            "Enabling collision polygons"
+            if self.show_collision_polygons
+            else "Disabling collision polygons"
+        )
         self.show_hallways()
         self.show_rooms()
 


### PR DESCRIPTION
- Refactored `show()` by creating `show_rooms()` function https://github.com/sea-bass/pyrobosim/blob/ea926bbdf736f5dbc2537dcc0d35789bb54e2d86/pyrobosim/pyrobosim/gui/world_canvas.py#L305
- Implemented `show_rooms()` similar `show_hallways()` https://github.com/sea-bass/pyrobosim/blob/ea926bbdf736f5dbc2537dcc0d35789bb54e2d86/pyrobosim/pyrobosim/gui/world_canvas.py#L223
- This helped me create a new function `toggle_collision_polygons()` which calls `show()` and `show_rooms()` to redraw rooms and hallways with/without collision polygons upon toggling a checkbox
- Added a checkbox as part of action buttons https://github.com/sea-bass/pyrobosim/blob/ea926bbdf736f5dbc2537dcc0d35789bb54e2d86/pyrobosim/pyrobosim/gui/main.py#L135
- Pull request shows 2 contributors because I had some trouble configuring git user on ubuntu so somehow it shows the name of my ubuntu user
- Ran `pre-commit run -a` and `test/run_tests.bash` (196 passed with 6 warnings) before submitting pull request as per the [contributing guidelines](https://github.com/sea-bass/pyrobosim/blob/ea926bbdf736f5dbc2537dcc0d35789bb54e2d86/CONTRIBUTING.md)