### PR TITLE
Add header to RobotState message

### DIFF
--- a/pyrobosim_msgs/msg/RobotState.msg
+++ b/pyrobosim_msgs/msg/RobotState.msg
@@ -1,5 +1,8 @@
 # Robot state definition message
 
+# Header containing a timestamp
+std_msgs/Header header
+
 # Robot information
 string name
 

--- a/pyrobosim_ros/pyrobosim_ros/ros_interface.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_interface.py
@@ -647,6 +647,7 @@ class WorldROSWrapper(Node):
         :rtype: :class:`pyrobosim_msgs.msg.RobotState`
         """
         state_msg = RobotState(name=robot.name)
+        state_msg.header.stamp = self.get_clock().now().to_msg()
         state_msg.pose = pose_to_ros(robot.get_pose())
         state_msg.battery_level = robot.battery_level
         state_msg.executing_action = robot.executing_action


### PR DESCRIPTION
It's generally a good idea to have timestamped robot state messages if they are being streamed via topic.