### PR TITLE
Count open, close, lock, and unlock trivial operations as success

### DIFF
--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -496,7 +496,7 @@ class World:
             message = f"{location} is already open."
             warnings.warn(message)
             return ExecutionResult(
-                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+                status=ExecutionStatus.SUCCESS, message=message
             )
 
         if location.is_locked:
@@ -550,7 +550,7 @@ class World:
             message = f"{location} is already closed."
             warnings.warn(message)
             return ExecutionResult(
-                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+                status=ExecutionStatus.SUCCESS, message=message
             )
 
         if location.is_locked:
@@ -612,7 +612,7 @@ class World:
             message = f"{location} is already locked."
             warnings.warn(message)
             return ExecutionResult(
-                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+                status=ExecutionStatus.SUCCESS, message=message
             )
 
         location.is_locked = True
@@ -650,7 +650,7 @@ class World:
             message = f"{location} is already unlocked."
             warnings.warn(message)
             return ExecutionResult(
-                status=ExecutionStatus.PRECONDITION_FAILURE, message=message
+                status=ExecutionStatus.SUCCESS, message=message
             )
 
         location.is_locked = False

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -495,9 +495,7 @@ class World:
         if location.is_open:
             message = f"{location} is already open."
             warnings.warn(message)
-            return ExecutionResult(
-                status=ExecutionStatus.SUCCESS, message=message
-            )
+            return ExecutionResult(status=ExecutionStatus.SUCCESS, message=message)
 
         if location.is_locked:
             message = f"{location} is locked."
@@ -549,9 +547,7 @@ class World:
         if not location.is_open:
             message = f"{location} is already closed."
             warnings.warn(message)
-            return ExecutionResult(
-                status=ExecutionStatus.SUCCESS, message=message
-            )
+            return ExecutionResult(status=ExecutionStatus.SUCCESS, message=message)
 
         if location.is_locked:
             message = f"{location} is locked."
@@ -611,9 +607,7 @@ class World:
         if location.is_locked:
             message = f"{location} is already locked."
             warnings.warn(message)
-            return ExecutionResult(
-                status=ExecutionStatus.SUCCESS, message=message
-            )
+            return ExecutionResult(status=ExecutionStatus.SUCCESS, message=message)
 
         location.is_locked = True
         return ExecutionResult(status=ExecutionStatus.SUCCESS)
@@ -649,9 +643,7 @@ class World:
         if not location.is_locked:
             message = f"{location} is already unlocked."
             warnings.warn(message)
-            return ExecutionResult(
-                status=ExecutionStatus.SUCCESS, message=message
-            )
+            return ExecutionResult(status=ExecutionStatus.SUCCESS, message=message)
 
         location.is_locked = False
         return ExecutionResult(status=ExecutionStatus.SUCCESS)

--- a/pyrobosim/test/core/test_hallway.py
+++ b/pyrobosim/test/core/test_hallway.py
@@ -96,10 +96,10 @@ class TestHallway:
         assert hallway.is_open
         assert not hallway.is_locked
 
-        # When trying to open the hallway, it should say it's already open.
+        # When trying to open the hallway, it should succeed and say it's already open.
         with pytest.warns(UserWarning):
             result = self.test_world.open_location(hallway)
-        assert result.status == ExecutionStatus.PRECONDITION_FAILURE
+        assert result.is_success()
         assert result.message == "Hallway: hall_room_start_room_end is already open."
         assert hallway.is_open
         assert not hallway.is_locked
@@ -124,18 +124,18 @@ class TestHallway:
         assert not hallway.is_open
         assert hallway.is_locked
 
-        # Closing should not work due to already being closed
+        # Closing should succeed due to already being closed
         with pytest.warns(UserWarning):
             result = self.test_world.close_location(hallway)
-        assert result.status == ExecutionStatus.PRECONDITION_FAILURE
+        assert result.is_success()
         assert result.message == "Hallway: hall_room_start_room_end is already closed."
         assert not hallway.is_open
         assert hallway.is_locked
 
-        # Locking should not work due to already being locked
+        # Locking should succeed due to already being locked
         with pytest.warns(UserWarning):
             result = self.test_world.lock_location(hallway)
-        assert result.status == ExecutionStatus.PRECONDITION_FAILURE
+        assert result.is_success()
         assert result.message == "Hallway: hall_room_start_room_end is already locked."
         assert not hallway.is_open
         assert hallway.is_locked
@@ -146,10 +146,10 @@ class TestHallway:
         assert not hallway.is_open
         assert not hallway.is_locked
 
-        # Unlocking should not work due to already being unlocked
+        # Unlocking should succeed due to already being unlocked
         with pytest.warns(UserWarning):
             result = self.test_world.unlock_location(hallway)
-        assert result.status == ExecutionStatus.PRECONDITION_FAILURE
+        assert result.is_success()
         assert (
             result.message == "Hallway: hall_room_start_room_end is already unlocked."
         )

--- a/pyrobosim/test/core/test_locations.py
+++ b/pyrobosim/test/core/test_locations.py
@@ -69,10 +69,10 @@ class TestLocations:
         assert location.is_open
         assert not location.is_locked
 
-        # When trying to open the location, it should say it's already open.
+        # When trying to open the location, it should succeed and say it's already open.
         with pytest.warns(UserWarning):
             result = self.test_world.open_location(location)
-        assert result.status == ExecutionStatus.PRECONDITION_FAILURE
+        assert result.is_success()
         assert result.message == "Location: test_table is already open."
         assert location.is_open
         assert not location.is_locked
@@ -97,18 +97,18 @@ class TestLocations:
         assert not location.is_open
         assert location.is_locked
 
-        # Closing should not work due to already being closed
+        # Closing should succeed due to already being closed
         with pytest.warns(UserWarning):
             result = self.test_world.close_location(location)
-        assert result.status == ExecutionStatus.PRECONDITION_FAILURE
+        assert result.is_success()
         assert result.message == "Location: test_table is already closed."
         assert not location.is_open
         assert location.is_locked
 
-        # Locking should not work due to already being locked
+        # Locking should succeed due to already being locked
         with pytest.warns(UserWarning):
             result = self.test_world.lock_location(location)
-        assert result.status == ExecutionStatus.PRECONDITION_FAILURE
+        assert result.is_success()
         assert result.message == "Location: test_table is already locked."
         assert not location.is_open
         assert location.is_locked
@@ -119,10 +119,10 @@ class TestLocations:
         assert not location.is_open
         assert not location.is_locked
 
-        # Unlocking should not work due to already being unlocked
+        # Unlocking should succeed due to already being unlocked
         with pytest.warns(UserWarning):
             result = self.test_world.unlock_location(location)
-        assert result.status == ExecutionStatus.PRECONDITION_FAILURE
+        assert result.is_success()
         assert result.message == "Location: test_table is already unlocked."
         assert not location.is_open
         assert not location.is_locked


### PR DESCRIPTION
If a robot tries to open a location and it's already open, we were previously counting this as a failure. Instead, we could consider this a trivial action and still count it as a success.

Same for close, lock, and unlock operations.