### PR TITLE
Use `get_location_from_pose` function consistently and optimize it to check the previous location

### DIFF
--- a/pyrobosim/pyrobosim/core/dynamics.py
+++ b/pyrobosim/pyrobosim/core/dynamics.py
@@ -98,7 +98,10 @@ class RobotDynamics2D:
 
         # If we made it, we succeeded
         self.collision = False
-        self.pose = target_pose
+        if self.robot:
+            self.robot.set_pose(target_pose)
+        else:
+            self.pose = target_pose
 
     def enforce_dynamics_limits(self, cmd_vel, dt):
         """
@@ -133,5 +136,8 @@ class RobotDynamics2D:
         :type velocity: :class:`numpy.array`, optional
         """
         if pose is not None:
-            self.pose = pose
+            if self.robot:
+                self.robot.set_pose(pose)
+            else:
+                self.pose = pose
         self.velocity = velocity

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -138,6 +138,10 @@ class Robot:
         :type pose: :class:`pyrobosim.utils.pose.Pose`
         """
         self.dynamics.pose = pose
+        if self.world:
+            self.location = self.world.get_location_from_pose(
+                pose, prev_location=self.location
+            )
 
     def set_path_planner(self, path_planner):
         """
@@ -344,7 +348,6 @@ class Robot:
                 * self.path_executor.current_distance_traveled,
             )
         if self.world:
-            self.location = self.world.get_location_from_pose(self.get_pose())
             if (
                 isinstance(self.location, ObjectSpawn)
                 and self.location.parent.is_charger

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -1564,8 +1564,9 @@ class World:
         elif isinstance(entity, Hallway):
             graph_nodes = [entity.graph_nodes[0], entity.graph_nodes[-1]]
 
-            # Special rule: If all the hallways connected to the room are closed, and the robot is not in the room, remove the graph node from consideration.
-            if robot is not None:
+            # Special rule: If all the hallways connected to the room are closed, and the robot is not in the room or at the hallway,
+            # remove the graph node from consideration.
+            if (robot is not None) and (robot.location != entity):
                 robot_in_start_room = entity.room_start.is_collision_free(
                     robot.get_pose()
                 )

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -1243,7 +1243,9 @@ class World:
             if isinstance(prev_location, Room):
                 loc = self.get_location_in_room(pose, prev_location)
                 if loc is not None:
-                    attached_hallways = self.get_hallways_attached_to_room(prev_location)
+                    attached_hallways = self.get_hallways_attached_to_room(
+                        prev_location
+                    )
                     for hallway in attached_hallways:
                         hall_loc = self.get_location_in_hallway(pose, hallway)
                         if hall_loc:

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -1243,11 +1243,12 @@ class World:
             if isinstance(prev_location, Room):
                 loc = self.get_location_in_room(pose, prev_location)
                 if loc is not None:
-                    for hallway in self.get_hallways_attached_to_room(prev_location):
+                    attached_hallways = self.get_hallways_attached_to_room(prev_location)
+                    for hallway in attached_hallways:
                         hall_loc = self.get_location_in_hallway(pose, hallway)
                         if hall_loc:
                             return hall_loc
-                        prev_hallways.append(hall_loc)
+                        prev_hallways = attached_hallways
                     return loc
                 prev_room = loc
             elif isinstance(prev_location, Hallway):

--- a/pyrobosim/pyrobosim/gui/world_canvas.py
+++ b/pyrobosim/pyrobosim/gui/world_canvas.py
@@ -449,11 +449,7 @@ class WorldCanvas(FigureCanvasQTAgg):
         """
         if robot is not None:
             title_bits = []
-            if navigating:
-                robot_loc = self.world.get_location_from_pose(robot.get_pose())
-                if robot_loc is not None:
-                    title_bits.append(f"Location: {robot_loc.name}")
-            elif robot.location is not None:
+            if robot.location is not None:
                 if isinstance(robot.location, str):
                     robot_loc = robot.location
                 else:

--- a/pyrobosim_ros/pyrobosim_ros/ros_interface.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_interface.py
@@ -654,10 +654,11 @@ class WorldROSWrapper(Node):
         if robot.manipulated_object is not None:
             state_msg.holding_object = True
             state_msg.manipulated_object = robot.manipulated_object.name
-        if isinstance(robot.location, str):
-            state_msg.last_visited_location = robot.location
-        else:
-            state_msg.last_visited_location = robot.location.name
+        if robot.location is not None:
+            if isinstance(robot.location, str):
+                state_msg.last_visited_location = robot.location
+            else:
+                state_msg.last_visited_location = robot.location.name
         return state_msg
 
     def publish_robot_state(self, pub, robot):


### PR DESCRIPTION
This PR runs the `World.get_location_from_pose()` function consistently when a robot's pose is changed, but also optimizes it to favor the robot's previous location.

Empirically, I could notice a ~5-10x speedup assuming the robot isn't teleporting all the time.