### PR TITLE
Allow specifying poses as YAML in world files

### DIFF
--- a/docs/source/yaml/world_schema.rst
+++ b/docs/source/yaml/world_schema.rst
@@ -114,7 +114,7 @@ The world schema looks as follows, where ``<angle brackets>`` are placeholders:
        pose:  # If not specified, will sample
          position:
            x: <x>
-           y: <z>
+           y: <y>
          rotation_quat:
            w: <w>
            x: <x>

--- a/docs/source/yaml/world_schema.rst
+++ b/docs/source/yaml/world_schema.rst
@@ -23,7 +23,12 @@ The world schema looks as follows, where ``<angle brackets>`` are placeholders:
        radius: <value>  # Robot radius
        height: <value>  # Robot height
        location: <loc_name>  # Initial location
-       pose: [<x>, <y>, <z>, <yaw>]  # Initial pose, if not specified will sample
+       pose:  # Initial pose, if not specified will sample
+         position:
+           x: <x>
+           y: <y>
+         rotation_eul:
+           yaw: <yaw>
        initial_battery_level: 50.0
        # Dynamics limits
        max_linear_velocity: <value>
@@ -89,7 +94,12 @@ The world schema looks as follows, where ``<angle brackets>`` are placeholders:
      - name: <loc_name>  # If not specified, will be automatic
        category: <loc_category>  # From location YAML file
        parent: <room_name>
-       pose: [<x>, <y>, <z>, <yaw>]  # If not specified, will sample
+       pose:  # If not specified, will sample
+        position:
+          x: <x>
+          y: <y>
+        rotation_eul:
+          yaw: <yaw>
        is_open: true  # Can only pick, place, and detect if open
        is_locked: true  # Can only open and close if unlocked
        is_charger: false  # Robots can charge at this location
@@ -101,4 +111,15 @@ The world schema looks as follows, where ``<angle brackets>`` are placeholders:
      - name: <obj_name>  # If not specified, will be automatic
        category: <obj_category>  # From object YAML file
        parent: <loc_name>
-       pose: [<x>, <y>, <z>, <yaw>]  # If not specified, will sample
+       pose:  # If not specified, will sample
+         position:
+           x: <x>
+           y: <z>
+         rotation_quat:
+           w: <w>
+           x: <x>
+           y: <y>
+           z: <z>
+
+Note that you can use both Euler angles and quaternions to specify poses.
+Any unspecified values will default to ``0.0``.

--- a/pyrobosim/pyrobosim/core/yaml_utils.py
+++ b/pyrobosim/pyrobosim/core/yaml_utils.py
@@ -69,10 +69,9 @@ class WorldYamlLoader:
     def add_rooms(self):
         """Add rooms to the world."""
         for room_data in self.data.get("rooms", []):
-            # TODO: Find a way to parse poses as YAML.
             if "nav_poses" in room_data:
                 room_data["nav_poses"] = [
-                    Pose.from_list(p) for p in room_data["nav_poses"]
+                    Pose.construct(p) for p in room_data["nav_poses"]
                 ]
 
             self.world.add_room(**room_data)
@@ -85,8 +84,7 @@ class WorldYamlLoader:
     def add_locations(self):
         """Add locations for object spawning to the world."""
         for loc_data in self.data.get("locations", []):
-            # TODO: Find a way to parse poses as YAML.
-            loc_data["pose"] = Pose.from_list(loc_data["pose"])
+            loc_data["pose"] = Pose.construct(loc_data["pose"])
 
             self.world.add_location(**loc_data)
 
@@ -96,9 +94,8 @@ class WorldYamlLoader:
             return
 
         for obj_data in self.data.get("objects", []):
-            # TODO: Find a way to parse poses as YAML.
             if "pose" in obj_data:
-                obj_data["pose"] = Pose.from_list(obj_data["pose"])
+                obj_data["pose"] = Pose.construct(obj_data["pose"])
             self.world.add_object(**obj_data)
 
     def add_robots(self):
@@ -135,7 +132,7 @@ class WorldYamlLoader:
             if loc:
                 loc = self.world.get_entity_by_name(loc)
             if "pose" in robot_data:
-                pose = Pose.from_list(robot_data["pose"])
+                pose = Pose.construct(robot_data["pose"])
             else:
                 pose = None
             self.world.add_robot(robot, loc=loc, pose=pose)

--- a/pyrobosim/pyrobosim/data/pddlstream_simple_world.yaml
+++ b/pyrobosim/pyrobosim/data/pddlstream_simple_world.yaml
@@ -20,7 +20,10 @@ robots:
   - name: robot
     radius: 0.1
     location: kitchen
-    pose: [0, 0, 0]
+    pose:
+      position:
+        x: 0.0
+        y: 0.0
     path_planner:
       type: rrt
       collision_check_step_dist: 0.025
@@ -57,7 +60,9 @@ rooms:
         - [1.5, 1.5]
         - [0.5, 1.5]
     nav_poses:
-      - [0.75, 0.5, 0.0]
+      - position:
+          x: 0.75
+          y: 0.5
     wall_width: 0.2
     color: [1, 0, 0]
 
@@ -115,19 +120,32 @@ hallways:
 locations:
   - category: table
     parent: kitchen
-    pose: [0.85, -0.5, 0.0, -1.57]
+    pose:
+      position:
+        x: 0.85
+        y: -0.5
+      rotation_eul:
+        yaw: -1.57
     is_open: True
     is_locked: True
 
   - category: desk
     parent: bedroom
-    pose: [3.15, 3.65, 0.0, 0.0]
+    pose:
+      position:
+        x: 3.15
+        y: 3.65
     is_open: True
     is_locked: False
 
   - category: counter
     parent: bathroom
-    pose: [-2.45, 2.5, 0.0, 1.767]
+    pose:
+      position:
+        x: -2.45
+        y: 2.5
+      rotation_eul:
+        yaw: 1.767
     is_open: True
     is_locked: True
 
@@ -136,11 +154,19 @@ locations:
 objects:
   - category: banana
     parent: table0
-    pose: [1.0, -0.5, 0.0, 0.707]
+    pose:
+      position:
+        x: 1.0
+        y: -0.5
+      rotation_eul:
+        yaw: 0.707
 
   - category: apple
     parent: desk0
-    pose: [3.2, 3.5, 0.0, 0.0]
+    pose:
+      position:
+        x: 3.2
+        y: 3.5
 
   - category: apple
     parent: table0

--- a/pyrobosim/pyrobosim/data/test_world.yaml
+++ b/pyrobosim/pyrobosim/data/test_world.yaml
@@ -20,7 +20,10 @@ robots:
   - name: robot
     radius: 0.1
     location: kitchen
-    pose: [0, 0, 0]
+    pose:
+      position:
+        x: 0.0
+        y: 0.0
     max_linear_velocity: 1.0
     max_angular_velocity: 4.0
     max_linear_acceleration: 2.5
@@ -67,7 +70,9 @@ rooms:
         - [1.5, 1.5]
         - [0.5, 1.5]
     nav_poses:
-      - [0.75, 0.5, 0.0]
+      - position:
+          x: 0.75
+          y: 0.5
     wall_width: 0.2
     color: [1, 0, 0]
 
@@ -126,28 +131,46 @@ locations:
   - name: table0
     category: table
     parent: kitchen
-    pose: [0.85, -0.5, 0.0, -1.57]
+    pose:
+      position:
+        x: 0.85
+        y: -0.5
+      rotation_eul:
+        yaw: -1.57
     is_open: True
     is_locked: True
 
   - name: my_desk
     category: desk
     parent: bedroom
-    pose: [3.15, 3.65, 0.0, 0.0]
+    pose:
+      position:
+        x: 3.15
+        y: 3.65
     is_open: True
     is_locked: False
 
   - name: counter0
     category: counter
     parent: bathroom
-    pose: [-2.45, 2.5, 0.0, 1.767]
+    pose:
+      position:
+        x: -2.45
+        y: 2.5
+      rotation_eul:
+        yaw: 1.767
     is_open: True
     is_locked: True
 
   - name: trash
     category: trash_can
     parent: kitchen
-    pose: [0.9, 1.1, 0.0, 1.57]
+    pose:
+      position:
+        x: 0.9
+        y: 1.1
+      rotation_eul:
+        yaw: 1.57
     is_open: False
     is_locked: False
 
@@ -156,11 +179,19 @@ locations:
 objects:
   - category: banana
     parent: table0
-    pose: [1.0, -0.5, 0.0, 0.707]
+    pose:
+      position:
+        x: 1.0
+        y: -0.5
+      rotation_eul:
+        yaw: 0.707
 
   - category: apple
     parent: my_desk
-    pose: [3.2, 3.5, 0.0, 0.0]
+    pose:
+      position:
+        x: 3.2
+        y: 3.5
 
   - name: gala
     category: apple

--- a/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
+++ b/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
@@ -21,7 +21,10 @@ robots:
     radius: 0.1
     color: [0.8, 0.0, 0.8]
     location: kitchen
-    pose: [0, 0, 0]
+    pose:
+      position:
+        x: 0.0
+        y: 0.0
     path_planner:
       type: rrt
       collision_check_step_dist: 0.025
@@ -99,7 +102,9 @@ rooms:
         - [1.5, 1.5]
         - [0.5, 1.5]
     nav_poses:
-      - [0.75, 0.5, 0.0]
+      - position:
+          x: 0.75
+          y: 0.5
     wall_width: 0.2
     color: [1, 0, 0]
 
@@ -158,35 +163,56 @@ locations:
   - name: table0
     category: table
     parent: kitchen
-    pose: [0.85, -0.5, 0.0, -1.57]
+    pose:
+      position:
+        x: 0.85
+        y: -0.5
+      rotation_eul:
+        yaw: -1.57
     is_open: True
     is_locked: True
 
   - name: my_desk
     category: desk
     parent: bedroom
-    pose: [3.15, 3.65, 0.0, 0.0]
+    pose:
+      position:
+        x: 3.15
+        y: 3.65
     is_open: True
     is_locked: False
 
   - name: counter0
     category: counter
     parent: bathroom
-    pose: [-2.45, 2.5, 0.0, 1.767]
+    pose:
+      position:
+        x: -2.45
+        y: 2.5
+      rotation_eul:
+        yaw: 1.767
     is_open: True
     is_locked: True
 
   - name: trash
     category: trash_can
     parent: kitchen
-    pose: [0.9, 1.1, 0.0, 1.57]
+    pose:
+      position:
+        x: 0.9
+        y: 1.1
+      rotation_eul:
+        yaw: 1.57
     is_open: False
     is_locked: False
 
   - name: charger
     category: charger
     parent: bedroom
-    pose: [3.15, 2.7, 0.0, 0.0]
+    pose:
+      position:
+        x: 3.15
+        y: 2.7
     is_open: False
     is_locked: True
     is_charger: True
@@ -196,11 +222,19 @@ locations:
 objects:
   - category: banana
     parent: table0
-    pose: [1.0, -0.5, 0.0, 0.707]
+    pose:
+      position:
+        x: 1.0
+        y: -0.5
+      rotation_eul:
+        yaw: 0.707
 
   - category: apple
     parent: my_desk
-    pose: [3.2, 3.5, 0.0, 0.0]
+    pose:
+      position:
+        x: 3.2
+        y: 3.5
 
   - name: gala
     category: apple

--- a/pyrobosim/pyrobosim/utils/pose.py
+++ b/pyrobosim/pyrobosim/utils/pose.py
@@ -168,7 +168,7 @@ class Pose:
             return Pose.from_transform(data)
         else:
             raise ValueError(
-                f"Cannot construct pose from object of type {type(data).__name__}"
+                f"Cannot construct pose from object of type {type(data).__name__}."
             )
 
     def to_dict(self):

--- a/pyrobosim/pyrobosim/utils/pose.py
+++ b/pyrobosim/pyrobosim/utils/pose.py
@@ -92,6 +92,102 @@ class Pose:
             x=tform[0, 3], y=tform[1, 3], z=tform[2, 3], q=mat2quat(tform[:3, :3])
         )
 
+    @classmethod
+    def from_dict(cls, pose_dict):
+        """
+        Creates a pose from a dictionary.
+
+        The keys of this dictionary can be as follows:
+
+        .. code-block:: yaml
+
+           position:
+             x: 1.0
+             y: 2.0
+             z: 3.0
+           rotation_eul:
+             yaw: 0.5
+             pitch: 0.6
+             roll: 0.7
+           rotation_quat:
+             w: 0.7071
+             x: 0.0
+             y: -0.7071
+             z: 0.0
+
+        Note that the ``rotation_quat`` key overrides the `rotation_eul` key.
+
+        :param pose_dict: A pose dictionary.
+        :type pose_dict: dict[str, Any]
+        :return: Pose object
+        :rype: :class:`pyrobosim.utils.pose.Pose`
+        """
+
+        pos = pose_dict.get("position", {})
+        args = {"x": pos.get("x", 0.0), "y": pos.get("y", 0.0), "z": pos.get("z", 0.0)}
+
+        quat = pose_dict.get("rotation_quat")
+        eul = pose_dict.get("rotation_eul")
+        if quat is not None:
+            args.update(
+                {
+                    "q": [
+                        quat.get("w", 0.0),
+                        quat.get("x", 0.0),
+                        quat.get("y", 0.0),
+                        quat.get("z", 0.0),
+                    ]
+                }
+            )
+        elif eul is not None:
+            args.update(
+                {
+                    "yaw": eul.get("yaw", 0.0),
+                    "pitch": eul.get("pitch", 0.0),
+                    "roll": eul.get("roll", 0.0),
+                }
+            )
+        return cls(**args)
+
+    @classmethod
+    def construct(self, data):
+        """
+        Constructs a pose object from any of the allowable input types.
+
+        :param data: The input data describing the pose.
+        :type data: dict[str, Any] or list or :class:`numpy.ndarray`
+        :return: Pose object
+        :rype: :class:`pyrobosim.utils.pose.Pose`
+        raises ValueError: if the input data type is unsupported.
+        """
+        if isinstance(data, list):
+            return Pose.from_list(data)
+        elif isinstance(data, dict):
+            return Pose.from_dict(data)
+        elif isinstance(data, np.ndarray):
+            return Pose.from_transform(data)
+        else:
+            raise ValueError(
+                f"Cannot construct pose from object of type {type(data).__name__}"
+            )
+
+    def to_dict(self):
+        """
+        Converts the pose instance to a dictionary compatible with YAML.
+
+        :return: The output dictionary.
+        :type: dict[str, Any]
+        """
+        return {
+            "position": {"x": self.x, "y": self.y, "z": self.z},
+            "rotation_quat": {
+                "w": self.q[0],
+                "x": self.q[1],
+                "y": self.q[2],
+                "z": self.q[3],
+            },
+        }
+
     def get_linear_distance(self, other, ignore_z=False):
         """
         Gets the straight-line distance between two poses.

--- a/pyrobosim/test/system/test_system_world.yaml
+++ b/pyrobosim/test/system/test_system_world.yaml
@@ -20,7 +20,10 @@ robots:
   - name: robot
     radius: 0.1
     location: kitchen
-    pose: [0, 0, 0]
+    pose:
+      position:
+        x: 0.0
+        y: 0.0
     # Rapidly-expanding Random Tree (RRT) planner
     path_planner:
       type: rrt
@@ -55,7 +58,9 @@ rooms:
         - [1.5, 1.5]
         - [0.5, 1.5]
     nav_poses:
-      - [0.75, 0.5, 0.0]
+      - position:
+          x: 0.75
+          y: 0.5
     wall_width: 0.2
     color: [1, 0, 0]
 
@@ -114,21 +119,34 @@ locations:
   - name: table0
     category: table
     parent: kitchen
-    pose: [0.85, -0.5, 0.0, -1.57]
+    pose:
+      position:
+        x: 0.85
+        y: -0.5
+      rotation_eul:
+        yaw: -1.57
     is_open: true
     is_locked: true
 
   - name: my_desk
     category: desk
     parent: bedroom
-    pose: [3.15, 3.65, 0.0, 0.0]
+    pose:
+      position:
+        x: 3.15
+        y: 3.65
     is_open: true
     is_locked: false
 
   - name: counter0
     category: counter
     parent: bathroom
-    pose: [-2.45, 2.5, 0.0, 1.767]
+    pose:
+      position:
+        x: -2.45
+        y: 2.5
+      rotation_eul:
+        yaw: 1.767
     is_open: true
     is_locked: true
 
@@ -137,7 +155,10 @@ locations:
 objects:
   - category: apple
     parent: my_desk
-    pose: [3.2, 3.5, 0.0, 0.0]
+    pose:
+      position:
+        x: 3.2
+        y: 3.5
 
   - name: gala
     category: apple

--- a/pyrobosim/test/utils/test_pose_utils.py
+++ b/pyrobosim/test/utils/test_pose_utils.py
@@ -183,6 +183,29 @@ def test_pose_to_from_dict():
     assert quat["z"] == pytest.approx(0.0)
 
 
+def test_construct_pose():
+    """Test pose construct function that accepts various types."""
+    pose_from_list = Pose.construct([1.0, 2.0, 3.0, np.pi / 2.0])
+
+    pose_from_dict = Pose.construct({"position": {"x": 1.0, "y": 2.0, "z": 3.0}, "rotation_eul": {"yaw": np.pi / 2.0}})
+
+    tform = np.array(
+        [
+            [0.0, -1.0, 0.0, 1.0],
+            [1.0, 0.0, 0.0, 2.0],
+            [0.0, 0.0, 1.0, 3.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+    pose_from_tform = Pose.construct(tform)
+
+    assert pose_from_list.is_approx(pose_from_dict)
+    assert pose_from_dict.is_approx(pose_from_tform)
+
+    with pytest.raises(ValueError) as exc_info:
+        Pose.construct(42)
+    assert exc_info.value.args[0] == "Cannot construct pose from object of type int."
+
 def test_get_linear_distance():
     """Test linear distance calculation function."""
     pose1 = Pose(x=1.0, y=2.0, z=3.0)

--- a/pyrobosim/test/utils/test_pose_utils.py
+++ b/pyrobosim/test/utils/test_pose_utils.py
@@ -187,7 +187,12 @@ def test_construct_pose():
     """Test pose construct function that accepts various types."""
     pose_from_list = Pose.construct([1.0, 2.0, 3.0, np.pi / 2.0])
 
-    pose_from_dict = Pose.construct({"position": {"x": 1.0, "y": 2.0, "z": 3.0}, "rotation_eul": {"yaw": np.pi / 2.0}})
+    pose_from_dict = Pose.construct(
+        {
+            "position": {"x": 1.0, "y": 2.0, "z": 3.0},
+            "rotation_eul": {"yaw": np.pi / 2.0},
+        }
+    )
 
     tform = np.array(
         [
@@ -205,6 +210,7 @@ def test_construct_pose():
     with pytest.raises(ValueError) as exc_info:
         Pose.construct(42)
     assert exc_info.value.args[0] == "Cannot construct pose from object of type int."
+
 
 def test_get_linear_distance():
     """Test linear distance calculation function."""

--- a/pyrobosim/test/utils/test_pose_utils.py
+++ b/pyrobosim/test/utils/test_pose_utils.py
@@ -122,6 +122,67 @@ def test_pose_from_transform():
     assert pose.q == pytest.approx([0.5, 0.5, 0.5, -0.5])
 
 
+def test_pose_to_from_dict():
+    """Test creating poses using a dictionary and saving them back out."""
+    pose_dict = {}
+    pose = Pose.from_dict(pose_dict)
+    assert pose.x == pytest.approx(0.0)
+    assert pose.y == pytest.approx(0.0)
+    assert pose.z == pytest.approx(0.0)
+    assert pose.eul == pytest.approx([0.0, 0.0, 0.0])
+    assert pose.q == pytest.approx([1.0, 0.0, 0.0, 0.0])
+
+    pose_dict = {
+        "position": {"x": 1.0, "y": 2.0, "z": 3.0},
+        "rotation_eul": {
+            "yaw": np.pi / 2.0,
+            "pitch": np.pi / 4.0,
+            "roll": -np.pi / 2.0,
+        },
+    }
+    pose = Pose.from_dict(pose_dict)
+    assert pose.x == pytest.approx(1.0)
+    assert pose.y == pytest.approx(2.0)
+    assert pose.z == pytest.approx(3.0)
+    assert pose.eul == pytest.approx([-np.pi / 2.0, np.pi / 4.0, np.pi / 2.0])
+
+    pose_dict = {
+        "position": {"x": 1.0, "y": 2.0, "z": 3.0},
+        "rotation_eul": {
+            "yaw": np.pi / 2.0,
+            "pitch": np.pi / 4.0,
+            "roll": -np.pi / 2.0,
+        },
+        "rotation_quat": {"w": 0.707107, "x": -0.707107, "y": 0.0, "z": 0.0},
+    }
+    pose = Pose.from_dict(pose_dict)
+    assert pose.x == pytest.approx(1.0)
+    assert pose.y == pytest.approx(2.0)
+    assert pose.z == pytest.approx(3.0)
+    assert pose.eul == pytest.approx([-np.pi / 2.0, 0.0, 0.0])
+    assert pose.q == pytest.approx([0.707107, -0.707107, 0.0, 0.0])
+
+    out_dict = pose.to_dict()
+    assert "position" in out_dict
+    pos = out_dict["position"]
+    assert "x" in pos
+    assert pos["x"] == pytest.approx(1.0)
+    assert "y" in pos
+    assert pos["y"] == pytest.approx(2.0)
+    assert "z" in pos
+    assert pos["z"] == pytest.approx(3.0)
+    assert "rotation_quat" in out_dict
+    quat = out_dict["rotation_quat"]
+    assert "w" in quat
+    assert quat["w"] == pytest.approx(0.707107)
+    assert "x" in quat
+    assert quat["x"] == pytest.approx(-0.707107)
+    assert "y" in quat
+    assert quat["y"] == pytest.approx(0.0)
+    assert "z" in quat
+    assert quat["z"] == pytest.approx(0.0)
+
+
 def test_get_linear_distance():
     """Test linear distance calculation function."""
     pose1 = Pose(x=1.0, y=2.0, z=3.0)


### PR DESCRIPTION
This PR allows YAML specifications of poses, such as

```yaml
pose:
  position:
    x: 1.0
    y: 2.0
  rotation_eul:
    yaw: 1.57
```

or

```yaml
pose:
  position:
    x: 1.0
    y: 2.0
  rotation_quat:
    w: 0.7071
    x: 0.0
    y: 0.0
    z: -0.7071
```

This is intended to be the default specification going forward, but keeping the old one for backward compatibility.

It also adds a `to_dict()` method for poses, which will be instrumental to serializing worlds to YAML in follow-on PRs.