### PR TITLE
Count paths with zero poses as path planning failures

### DIFF
--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -306,7 +306,7 @@ class Robot:
         """
         self.last_nav_result = ExecutionResult()
 
-        if path is None:
+        if path is None or path.num_poses == 0:
             self.executing_nav = False
             message = "No path to execute."
             warnings.warn(message)
@@ -323,13 +323,8 @@ class Robot:
                 message=message,
             )
 
-        if path.num_poses == 0:
-            # Trivial case where the path is empty.
-            result = ExecutionResult(status=ExecutionStatus.SUCCESS)
-            self.last_nav_result = result
-        else:
-            # Execute in this thread and check that the robot made it to its goal pose.
-            result = self.path_executor.execute(path, realtime_factor)
+        # Follow the path.
+        result = self.path_executor.execute(path, realtime_factor)
 
         # Check that the robot made it to its goal pose at the end of execution.
         at_goal_pose = self.get_pose().is_approx(path.poses[-1])

--- a/pyrobosim/pyrobosim/navigation/rrt.py
+++ b/pyrobosim/pyrobosim/navigation/rrt.py
@@ -69,14 +69,12 @@ class RRTPlanner:
         self.max_nodes_sampled = max_nodes_sampled
         self.max_time = max_time
         self.rewire_radius = rewire_radius
+        self.compress_path = compress_path
 
         # Visualization
         self.color_start = [0, 0, 0]
         self.color_goal = [0, 0.4, 0.8]
         self.color_alpha = 0.5
-
-        self.latest_path = Path()
-        self.compress_path = compress_path
 
         self.reset()
 

--- a/pyrobosim_ros/pyrobosim_ros/ros_interface.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_interface.py
@@ -491,7 +491,7 @@ class WorldROSWrapper(Node):
         path = robot.plan_path(goal=goal)
         goal_handle.succeed()
 
-        if path is None:
+        if path is None or path.num_poses == 0:
             return PlanPath.Result(
                 execution_result=ExecutionResult(
                     status=ExecutionResult.PLANNING_FAILURE,


### PR DESCRIPTION
When path planning fails, most planners return a `Path` with 0 poses instead of `None`.

So this should also be counted as a failure, in contrast with a trivial path which has 2 identical start and goal points.