### PR TITLE
Allow multiple hallways connecting two rooms and check for duplicate names in world add methods

### DIFF
--- a/pyrobosim/pyrobosim/core/hallway.py
+++ b/pyrobosim/pyrobosim/core/hallway.py
@@ -40,6 +40,8 @@ class Hallway:
         :type room_start: :class:`pyrobosim.core.room.Room`
         :param room_end: Room object for the end of the hallway (required).
         :type room_end: :class:`pyrobosim.core.room.Room`
+        :param name: Hallway name.
+        :type name: str, optional
         :param width: Width of the hallway, in meters (required).
         :type width: float
         :param conn_method: Connection method (see description above).

--- a/pyrobosim/pyrobosim/core/hallway.py
+++ b/pyrobosim/pyrobosim/core/hallway.py
@@ -17,6 +17,7 @@ class Hallway:
         self,
         room_start=None,
         room_end=None,
+        name=None,
         width=0.0,
         conn_method="auto",
         offset=0,
@@ -71,8 +72,7 @@ class Hallway:
         # Unpack input
         self.room_start = room_start
         self.room_end = room_end
-        self.name = f"hall_{room_start.name}_{room_end.name}"
-        self.reversed_name = f"hall_{room_end.name}_{room_start.name}"
+        self.name = self.reversed_name = name
         self.width = width
         self.wall_width = wall_width
         self.offset = offset

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -254,10 +254,10 @@ class World:
 
         if hallway.name is None:
             hallway.name = (
-                f"hall_{hallway.room_start.name}_{hallway.room_end.name}{suffix}"
+                f"hall_{ordered_rooms[0]}_{ordered_rooms[1]}{suffix}"
             )
             hallway.reversed_name = (
-                f"hall_{hallway.room_end.name}_{hallway.room_start.name}{suffix}"
+                f"hall_{ordered_rooms[1]}_{ordered_rooms[0]}{suffix}"
             )
 
         # Check if the hallway collides with any other rooms or hallways

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -253,9 +253,7 @@ class World:
             suffix = f"_{self.hallway_instance_counts[ordered_rooms]}"
 
         if hallway.name is None:
-            hallway.name = (
-                f"hall_{ordered_rooms[0]}_{ordered_rooms[1]}{suffix}"
-            )
+            hallway.name = f"hall_{ordered_rooms[0]}_{ordered_rooms[1]}{suffix}"
             hallway.reversed_name = (
                 f"hall_{ordered_rooms[1]}_{ordered_rooms[0]}{suffix}"
             )

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -64,6 +64,7 @@ class World:
         self.num_hallways = 0
         self.num_locations = 0
         self.num_objects = 0
+        self.hallway_instance_counts = {}
         self.location_instance_counts = {}
         self.object_instance_counts = {}
 
@@ -137,6 +138,11 @@ class World:
             room = room_config["room"]
         else:
             room = Room(**room_config)
+
+        # Check for duplicate names.
+        if room.name in self.get_room_names():
+            warnings.warn(f"Room {room.name} already exists in the world. Cannot add.")
+            return None
 
         # If the room name is empty, automatically name it.
         if room.name is None:
@@ -231,6 +237,29 @@ class World:
 
             hallway = Hallway(**hallway_config)
 
+        # Check for duplicate names.
+        if hallway.name in self.get_hallway_names():
+            warnings.warn(
+                f"Hallway {hallway.name} already exists in the world. Cannot add."
+            )
+            return None
+
+        # If the hallway name is empty, automatically name it.
+        ordered_rooms = tuple(sorted([hallway.room_start.name, hallway.room_end.name]))
+        if ordered_rooms not in self.hallway_instance_counts:
+            self.hallway_instance_counts[ordered_rooms] = 0
+            suffix = ""
+        else:
+            suffix = f"_{self.hallway_instance_counts[ordered_rooms]}"
+
+        if hallway.name is None:
+            hallway.name = (
+                f"hall_{hallway.room_start.name}_{hallway.room_end.name}{suffix}"
+            )
+            hallway.reversed_name = (
+                f"hall_{hallway.room_end.name}_{hallway.room_start.name}{suffix}"
+            )
+
         # Check if the hallway collides with any other rooms or hallways
         is_valid_pose = True
         for other_loc in self.rooms + self.hallways:
@@ -253,6 +282,7 @@ class World:
         hallway.room_start.update_visualization_polygon()
         hallway.room_end.hallways.append(hallway)
         hallway.room_end.update_visualization_polygon()
+        self.hallway_instance_counts[ordered_rooms] += 1
         self.num_hallways += 1
         hallway.update_collision_polygons(self.inflation_radius)
         self.update_bounds(entity=hallway)
@@ -277,6 +307,9 @@ class World:
 
         # Remove the hallways from the world and relevant rooms.
         self.hallways.remove(hallway)
+        self.num_hallways -= 1
+        ordered_rooms = tuple(sorted([hallway.room_start.name, hallway.room_end.name]))
+        self.hallway_instance_counts[ordered_rooms] -= 1
         self.name_to_entity.pop(hallway.name)
         self.name_to_entity.pop(hallway.reversed_name)
         for room in [hallway.room_start, hallway.room_end]:
@@ -320,6 +353,13 @@ class World:
                 return None
         else:
             warnings.warn("Location instance or parent must be specified.")
+            return None
+
+        # Check for duplicate names.
+        if loc.name in self.get_location_names():
+            warnings.warn(
+                f"Location {loc.name} already exists in the world. Cannot add."
+            )
             return None
 
         # If the category name is empty, use "location" as the base name.
@@ -699,6 +739,11 @@ class World:
                 return None
         else:
             warnings.warn("Object instance or parent must be specified.")
+            return None
+
+        # Check for duplicate names.
+        if obj.name in self.get_object_names():
+            warnings.warn(f"Object {obj.name} already exists in the world. Cannot add.")
             return None
 
         # If the category name is empty, use "object" as the base name.

--- a/pyrobosim/test/core/test_hallway.py
+++ b/pyrobosim/test/core/test_hallway.py
@@ -64,8 +64,8 @@ class TestHallway:
         assert self.test_world.num_hallways == 1
         assert self.test_world.hallways[0].room_start == self.room_start
         assert self.test_world.hallways[0].room_end == self.room_end
-        assert self.test_world.hallways[0].name == "hall_room_start_room_end"
-        assert self.test_world.hallways[0].reversed_name == "hall_room_end_room_start"
+        assert self.test_world.hallways[0].name == "hall_room_end_room_start"
+        assert self.test_world.hallways[0].reversed_name == "hall_room_start_room_end"
         assert self.test_world.hallways[0].width == 0.1
 
         # Adding a second room should add a mangle.
@@ -80,8 +80,8 @@ class TestHallway:
         assert self.test_world.num_hallways == 2
         assert self.test_world.hallways[1].room_start == self.room_start
         assert self.test_world.hallways[1].room_end == self.room_end
-        assert self.test_world.hallways[1].name == "hall_room_start_room_end_1"
-        assert self.test_world.hallways[1].reversed_name == "hall_room_end_room_start_1"
+        assert self.test_world.hallways[1].name == "hall_room_end_room_start_1"
+        assert self.test_world.hallways[1].reversed_name == "hall_room_start_room_end_1"
         assert self.test_world.hallways[1].width == 0.08
 
     def test_add_hallway_fail_validation(self):
@@ -135,7 +135,7 @@ class TestHallway:
         with pytest.warns(UserWarning):
             result = self.test_world.open_location(hallway)
         assert result.is_success()
-        assert result.message == "Hallway: hall_room_start_room_end is already open."
+        assert result.message == "Hallway: hall_room_end_room_start is already open."
         assert hallway.is_open
         assert not hallway.is_locked
 
@@ -155,7 +155,7 @@ class TestHallway:
         with pytest.warns(UserWarning):
             result = self.test_world.open_location(hallway)
         assert result.status == ExecutionStatus.PRECONDITION_FAILURE
-        assert result.message == "Hallway: hall_room_start_room_end is locked."
+        assert result.message == "Hallway: hall_room_end_room_start is locked."
         assert not hallway.is_open
         assert hallway.is_locked
 
@@ -163,7 +163,7 @@ class TestHallway:
         with pytest.warns(UserWarning):
             result = self.test_world.close_location(hallway)
         assert result.is_success()
-        assert result.message == "Hallway: hall_room_start_room_end is already closed."
+        assert result.message == "Hallway: hall_room_end_room_start is already closed."
         assert not hallway.is_open
         assert hallway.is_locked
 
@@ -171,7 +171,7 @@ class TestHallway:
         with pytest.warns(UserWarning):
             result = self.test_world.lock_location(hallway)
         assert result.is_success()
-        assert result.message == "Hallway: hall_room_start_room_end is already locked."
+        assert result.message == "Hallway: hall_room_end_room_start is already locked."
         assert not hallway.is_open
         assert hallway.is_locked
 
@@ -186,7 +186,7 @@ class TestHallway:
             result = self.test_world.unlock_location(hallway)
         assert result.is_success()
         assert (
-            result.message == "Hallway: hall_room_start_room_end is already unlocked."
+            result.message == "Hallway: hall_room_end_room_start is already unlocked."
         )
         assert not hallway.is_open
         assert not hallway.is_locked

--- a/pyrobosim/test/core/test_hallway.py
+++ b/pyrobosim/test/core/test_hallway.py
@@ -26,15 +26,30 @@ class TestHallway:
     def test_add_hallway_to_world_from_object(self):
         """Test adding a hallway from a Hallway object."""
 
-        hallway = Hallway(room_start=self.room_start, room_end=self.room_end, width=0.1)
+        hallway = Hallway(
+            room_start=self.room_start,
+            room_end=self.room_end,
+            name="test_hallway",
+            width=0.1,
+        )
         result = self.test_world.add_hallway(hallway=hallway)
         assert isinstance(result, Hallway)
         assert self.test_world.num_hallways == 1
         assert self.test_world.hallways[0].room_start == self.room_start
         assert self.test_world.hallways[0].room_end == self.room_end
-        assert self.test_world.hallways[0].name == "hall_room_start_room_end"
-        assert self.test_world.hallways[0].reversed_name == "hall_room_end_room_start"
+        assert self.test_world.hallways[0].name == "test_hallway"
+        assert self.test_world.hallways[0].reversed_name == "test_hallway"
         assert self.test_world.hallways[0].width == 0.1
+
+        # Adding the same hallway again should fail due to duplicate names.
+        with pytest.warns(UserWarning) as warn_info:
+            result = self.test_world.add_hallway(hallway=hallway)
+        assert result is None
+        assert self.test_world.num_hallways == 1
+        assert (
+            warn_info[0].message.args[0]
+            == "Hallway test_hallway already exists in the world. Cannot add."
+        )
 
     def test_add_hallway_to_world_from_args(self):
         """Test adding a hallway from a list of named keyword arguments."""
@@ -52,6 +67,22 @@ class TestHallway:
         assert self.test_world.hallways[0].name == "hall_room_start_room_end"
         assert self.test_world.hallways[0].reversed_name == "hall_room_end_room_start"
         assert self.test_world.hallways[0].width == 0.1
+
+        # Adding a second room should add a mangle.
+        result = self.test_world.add_hallway(
+            room_start=self.room_start,
+            room_end="room_end",
+            width=0.08,
+            conn_method="points",
+            conn_points=[(0.0, 0.0), (-2.0, 0.0), (-2.0, 4.0)],
+        )
+        assert isinstance(result, Hallway)
+        assert self.test_world.num_hallways == 2
+        assert self.test_world.hallways[1].room_start == self.room_start
+        assert self.test_world.hallways[1].room_end == self.room_end
+        assert self.test_world.hallways[1].name == "hall_room_start_room_end_1"
+        assert self.test_world.hallways[1].reversed_name == "hall_room_end_room_start_1"
+        assert self.test_world.hallways[1].width == 0.08
 
     def test_add_hallway_fail_validation(self):
         """Test that all the hallway validation checks work."""

--- a/pyrobosim/test/core/test_locations.py
+++ b/pyrobosim/test/core/test_locations.py
@@ -29,19 +29,31 @@ class TestLocations:
     def test_add_location_to_world_from_object(self):
         """Test adding a location from a Location object."""
         location = Location(
-            category="table", parent=self.test_room, pose=Pose(x=0.0, y=0.0)
+            category="table",
+            name="test_table",
+            parent=self.test_room,
+            pose=Pose(x=0.0, y=0.0),
         )
         result = self.test_world.add_location(location=location)
         assert isinstance(result, Location)
         assert self.test_world.num_locations == 1
-        assert self.test_world.locations[0].name == "table0"
+        assert self.test_world.locations[0].name == "test_table"
         assert self.test_world.locations[0].is_open
         assert not self.test_world.locations[0].is_locked
+
+        # Adding the same location again should fail due to duplicate names.
+        with pytest.warns(UserWarning) as warn_info:
+            result = self.test_world.add_location(location=location)
+        assert result is None
+        assert self.test_world.num_locations == 1
+        assert (
+            warn_info[0].message.args[0]
+            == "Location test_table already exists in the world. Cannot add."
+        )
 
     def test_add_location_to_world_from_args(self):
         """Test adding a location from a list of named keyword arguments."""
         result = self.test_world.add_location(
-            name="test_table",
             category="table",
             parent="test_room",
             pose=Pose(x=0.0, y=0.0),
@@ -50,7 +62,7 @@ class TestLocations:
         )
         assert isinstance(result, Location)
         assert self.test_world.num_locations == 1
-        assert self.test_world.locations[0].name == "test_table"
+        assert self.test_world.locations[0].name == "table0"
         assert not self.test_world.locations[0].is_open
         assert self.test_world.locations[0].is_locked
 

--- a/pyrobosim/test/core/test_objects.py
+++ b/pyrobosim/test/core/test_objects.py
@@ -5,6 +5,7 @@ Tests for object creation in pyrobosim.
 """
 
 import os
+import pytest
 
 from pyrobosim.core import Object, World
 from pyrobosim.utils.general import get_data_folder
@@ -36,6 +37,7 @@ class TestObjects:
         assert table is not None
 
         obj = Object(
+            name="test_banana",
             category="banana",
             parent=table.children[0],
             pose=Pose(x=0.0, y=0.0, yaw=1.0),
@@ -43,8 +45,18 @@ class TestObjects:
         result = world.add_object(object=obj)
         assert isinstance(result, Object)
         assert world.num_objects == 1
-        assert world.objects[0].name == "banana0"
+        assert world.objects[0].name == "test_banana"
         assert world.objects[0].parent.parent == table
+
+        # Adding the same object again should fail due to duplicate names.
+        with pytest.warns(UserWarning) as warn_info:
+            result = world.add_object(object=obj)
+        assert result is None
+        assert world.num_objects == 1
+        assert (
+            warn_info[0].message.args[0]
+            == "Object test_banana already exists in the world. Cannot add."
+        )
 
     def test_add_object_to_world_from_args(self):
         """Test adding an object from a list of named keyword arguments."""
@@ -66,15 +78,8 @@ class TestObjects:
         )
         assert table is not None
 
-        result = world.add_object(name="test_banana", category="banana", parent=table)
+        result = world.add_object(category="banana", parent=table)
         assert isinstance(result, Object)
         assert world.num_objects == 1
-        assert world.objects[0].name == "test_banana"
+        assert world.objects[0].name == "banana0"
         assert world.objects[0].parent.parent == table
-
-
-if __name__ == "__main__":
-    t = TestObjects()
-    t.test_add_object_to_world_from_object()
-    t.test_add_object_to_world_from_args()
-    print("Tests passed!")

--- a/pyrobosim/test/core/test_robot.py
+++ b/pyrobosim/test/core/test_robot.py
@@ -493,7 +493,7 @@ class TestRobot:
         assert result.status == ExecutionStatus.PRECONDITION_FAILURE
         assert (
             result.message
-            == "Robot blocker is in Hallway: hall_kitchen_bedroom. Cannot close."
+            == "Robot blocker is in Hallway: hall_bedroom_kitchen. Cannot close."
         )
 
     def test_execute_action(self):

--- a/pyrobosim/test/core/test_room.py
+++ b/pyrobosim/test/core/test_room.py
@@ -14,12 +14,22 @@ class TestRoom:
         world = World()
 
         coords = [(-1.0, -1.0), (1.0, -1.0), (1.0, 1.0), (-1.0, 1.0)]
-        room = Room(footprint=coords)
+        room = Room(name="test_room", footprint=coords)
         result = world.add_room(room=room)
 
         assert isinstance(result, Room)
         assert world.num_rooms == 1
-        assert world.rooms[0].name == "room0"
+        assert world.rooms[0].name == "test_room"
+
+        # Adding the same room again should fail due to duplicate names.
+        with pytest.warns(UserWarning) as warn_info:
+            result = world.add_room(room=room)
+        assert result is None
+        assert world.num_rooms == 1
+        assert (
+            warn_info[0].message.args[0]
+            == "Room test_room already exists in the world. Cannot add."
+        )
 
     def test_add_room_to_world_from_args(self):
         """Test adding a room from a list of named keyword arguments."""
@@ -27,11 +37,11 @@ class TestRoom:
 
         coords = [(-1.0, -1.0), (1.0, -1.0), (1.0, 1.0), (-1.0, 1.0)]
         color = [1.0, 0.0, 0.1]
-        result = world.add_room(name="test_room", footprint=coords, color=color)
+        result = world.add_room(footprint=coords, color=color)
 
         assert isinstance(result, Room)
         assert world.num_rooms == 1
-        assert world.rooms[0].name == "test_room"
+        assert world.rooms[0].name == "room0"
         assert world.rooms[0].viz_color == color
 
     def test_add_room_to_world_empty_geometry(self):

--- a/pyrobosim/test/utils/test_knowledge_utils.py
+++ b/pyrobosim/test/utils/test_knowledge_utils.py
@@ -103,10 +103,10 @@ def test_query_to_entity():
     assert entity.name == "kitchen"
     entity = query_to_entity(test_world, ["my_desk_desktop"], "location")
     assert entity.name == "my_desk_desktop"
-    entity = query_to_entity(test_world, ["hall_kitchen_bathroom"], "location")
-    assert entity.name == "hall_kitchen_bathroom"
     entity = query_to_entity(test_world, ["hall_bathroom_kitchen"], "location")
-    assert entity.name == "hall_kitchen_bathroom"
+    assert entity.name == "hall_bathroom_kitchen"
+    entity = query_to_entity(test_world, ["hall_kitchen_bathroom"], "location")
+    assert entity.name == "hall_bathroom_kitchen"
 
     # Query entities based on locations and categories
     query = "kitchen table apple"


### PR DESCRIPTION
This PR enforces consistency in hallway naming by allowing users to specify an explicit name for their hallway. Otherwise, the `World.add_hallway()` method will choose a name such as `hall_kitchen_bathroom`.

Moreover, this allows multiple hallways connecting two rooms to be specified, as the naming convention will follow:
* `hall_bathroom_kitchen` (always alphabetized, starts with no mangle for backward compatibility)
* `hall_bathroom_kitchen_1` (starts mangle at 1)
* `hall_bathroom_kitchen_2`
* ...

It also fixes a few extra things along the way:
* The `num_hallways` counter was not being properly decremented when a hallway was removed
* Added duplicate name checking logic to `add_room`, `add_hallway`, `add_location`, and `add_object` methods, including unit tests.

Closes https://github.com/sea-bass/pyrobosim/issues/267

![image](https://github.com/user-attachments/assets/82837e10-cf7e-430f-a56e-e978b7488644)
