### PR TITLE
Add Reset Path Planner UI button

### DIFF
--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -421,6 +421,20 @@ class Robot:
 
         return self.follow_path(path, realtime_factor=realtime_factor)
 
+    def reset_path_planner(self):
+        """Resets the robot's path planner, if available."""
+        if self.path_planner is None:
+            warnings.warn(f"[{self.name}] Robot has no path planner. Cannot reset.")
+            return
+
+        if not hasattr(self.path_planner, "reset"):
+            warnings.warn(
+                f"[{self.name}] Path planner does not have a reset() method. Cannot reset."
+            )
+            return
+
+        self.path_planner.reset()
+
     def pick_object(self, obj_query, grasp_pose=None):
         """
         Picks up an object in the world given an object and/or location query.

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -434,6 +434,12 @@ class Robot:
             return
 
         self.path_planner.reset()
+        if self.world.has_gui:
+            show_graphs = True
+            path = None
+            self.world.gui.canvas.show_planner_and_path_signal.emit(
+                self, show_graphs, path
+            )
 
     def pick_object(self, obj_query, grasp_pose=None):
         """

--- a/pyrobosim/pyrobosim/core/yaml_utils.py
+++ b/pyrobosim/pyrobosim/core/yaml_utils.py
@@ -7,11 +7,7 @@ import yaml
 
 from .robot import Robot
 from .world import World
-from ..navigation import (
-    ConstantVelocityExecutor,
-    OccupancyGrid,
-    get_planner_class,
-)
+from ..navigation import ConstantVelocityExecutor, get_planner_class
 from ..planning.actions import ExecutionOptions
 from ..utils.general import replace_special_yaml_tokens
 from ..utils.pose import Pose

--- a/pyrobosim/test/core/test_robot.py
+++ b/pyrobosim/test/core/test_robot.py
@@ -162,7 +162,7 @@ class TestRobot:
             == "[robot] Robot has no path planner. Cannot reset."
         )
 
-        # Re-add the path planner and set it
+        # Re-add the path planner and reset it. There should be no warnings.
         robot.path_planner = path_planner
         robot.reset_path_planner()
 

--- a/pyrobosim/test/core/test_robot.py
+++ b/pyrobosim/test/core/test_robot.py
@@ -122,10 +122,8 @@ class TestRobot:
         init_pose = Pose(x=1.0, y=0.5, yaw=0.0)
         goal_pose = Pose(x=2.5, y=3.0, yaw=np.pi / 2.0)
 
-        robot = Robot(
-            pose=init_pose,
-            path_planner=WorldGraphPlanner(world=self.test_world),
-        )
+        path_planner = WorldGraphPlanner(world=self.test_world)
+        robot = Robot(pose=init_pose, path_planner=path_planner)
         robot.world = self.test_world
         robot.location = self.test_world.get_entity_by_name("kitchen")
 
@@ -155,6 +153,18 @@ class TestRobot:
         assert (
             warn_info[0].message.args[0] == "No path planner attached to robot robot."
         )
+
+        # Try and reset the path planner with no planner set
+        with pytest.warns(UserWarning) as warn_info:
+            robot.reset_path_planner()
+        assert (
+            warn_info[0].message.args[0]
+            == "[robot] Robot has no path planner. Cannot reset."
+        )
+
+        # Re-add the path planner and set it
+        robot.path_planner = path_planner
+        robot.reset_path_planner()
 
     def test_robot_path_executor(self):
         """Check that path executors can be used from a robot."""

--- a/pyrobosim_ros/pyrobosim_ros/ros_interface.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_interface.py
@@ -572,12 +572,6 @@ class WorldROSWrapper(Node):
             return Trigger.Response(success=False, message=message)
 
         robot.reset_path_planner()
-        if self.world.has_gui:
-            show_graphs = True
-            path = None
-            self.world.gui.canvas.show_planner_and_path_signal.emit(
-                robot, show_graphs, path
-            )
         return Trigger.Response(success=True)
 
     def robot_detect_objects_callback(self, goal_handle, robot=None):

--- a/pyrobosim_ros/pyrobosim_ros/ros_interface.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_interface.py
@@ -571,7 +571,7 @@ class WorldROSWrapper(Node):
             self.get_logger().warn(message)
             return Trigger.Response(success=False, message=message)
 
-        robot.path_planner.reset()
+        robot.reset_path_planner()
         if self.world.has_gui:
             show_graphs = True
             path = None


### PR DESCRIPTION
This PR allows resetting the path planner from the UI.

This means that now if you close a hallway from the UI, you can reset the planner for a robot with PRM/A* and then replan without going right through the door.

Thanks to @muhidabid for setting the foundation with his "Cancel Action" button, I could just copy-paste exactly what he did :)

![image](https://github.com/user-attachments/assets/f98f6afb-ddcf-4160-8346-bb6b6476badc)
