### PR TITLE
Allow looking up hallways by reversed name

### DIFF
--- a/pyrobosim/pyrobosim/core/hallway.py
+++ b/pyrobosim/pyrobosim/core/hallway.py
@@ -72,6 +72,7 @@ class Hallway:
         self.room_start = room_start
         self.room_end = room_end
         self.name = f"hall_{room_start.name}_{room_end.name}"
+        self.reversed_name = f"hall_{room_end.name}_{room_start.name}"
         self.width = width
         self.wall_width = wall_width
         self.offset = offset

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -248,6 +248,7 @@ class World:
         # Do all the necessary bookkeeping
         self.hallways.append(hallway)
         self.name_to_entity[hallway.name] = hallway
+        self.name_to_entity[hallway.reversed_name] = hallway
         hallway.room_start.hallways.append(hallway)
         hallway.room_start.update_visualization_polygon()
         hallway.room_end.hallways.append(hallway)
@@ -277,6 +278,7 @@ class World:
         # Remove the hallways from the world and relevant rooms.
         self.hallways.remove(hallway)
         self.name_to_entity.pop(hallway.name)
+        self.name_to_entity.pop(hallway.reversed_name)
         for room in [hallway.room_start, hallway.room_end]:
             room.hallways.remove(hallway)
             room.update_collision_polygons()

--- a/pyrobosim/pyrobosim/utils/knowledge.py
+++ b/pyrobosim/pyrobosim/utils/knowledge.py
@@ -107,7 +107,7 @@ def query_to_entity(world, query_list, mode, resolution_strategy="first", robot=
                     resolved_queries.add(elem)
         # Also search for hallway names
         for hall in world.hallways:
-            if elem == hall.name:
+            if (elem == hall.name) or (elem == hall.reversed_name):
                 named_location = hall
                 resolved_queries.add(elem)
         # Then, directly search for object names and get the location

--- a/pyrobosim/test/core/test_hallway.py
+++ b/pyrobosim/test/core/test_hallway.py
@@ -32,6 +32,8 @@ class TestHallway:
         assert self.test_world.num_hallways == 1
         assert self.test_world.hallways[0].room_start == self.room_start
         assert self.test_world.hallways[0].room_end == self.room_end
+        assert self.test_world.hallways[0].name == "hall_room_start_room_end"
+        assert self.test_world.hallways[0].reversed_name == "hall_room_end_room_start"
         assert self.test_world.hallways[0].width == 0.1
 
     def test_add_hallway_to_world_from_args(self):
@@ -47,6 +49,9 @@ class TestHallway:
         assert self.test_world.num_hallways == 1
         assert self.test_world.hallways[0].room_start == self.room_start
         assert self.test_world.hallways[0].room_end == self.room_end
+        assert self.test_world.hallways[0].width == 0.1
+        assert self.test_world.hallways[0].name == "hall_room_start_room_end"
+        assert self.test_world.hallways[0].reversed_name == "hall_room_end_room_start"
         assert self.test_world.hallways[0].width == 0.1
 
     def test_add_hallway_fail_validation(self):

--- a/pyrobosim/test/core/test_hallway.py
+++ b/pyrobosim/test/core/test_hallway.py
@@ -49,7 +49,6 @@ class TestHallway:
         assert self.test_world.num_hallways == 1
         assert self.test_world.hallways[0].room_start == self.room_start
         assert self.test_world.hallways[0].room_end == self.room_end
-        assert self.test_world.hallways[0].width == 0.1
         assert self.test_world.hallways[0].name == "hall_room_start_room_end"
         assert self.test_world.hallways[0].reversed_name == "hall_room_end_room_start"
         assert self.test_world.hallways[0].width == 0.1

--- a/pyrobosim/test/core/test_world.py
+++ b/pyrobosim/test/core/test_world.py
@@ -75,11 +75,11 @@ class TestWorldModeling:
         )
         assert len(TestWorldModeling.world.hallways) == 1
         assert (
-            TestWorldModeling.world.get_location_by_name("hall_kitchen_bedroom")
+            TestWorldModeling.world.get_hallway_by_name("hall_kitchen_bedroom")
             == hallway
         )
         assert (
-            TestWorldModeling.world.get_location_by_name("hall_bedroom_kitchen")
+            TestWorldModeling.world.get_hallway_by_name("hall_bedroom_kitchen")
             == hallway
         )
 

--- a/pyrobosim/test/core/test_world.py
+++ b/pyrobosim/test/core/test_world.py
@@ -66,7 +66,7 @@ class TestWorldModeling:
     def test_create_hallway():
         """Tests the creation of a hallway between 2 rooms"""
 
-        TestWorldModeling.world.add_hallway(
+        hallway = TestWorldModeling.world.add_hallway(
             room_start="kitchen",
             room_end="bedroom",
             offset=0.5,
@@ -74,6 +74,14 @@ class TestWorldModeling:
             width=0.5,
         )
         assert len(TestWorldModeling.world.hallways) == 1
+        assert (
+            TestWorldModeling.world.get_location_by_name("hall_kitchen_bedroom")
+            == hallway
+        )
+        assert (
+            TestWorldModeling.world.get_location_by_name("hall_bedroom_kitchen")
+            == hallway
+        )
 
     @staticmethod
     @pytest.mark.dependency(

--- a/pyrobosim/test/utils/test_knowledge_utils.py
+++ b/pyrobosim/test/utils/test_knowledge_utils.py
@@ -105,6 +105,8 @@ def test_query_to_entity():
     assert entity.name == "my_desk_desktop"
     entity = query_to_entity(test_world, ["hall_kitchen_bathroom"], "location")
     assert entity.name == "hall_kitchen_bathroom"
+    entity = query_to_entity(test_world, ["hall_bathroom_kitchen"], "location")
+    assert entity.name == "hall_kitchen_bathroom"
 
     # Query entities based on locations and categories
     query = "kitchen table apple"


### PR DESCRIPTION
If a hallway is created from, e.g., `kitchen` to `bathroom`, it is automatically named `hall_kitchen_bathroom` and can only be looked up with that name. But it is mildly annoying to have to get the order right.

This PR adds a "reversed name", so `hall_bathroom_kitchen` also works in lookups.

@dcconner FYI