### PR TITLE
Cleanly shutdown ROS interface node

### DIFF
--- a/pyrobosim/pyrobosim/gui/main.py
+++ b/pyrobosim/pyrobosim/gui/main.py
@@ -76,6 +76,8 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):
         """Cleans up running threads on closing the window."""
         self.canvas.nav_animator.stop()
         self.canvas.thread_pool.waitForDone()
+        if self.world and self.world.has_ros_node:
+            self.world.ros_node.shutdown()
 
     def set_window_dims(self, screen_fraction=0.8):
         """

--- a/pyrobosim_ros/test/test_ros_interface.py
+++ b/pyrobosim_ros/test/test_ros_interface.py
@@ -374,5 +374,5 @@ class TestRosInterface:
         name="test_shutdown_ros_interface", depends=["test_specialized_actions"]
     )
     def test_shutdown_ros_interface(self):
-        """Shuts down rclpy at the end of all other tests."""
-        rclpy.shutdown()
+        """Shuts down the interface node and rclpy at the end of all other tests."""
+        TestRosInterface.ros_interface.shutdown()


### PR DESCRIPTION
This PR cleanly shuts down the ROS interface node by bringing down the ROS executor as part of the GUI's close event, and handling some other logic a bit.

Closes #252