### PR TITLE
Import matplotlib 3D tools in the bodies of grasp plotting functions

### DIFF
--- a/pyrobosim/pyrobosim/manipulation/grasping.py
+++ b/pyrobosim/pyrobosim/manipulation/grasping.py
@@ -6,8 +6,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from enum import Enum
-from mpl_toolkits.mplot3d import Axes3D
-from mpl_toolkits.mplot3d.art3d import Poly3DCollection
 from transforms3d.quaternions import rotate_vector, qinverse
 
 
@@ -107,6 +105,8 @@ class Grasp:
 
     def plot(self, ax, color, alpha=0.8):
         """Displays the grasp on an existing set of axes."""
+        from mpl_toolkits.mplot3d.art3d import Poly3DCollection
+
         d = self.properties.depth
         h = self.properties.height / 2
         w = self.properties.max_width / 2
@@ -563,6 +563,9 @@ class GraspGenerator:
         :param object_footprint: Optional N-by-2 array of the object footprint points to overlay
         :type object_footprint: :class:`numpy.ndarray`, optional
         """
+        from mpl_toolkits.mplot3d import Axes3D
+        from mpl_toolkits.mplot3d.art3d import Poly3DCollection
+
         fig = plt.figure()
         ax = Axes3D(fig)
         fig.add_axes(ax)


### PR DESCRIPTION
Found an issue in which the ROS versions of matplotlib (installed via `rosdep`/`apt`) can conflict with `pip` installed versions -- specifically for the `mpl_toolkits.mplot3d.axes3d` module.

```
/usr/local/lib/python3.12/dist-packages/matplotlib/projections/__init__.py:63: 
UserWarning: Unable to import Axes3D. 
This may be due to multiple versions of Matplotlib being installed (e.g. as a system package and as a pip package).
As a result, the 3D projection is not available.

...

  File "/delib_ws/build/pyrobosim/pyrobosim/manipulation/grasping.py", line 9, in <module>
    from mpl_toolkits.mplot3d import Axes3D
  File "/usr/lib/python3/dist-packages/mpl_toolkits/mplot3d/__init__.py", line 1, in <module>
    from .axes3d import Axes3D
  File "/usr/lib/python3/dist-packages/mpl_toolkits/mplot3d/axes3d.py", line 35, in <module>
    from matplotlib.tri.triangulation import Triangulation
ModuleNotFoundError: No module named 'matplotlib.tri.triangulation'
```

So to be a bit safer, I'm moving these imports inside the 2 functions that actually use them.