### PR TITLE
Allow opening and closing locations globally from GUI

### DIFF
--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -907,7 +907,7 @@ class Robot:
             )
 
         if self.world.has_gui:
-            self.world.gui.set_buttons_during_action(True)
+            self.world.gui.update_button_state()
         print(f"[{self.name}] Action completed with result: {result.status.name}")
         self.current_action = None
         self.executing_action = False
@@ -975,7 +975,7 @@ class Robot:
             time.sleep(delay)  # Artificial delay between actions
 
         if self.world.has_gui:
-            self.world.gui.set_buttons_during_action(True)
+            self.world.gui.update_button_state()
 
         print(f"[{self.name}] Task plan completed with status: {result.status.name}")
         self.executing_plan = False

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -769,12 +769,10 @@ class Robot:
                 )
 
         if isinstance(self.location, ObjectSpawn):
-            return self.world.open_location(self.location.parent)
-        elif isinstance(self.location, Hallway):
-            return self.world.open_hallway(self.location)
-
-        # This should not happen
-        return ExecutionResult(status=ExecutionResult.UNKNOWN)
+            loc_to_open = self.location.parent
+        else:
+            loc_to_open = self.location
+        return self.world.open_location(loc_to_open)
 
     def close_location(self):
         """
@@ -825,12 +823,10 @@ class Robot:
                 )
 
         if isinstance(self.location, ObjectSpawn):
-            return self.world.close_location(self.location.parent)
-        elif isinstance(self.location, Hallway):
-            return self.world.close_hallway(self.location, ignore_robots=[self])
-
-        # This should not happen
-        return ExecutionResult(status=ExecutionResult.UNKNOWN)
+            loc_to_close = self.location.parent
+        else:
+            loc_to_close = self.location
+        return self.world.close_location(loc_to_close, ignore_robots=[self])
 
     def execute_action(self, action):
         """

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -468,8 +468,8 @@ class World:
         """
         Opens a storage location or hallway between two rooms..
 
-        :param location: Location or Hallway object to open.
-        :type location: :class:`pyrobosim.core.locations.Location` or :class:`pyrobosim.core.hallway.Hallway`
+        :param location: Location or Hallway object to open, or its name.
+        :type location: :class:`pyrobosim.core.locations.Location`, :class:`pyrobosim.core.hallway.Hallway`, or str
         :return: An object describing the execution result.
         :rtype: :class:`pyrobosim.planning.actions.ExecutionResult`
         """
@@ -520,8 +520,8 @@ class World:
         """
         Close a storage location or hallway.
 
-        :param location: Location or Hallway object to close.
-        :type location: :class:`pyrobosim.core.locations.Location` or :class:`pyrobosim.core.hallway.Hallway`
+        :param location: Location or Hallway object to close, or its name.
+        :type location: :class:`pyrobosim.core.locations.Location`, :class:`pyrobosim.core.hallway.Hallway`, or str
         :param ignore_robots: List of robots to ignore, for example the robot closing the hallway.
         :type ignore_robots: list[:class:`pyrobosim.core.robot.Robot`]
         :return: An object describing the execution result.
@@ -584,8 +584,8 @@ class World:
         """
         Locks a storage location or hallway.
 
-        :param location: Location object to lock.
-        :type location: :class:`pyrobosim.core.locations.Location` or :class:`pyrobosim.core.hallway.Hallway`
+        :param location: Location or Hallway object to lock, or its name.
+        :type location: :class:`pyrobosim.core.locations.Location`, :class:`pyrobosim.core.hallway.Hallway`, or str
         :return: An object describing the execution result.
         :rtype: :class:`pyrobosim.planning.actions.ExecutionResult`
         """
@@ -622,8 +622,8 @@ class World:
         """
         Unlocks a storage location or hallway.
 
-        :param location: Location object to unlock.
-        :type location: :class:`pyrobosim.core.locations.Location` or :class:`pyrobosim.core.hallway.Hallway`
+        :param location: Location or Hallway object to unlock, or its name.
+        :type location: :class:`pyrobosim.core.locations.Location`, :class:`pyrobosim.core.hallway.Hallway`, or str
         :return: An object describing the execution result.
         :rtype: :class:`pyrobosim.planning.actions.ExecutionResult`
         """

--- a/pyrobosim/pyrobosim/gui/main.py
+++ b/pyrobosim/pyrobosim/gui/main.py
@@ -217,10 +217,14 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):
             self.canvas.show_world_state(robot, navigating=is_moving)
         else:
             self.nav_button.setEnabled(False)
+            self.pick_button.setEnabled(False)
+            self.place_button.setEnabled(False)
+            self.detect_button.setEnabled(False)
             self.cancel_action_button.setEnabled(False)
-            self.reset_path_planner_button.setEnabled(False)
             self.open_button.setEnabled(True)
             self.close_button.setEnabled(True)
+            self.reset_path_planner_button.setEnabled(False)
+            self.rand_pose_button.setEnabled(False)
 
         self.canvas.draw_signal.emit()
 

--- a/pyrobosim/pyrobosim/gui/main.py
+++ b/pyrobosim/pyrobosim/gui/main.py
@@ -219,6 +219,8 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):
             self.nav_button.setEnabled(False)
             self.cancel_action_button.setEnabled(False)
             self.reset_path_planner_button.setEnabled(False)
+            self.open_button.setEnabled(True)
+            self.close_button.setEnabled(True)
 
         self.canvas.draw_signal.emit()
 
@@ -325,6 +327,8 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):
             print(f"[{robot.name}] Opening {robot.location}")
             self.canvas.open_location(robot)
             self.update_button_state()
+        elif not robot and self.goal_textbox.text():
+            self.world.open_location(self.goal_textbox.text())
 
     def on_close_click(self):
         """Callback to close a location."""
@@ -333,6 +337,8 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):
             print(f"[{robot.name}] Closing {robot.location}")
             self.canvas.close_location(robot)
             self.update_button_state()
+        elif not robot and self.goal_textbox.text():
+            self.world.close_location(self.goal_textbox.text())
 
     def on_collision_polygon_toggle_click(self):
         """Callback to toggle collision polygons."""

--- a/pyrobosim/test/core/test_hallway.py
+++ b/pyrobosim/test/core/test_hallway.py
@@ -98,27 +98,27 @@ class TestHallway:
 
         # When trying to open the hallway, it should say it's already open.
         with pytest.warns(UserWarning):
-            result = self.test_world.open_hallway(hallway)
+            result = self.test_world.open_location(hallway)
         assert result.status == ExecutionStatus.PRECONDITION_FAILURE
         assert result.message == "Hallway: hall_room_start_room_end is already open."
         assert hallway.is_open
         assert not hallway.is_locked
 
         # Closing should work
-        result = self.test_world.close_hallway(hallway)
+        result = self.test_world.close_location(hallway)
         assert result.is_success()
         assert not hallway.is_open
         assert not hallway.is_locked
 
         # Locking should work
-        result = self.test_world.lock_hallway(hallway)
+        result = self.test_world.lock_location(hallway)
         assert result.is_success()
         assert not hallway.is_open
         assert hallway.is_locked
 
         # Opening should not work due to being locked
         with pytest.warns(UserWarning):
-            result = self.test_world.open_hallway(hallway)
+            result = self.test_world.open_location(hallway)
         assert result.status == ExecutionStatus.PRECONDITION_FAILURE
         assert result.message == "Hallway: hall_room_start_room_end is locked."
         assert not hallway.is_open
@@ -126,7 +126,7 @@ class TestHallway:
 
         # Closing should not work due to already being closed
         with pytest.warns(UserWarning):
-            result = self.test_world.close_hallway(hallway)
+            result = self.test_world.close_location(hallway)
         assert result.status == ExecutionStatus.PRECONDITION_FAILURE
         assert result.message == "Hallway: hall_room_start_room_end is already closed."
         assert not hallway.is_open
@@ -134,21 +134,21 @@ class TestHallway:
 
         # Locking should not work due to already being locked
         with pytest.warns(UserWarning):
-            result = self.test_world.lock_hallway(hallway)
+            result = self.test_world.lock_location(hallway)
         assert result.status == ExecutionStatus.PRECONDITION_FAILURE
         assert result.message == "Hallway: hall_room_start_room_end is already locked."
         assert not hallway.is_open
         assert hallway.is_locked
 
         # Unlocking should work
-        result = self.test_world.unlock_hallway(hallway)
+        result = self.test_world.unlock_location(hallway)
         assert result.is_success()
         assert not hallway.is_open
         assert not hallway.is_locked
 
         # Unlocking should not work due to already being unlocked
         with pytest.warns(UserWarning):
-            result = self.test_world.unlock_hallway(hallway)
+            result = self.test_world.unlock_location(hallway)
         assert result.status == ExecutionStatus.PRECONDITION_FAILURE
         assert (
             result.message == "Hallway: hall_room_start_room_end is already unlocked."
@@ -157,7 +157,7 @@ class TestHallway:
         assert not hallway.is_locked
 
         # Opening should work
-        result = self.test_world.open_hallway(hallway)
+        result = self.test_world.open_location(hallway)
         assert result.is_success()
         assert hallway.is_open
         assert not hallway.is_locked

--- a/pyrobosim/test/core/test_robot.py
+++ b/pyrobosim/test/core/test_robot.py
@@ -229,7 +229,7 @@ class TestRobot:
         def close_all_hallways():
             time.sleep(0.5)
             for hallway in self.test_world.hallways:
-                self.test_world.close_hallway(hallway, ignore_robots=[robot])
+                self.test_world.close_location(hallway, ignore_robots=[robot])
 
         threading.Thread(target=close_all_hallways).start()
 
@@ -245,7 +245,7 @@ class TestRobot:
 
         # Now open the hallways and try again, which should succeed.
         for hallway in self.test_world.hallways:
-            self.test_world.open_hallway(hallway)
+            self.test_world.open_location(hallway)
         path = robot.plan_path(goal=goal_pose)
         result = robot.follow_path(path)
         assert result.status == ExecutionStatus.SUCCESS

--- a/pyrobosim/test/core/test_robot.py
+++ b/pyrobosim/test/core/test_robot.py
@@ -219,7 +219,6 @@ class TestRobot:
             ),
         )
         robot.world = self.test_world
-        robot.location = "kitchen"
 
         # Plan a path.
         robot.set_pose(init_pose)

--- a/pyrobosim_ros/pyrobosim_ros/ros_interface.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_interface.py
@@ -726,64 +726,27 @@ class WorldROSWrapper(Node):
             response.result.message = message
             return response
 
-        if isinstance(entity, Location):
-            # Try open or close the location if its status needs to be toggled.
-            if request.open != entity.is_open:
-                if request.open:
-                    result = self.world.open_location(entity)
-                else:
-                    result = self.world.close_location(entity)
+        # Try open or close the location if its status needs to be toggled.
+        if request.open != entity.is_open:
+            if request.open:
+                result = self.world.open_location(entity)
+            else:
+                result = self.world.close_location(entity)
 
-                if not result.is_success():
-                    response.result = execution_result_to_ros(result)
-                    return response
+            if not result.is_success():
+                response.result = execution_result_to_ros(result)
+                return response
 
-            # Try lock or unlock the location if its status needs to be toggled.
-            if request.lock != entity.is_locked:
-                if request.lock:
-                    result = self.world.lock_location(entity)
-                else:
-                    result = self.world.unlock_location(entity)
+        # Try lock or unlock the location if its status needs to be toggled.
+        if request.lock != entity.is_locked:
+            if request.lock:
+                result = self.world.lock_location(entity)
+            else:
+                result = self.world.unlock_location(entity)
 
-                if not result.is_success():
-                    response.result = execution_result_to_ros(result)
-                    return response
-
-            response.result.status = ExecutionResult.SUCCESS
-            return response
-
-        elif isinstance(entity, Hallway):
-            # Try open or close the hallway if its status needs to be toggled.
-            if request.open != entity.is_open:
-                if request.open:
-                    result = self.world.open_hallway(entity)
-                else:
-                    result = self.world.close_hallway(entity)
-
-                if not result.is_success():
-                    response.result = execution_result_to_ros(result)
-                    return response
-
-            # Try lock or unlock the hallway if its status needs to be toggled.
-            if request.lock != entity.is_locked:
-                if request.lock:
-                    result = self.world.lock_hallway(entity)
-                else:
-                    result = self.world.unlock_hallway(entity)
-
-                if not result.is_success():
-                    response.result = execution_result_to_ros(result)
-                    return response
-
-            response.result.status = ExecutionResult.SUCCESS
-            return response
-
-        # If no valid entity type is reached, we should fail here.
-        message = f"Cannot set state for {entity.name} since it is of type {type(entity).__name__}."
-        self.get_logger().warn(message)
-        response.result.status = ExecutionResult.INVALID_ACTION
-        response.result.message = message
-        return response
+            if not result.is_success():
+                response.result = execution_result_to_ros(result)
+                return response
 
 
 def update_world_from_state_msg(world, msg):

--- a/pyrobosim_ros/pyrobosim_ros/ros_interface.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_interface.py
@@ -737,7 +737,7 @@ class WorldROSWrapper(Node):
             else:
                 result = self.world.close_location(entity)
 
-            if not response.result.is_success():
+            if not result.is_success():
                 response.result = execution_result_to_ros(result)
                 return response
 

--- a/pyrobosim_ros/pyrobosim_ros/ros_interface.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_interface.py
@@ -748,6 +748,11 @@ class WorldROSWrapper(Node):
                 response.result = execution_result_to_ros(result)
                 return response
 
+        # If the command is a no-op, count it as a success.
+        response.result.status = ExecutionResult.SUCCESS
+        response.result.message = "No action needed."
+        return response
+
 
 def update_world_from_state_msg(world, msg):
     """


### PR DESCRIPTION
This PR allows opening/closing storage locations and hallways from the UI globally -- meaning you can select `"world"` from the drop-down menu and then open/close whatever location is set in the goal textbox.

I also unified the `open/close/lock/unlock` methods for hallways and locations and removed a lot of copypasta, as well as some bits of unreachable code.