### PR TITLE
Fix typo in actions documentation

### DIFF
--- a/docs/source/usage/robot_actions.rst
+++ b/docs/source/usage/robot_actions.rst
@@ -54,7 +54,7 @@ You can also command a robot with a *plan*, which is a sequences of actions:
         ),
         TaskAction("detect", object="apple"),
         TaskAction("pick", object="apple"),
-        TaskAction("place", "object", "apple"),
+        TaskAction("place", object="apple"),
         TaskAction(
             "navigate",
             source_location="my_desk",

--- a/pyrobosim/test/core/test_robot.py
+++ b/pyrobosim/test/core/test_robot.py
@@ -37,7 +37,7 @@ class TestRobot:
             ),
             TaskAction("detect", object="apple"),
             TaskAction("pick", object="apple"),
-            TaskAction("place", "object", "apple"),
+            TaskAction("place", object="apple"),
             TaskAction(
                 "navigate",
                 source_location="my_desk",


### PR DESCRIPTION
The actions docs include a `TaskAction`

```python
TaskAction("place", "object", "apple")
```

I think this is a typo and should be

```python
TaskAction("place", object="apple")
```

(except the robot is named "object" I guess 🙃 )