### PR TITLE
Consistently update robot state in GUI after path following

### DIFF
--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -351,6 +351,11 @@ class Robot:
             ):
                 print(f"[{self.name}] Battery charged at {self.location.name}!")
                 self.battery_level = 100.0
+
+            if self.world.has_gui:
+                self.world.gui.canvas.show_world_state(robot=self)
+                self.world.gui.update_button_state()
+
         self.last_nav_result = result
         return result
 

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -59,9 +59,6 @@ class NavRunner(QRunnable):
             realtime_factor=self.canvas.realtime_factor,
         )
 
-        self.canvas.show_world_state(robot=robot)
-        world.gui.update_button_state()
-
 
 class WorldCanvas(FigureCanvasQTAgg):
     """


### PR DESCRIPTION
Turns out that updating the robot state did not take effect after using the individual `/<robot_name>/follow_path` action, since these updates were tied to the completion of the execution of the abstract action rather than at the end of `Robot.follow_path()`.