### PR TITLE
Sample object poses in `World.update_object`

### DIFF
--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -689,12 +689,12 @@ class World:
         location.is_locked = False
         return ExecutionResult(status=ExecutionStatus.SUCCESS)
 
-    def sample_object_spawn_pose(self, object, obj_spawn, max_tries):
+    def sample_object_spawn_pose(self, obj, obj_spawn, max_tries):
         """
         Samples an object pose in a specific object spawn.
 
-        :param object: Object instance.
-        :type object: :class:`pyrobosim.core.objects.Object`
+        :param obj: Object instance.
+        :type obj: :class:`pyrobosim.core.objects.Object`
         :param obj_spawn: Object spawn instance.
         :type obj_spawn: :class:`pyrobosim.core.locations.ObjectSpawn`
         :param max_tries: The maximum number of tries to sample.
@@ -706,14 +706,19 @@ class World:
             x_sample, y_sample = sample_from_polygon(obj_spawn.polygon)
             yaw_sample = np.random.uniform(-np.pi, np.pi)
             pose_sample = Pose(x=x_sample, y=y_sample, z=0.0, yaw=yaw_sample)
-            poly = transform_polygon(object.raw_collision_polygon, pose_sample)
+            poly = transform_polygon(obj.raw_collision_polygon, pose_sample)
 
+            is_valid_pose = True
             if not poly.within(obj_spawn.polygon):
                 continue
             for other_obj in obj_spawn.children:
-                if poly.intersects(other_obj.collision_polygon):
+                if other_obj == obj:
                     continue
-            return pose_sample
+                if poly.intersects(other_obj.collision_polygon):
+                    is_valid_pose = False
+                    break
+            if is_valid_pose:
+                return pose_sample
         return None
 
     def add_object(self, **object_config):

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -708,13 +708,12 @@ class World:
             pose_sample = Pose(x=x_sample, y=y_sample, z=0.0, yaw=yaw_sample)
             poly = transform_polygon(object.raw_collision_polygon, pose_sample)
 
-            is_valid_pose = poly.within(obj_spawn.polygon)
+            if not poly.within(obj_spawn.polygon):
+                continue
             for other_obj in obj_spawn.children:
-                is_valid_pose = is_valid_pose and not poly.intersects(
-                    other_obj.collision_polygon
-                )
-            if is_valid_pose:
-                return pose_sample
+                if poly.intersects(other_obj.collision_polygon):
+                    continue
+            return pose_sample
         return None
 
     def add_object(self, **object_config):

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -842,15 +842,8 @@ class World:
             return False
 
         if loc is not None:
-            if pose is None:
-                pose = self.sample_object_spawn_pose(
-                    obj, obj_spawn, self.max_object_sample_tries
-                )
-            if pose is None:
-                warnings.warn("Cannot sample a valid spawn pose.")
-                return False
-
-            # If it's a string, get the location name
+            # Find an object spawn that matches the specified location.
+            # If it's a string, get the location name.
             if isinstance(loc, str):
                 loc = self.get_entity_by_name(loc)
             # If it's a location object, pick an object spawn at random.
@@ -863,6 +856,15 @@ class World:
                 warnings.warn(
                     f"Location {loc} did not resolve to a valid location for an object."
                 )
+                return False
+
+            # Next, sample a pose within the new object spawn, if one was not specified.
+            if pose is None:
+                pose = self.sample_object_spawn_pose(
+                    obj, obj_spawn, self.max_object_sample_tries
+                )
+            if pose is None:
+                warnings.warn("Cannot sample a valid spawn pose.")
                 return False
 
             obj.parent.children.remove(obj)


### PR DESCRIPTION
This PR allows for sampling object poses if its location is updated in `World.update_object()`.

Since the sampling logic was already present in `World.add_object()`, it also factors it out into a reusable function.

Closes #286 