### PR TITLE
Serialize worlds to YAML and allow resetting all worlds

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,12 @@ repos:
     hooks:
       - id: black
 
+  # Removes unused imports.
+  - repo: https://github.com/PyCQA/autoflake
+    rev: v2.3.1
+    hooks:
+      - id: autoflake
+
   # Finds spelling issues in code.
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0

--- a/docs/source/usage/path_planners.rst
+++ b/docs/source/usage/path_planners.rst
@@ -128,5 +128,19 @@ For visualization, you can provide ``get_graphs()`` and ``get_latest_paths()`` m
         def get_latest_path(self):
             return self.latest_path
 
+To serialize to file, which is needed to reset the world, you should also implement the ``to_dict()`` method.
+Note the ``get_planner_string()`` helper function, which extracts the name of the planner you defined in ``PATH_PLANNERS_MAP`` earlier on.
+
+.. code-block:: python
+
+        def to_dict(self, start, goal):
+            from pyrobosim.navigation import get_planner_string
+
+            return {
+                "type": get_planner_string(self),
+                "grid_resolution": self.grid_resolution,
+                "grid_inflation_radius": self.grid_inflation_radius,
+            }
+
 If you would like to implement your own path planner, it is highly recommended to look at the existing planner implementations as a reference.
 You can also always ask the maintainers through a Git issue!

--- a/docs/source/yaml/index.rst
+++ b/docs/source/yaml/index.rst
@@ -40,7 +40,7 @@ Then, the world can be loaded from file as follows.
 
    from pyrobosim.core import WorldYamlLoader
 
-   world = WorldYamlLoader().from_yaml("/path/to/world_file.yaml")
+   world = WorldYamlLoader().from_file("/path/to/world_file.yaml")
 
 Refer to the following sections for more details on the schemas.
 

--- a/pyrobosim/examples/demo.py
+++ b/pyrobosim/examples/demo.py
@@ -172,7 +172,7 @@ def create_world(multirobot=False):
 
 
 def create_world_from_yaml(world_file):
-    return WorldYamlLoader().from_yaml(os.path.join(data_folder, world_file))
+    return WorldYamlLoader().from_file(os.path.join(data_folder, world_file))
 
 
 def parse_args():

--- a/pyrobosim/examples/demo_astar.py
+++ b/pyrobosim/examples/demo_astar.py
@@ -10,7 +10,7 @@ from pyrobosim.utils.pose import Pose
 
 # Load a test world.
 world_file = os.path.join(get_data_folder(), "test_world.yaml")
-world = WorldYamlLoader().from_yaml(world_file)
+world = WorldYamlLoader().from_file(world_file)
 
 
 def demo_astar():

--- a/pyrobosim/examples/demo_pddl.py
+++ b/pyrobosim/examples/demo_pddl.py
@@ -36,7 +36,7 @@ def parse_args():
 def load_world():
     """Load a test world."""
     world_file = os.path.join(get_data_folder(), "pddlstream_simple_world.yaml")
-    return WorldYamlLoader().from_yaml(world_file)
+    return WorldYamlLoader().from_file(world_file)
 
 
 def start_planner(world, args):

--- a/pyrobosim/examples/demo_prm.py
+++ b/pyrobosim/examples/demo_prm.py
@@ -9,7 +9,7 @@ from pyrobosim.utils.pose import Pose
 
 # Load a test world.
 world_file = os.path.join(get_data_folder(), "test_world.yaml")
-world = WorldYamlLoader().from_yaml(world_file)
+world = WorldYamlLoader().from_file(world_file)
 
 
 def test_prm():

--- a/pyrobosim/examples/demo_rrt.py
+++ b/pyrobosim/examples/demo_rrt.py
@@ -9,7 +9,7 @@ from pyrobosim.utils.pose import Pose
 
 # Load a test world.
 world_file = os.path.join(get_data_folder(), "test_world.yaml")
-world = WorldYamlLoader().from_yaml(world_file)
+world = WorldYamlLoader().from_file(world_file)
 
 
 def test_rrt():

--- a/pyrobosim/examples/demo_world_save.py
+++ b/pyrobosim/examples/demo_world_save.py
@@ -53,7 +53,7 @@ def main():
     # Load a test world from YAML file.
     data_folder = get_data_folder()
     loader = WorldYamlLoader()
-    world = loader.from_yaml(os.path.join(data_folder, args.world_file))
+    world = loader.from_file(os.path.join(data_folder, args.world_file))
 
     # Export a Gazebo world.
     exp = WorldGazeboExporter(world)

--- a/pyrobosim/pyrobosim/core/hallway.py
+++ b/pyrobosim/pyrobosim/core/hallway.py
@@ -1,6 +1,6 @@
 """ Hallway representation for world modeling. """
 
-import numpy as np
+import math
 from shapely import intersects_xy
 from shapely.geometry import LineString, MultiLineString
 from shapely.plotting import patch_from_polygon
@@ -90,12 +90,12 @@ class Hallway:
         if conn_method == "auto" or conn_method == "angle":
             theta, length = get_bearing_range(room_start.centroid, room_end.centroid)
             if conn_method == "angle":
-                length = length * np.cos(theta - conn_angle)
+                length = length * math.cos(theta - conn_angle)
                 theta = conn_angle
 
             # Calculate start and end points for the hallway
-            c = np.cos(theta)
-            s = np.sin(theta)
+            c = math.cos(theta)
+            s = math.sin(theta)
             x, y = room_start.centroid
             pt_start = [x - offset * s, y + offset * c]
             pt_end = [pt_start[0] + length * c, pt_start[1] + length * s]
@@ -259,6 +259,26 @@ class Hallway:
         self.graph_nodes[-1].pose.set_euler_angles(yaw=door_pose_end_yaw)
 
         self.nav_poses = [self.graph_nodes[0].pose, self.graph_nodes[-1].pose]
+
+    def to_dict(self):
+        """
+        Serializes the hallway to a dictionary.
+
+        :return: A dictionary containing the hallway information.
+        :rtype: dict[str, Any]
+        """
+        return {
+            "name": self.name,
+            "room_start": self.room_start.name,
+            "room_end": self.room_end.name,
+            "width": self.width,
+            "wall_width": self.wall_width,
+            "conn_method": "points",
+            "conn_points": self.points,
+            "color": self.viz_color,
+            "is_open": self.is_open,
+            "is_locked": self.is_locked,
+        }
 
     def __repr__(self):
         """Returns printable string."""

--- a/pyrobosim/pyrobosim/core/locations.py
+++ b/pyrobosim/pyrobosim/core/locations.py
@@ -17,6 +17,8 @@ class Location:
     """Representation of a location in the world."""
 
     # Default class attributes
+    metadata = EntityMetadata()
+    """ Metadata for location categories. """
     height = 1.0
     """ Vertical height of location. """
     viz_color = (0, 0, 0)
@@ -201,6 +203,24 @@ class Location:
         """Creates graph nodes for searching."""
         for spawn in self.children:
             spawn.add_graph_nodes()
+
+    def to_dict(self):
+        """
+        Serializes the location to a dictionary.
+
+        :return: A dictionary containing the location information.
+        :rtype: dict[str, Any]
+        """
+        return {
+            "name": self.name,
+            "category": self.category,
+            "parent": self.parent.name,
+            "pose": self.pose.to_dict(),
+            "color": self.viz_color,
+            "is_open": self.is_open,
+            "is_locked": self.is_locked,
+            "is_charger": self.is_charger,
+        }
 
     def __repr__(self):
         """Returns printable string."""

--- a/pyrobosim/pyrobosim/core/objects.py
+++ b/pyrobosim/pyrobosim/core/objects.py
@@ -18,6 +18,8 @@ class Object:
     """Represents an object in the world."""
 
     # Default class attributes
+    metadata = EntityMetadata()
+    """ Metadata for object categories. """
     height = 0.1
     """ Vertical height of object. """
     viz_color = (0, 0, 1)
@@ -187,6 +189,21 @@ class Object:
                 self.pose.get_transform_matrix(),
             )
         )
+
+    def to_dict(self):
+        """
+        Serializes the object to a dictionary.
+
+        :return: A dictionary containing the object information.
+        :rtype: dict[str, Any]
+        """
+        return {
+            "name": self.name,
+            "category": self.category,
+            "parent": self.parent.name,
+            "pose": self.pose.to_dict(),
+            "color": self.viz_color,
+        }
 
     def __repr__(self):
         """Returns printable string."""

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -1008,6 +1008,38 @@ class Robot:
         self.current_plan = None
         return result, num_completed
 
+    def to_dict(self):
+        """
+        Serializes the robot to a dictionary.
+
+        :return: A dictionary containing the robot information.
+        :rtype: dict[str, Any]
+        """
+        pose = self.get_pose()
+
+        robot_dict = {
+            "name": self.name,
+            "radius": self.radius,
+            "pose": pose.to_dict(),
+            "max_linear_velocity": float(self.dynamics.vel_limits[0]),
+            "max_angular_velocity": float(self.dynamics.vel_limits[-1]),
+            "max_linear_acceleration": float(self.dynamics.accel_limits[0]),
+            "max_angular_acceleration": float(self.dynamics.accel_limits[-1]),
+        }
+
+        if self.world:
+            location = self.world.get_location_from_pose(pose)
+            if location is not None:
+                robot_dict["location"] = location.name
+        if self.path_planner:
+            robot_dict["path_planner"] = self.path_planner.to_dict()
+        if self.path_executor:
+            robot_dict["path_executor"] = self.path_executor.to_dict()
+        if self.grasp_generator:
+            robot_dict["grasping"] = self.grasp_generator.to_dict()
+
+        return robot_dict
+
     def __repr__(self):
         """Returns printable string."""
         return f"Robot: {self.name}"

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -1,6 +1,5 @@
 """ Defines a robot which operates in a world. """
 
-import logging
 import time
 import numpy as np
 
@@ -1020,6 +1019,8 @@ class Robot:
         robot_dict = {
             "name": self.name,
             "radius": self.radius,
+            "height": self.height,
+            "color": self.color,
             "pose": pose.to_dict(),
             "max_linear_velocity": float(self.dynamics.vel_limits[0]),
             "max_angular_velocity": float(self.dynamics.vel_limits[-1]),

--- a/pyrobosim/pyrobosim/core/room.py
+++ b/pyrobosim/pyrobosim/core/room.py
@@ -52,8 +52,12 @@ class Room:
         self.height = height
         if isinstance(footprint, list):
             self.polygon = Polygon(footprint)
+            self.footprint = {"type": "polygon", "coords": footprint}
         else:
-            self.polygon, _ = polygon_and_height_from_footprint(footprint)
+            self.polygon, height = polygon_and_height_from_footprint(footprint)
+            self.footprint = footprint
+            if height is not None:
+                self.height = height
         if self.polygon.is_empty:
             raise Exception("Room footprint cannot be empty.")
 
@@ -137,6 +141,22 @@ class Room:
     def add_graph_nodes(self):
         """Creates graph nodes for searching."""
         self.graph_nodes = [Node(p, parent=self) for p in self.nav_poses]
+
+    def to_dict(self):
+        """
+        Serializes the room to a dictionary.
+
+        :return: A dictionary containing the room information.
+        :rtype: dict[str, Any]
+        """
+        return {
+            "name": self.name,
+            "color": self.viz_color,
+            "wall_width": self.wall_width,
+            "footprint": self.footprint,
+            "height": self.height,
+            "nav_poses": [pose.to_dict() for pose in self.nav_poses],
+        }
 
     def __repr__(self):
         """Returns printable string."""

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -42,7 +42,7 @@ class World:
         """
         self.name = name
         self.wall_height = wall_height
-        self.source_file = None
+        self.source_yaml = None
         self.logger = create_logger(self.name)
 
         # Connected apps
@@ -51,10 +51,8 @@ class World:
         self.has_ros_node = False
         self.ros_node = False
 
-        # Robots
+        # World entities (robots, locations, objects, etc.)
         self.robots = []
-
-        # World entities (rooms, locations, objects, etc.)
         self.name_to_entity = {}
         self.rooms = []
         self.hallways = []
@@ -103,18 +101,23 @@ class World:
         if objects is not None:
             Object.set_metadata(objects)
 
-    def set_inflation_radius(self, inflation_radius=0.0):
+    def get_location_metadata(self):
         """
-        Sets world inflation radius.
+        Returns the location metadata associated with this world.
 
-        :param inflation_radius: Inflation radius, in meters.
-        :type inflation_radius: float, optional
+        :return: The location metadata.
+        :rtype: :class:`pyrobosim.utils.general.EntityMetadata`
         """
-        self.inflation_radius = inflation_radius
-        for loc in self.locations:
-            loc.update_collision_polygon(self.inflation_radius)
-        for entity in itertools.chain(self.rooms, self.hallways):
-            entity.update_collision_polygons(self.inflation_radius)
+        return Location.metadata
+
+    def get_object_metadata(self):
+        """
+        Returns the object metadata associated with this world.
+
+        :return: The object metadata.
+        :rtype: :class:`pyrobosim.utils.general.EntityMetadata`
+        """
+        return Object.metadata
 
     ##########################
     # World Building Methods #
@@ -1054,6 +1057,19 @@ class World:
         else:
             self.logger.warning(f"Could not find robot {robot_name} to remove.")
             return False
+
+    def set_inflation_radius(self, inflation_radius=0.0):
+        """
+        Sets world inflation radius.
+
+        :param inflation_radius: Inflation radius, in meters.
+        :type inflation_radius: float, optional
+        """
+        self.inflation_radius = inflation_radius
+        for loc in self.locations:
+            loc.update_collision_polygon(self.inflation_radius)
+        for entity in itertools.chain(self.rooms, self.hallways):
+            entity.update_collision_polygons(self.inflation_radius)
 
     def update_bounds(self, entity, remove=False):
         """

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -1,7 +1,6 @@
 """ Main file containing the core world modeling tools. """
 
 import itertools
-import logging
 import numpy as np
 
 from .hallway import Hallway
@@ -43,6 +42,7 @@ class World:
         self.name = name
         self.wall_height = wall_height
         self.source_yaml = None
+        self.source_yaml_file = None
         self.logger = create_logger(self.name)
 
         # Connected apps

--- a/pyrobosim/pyrobosim/core/yaml_utils.py
+++ b/pyrobosim/pyrobosim/core/yaml_utils.py
@@ -274,4 +274,10 @@ class WorldYamlWriter:
         """
         world_dict = self.to_dict(world)
         with open(filename, "w") as out_file:
-            yaml.dump(world_dict, out_file, default_flow_style=False)
+            yaml.dump(
+                world_dict,
+                out_file,
+                default_flow_style=False,
+                indent=2,
+                sort_keys=False,
+            )

--- a/pyrobosim/pyrobosim/core/yaml_utils.py
+++ b/pyrobosim/pyrobosim/core/yaml_utils.py
@@ -1,6 +1,6 @@
 """ Utilities to create worlds from YAML files. """
 
-import numpy as np
+import copy
 import os
 import yaml
 
@@ -52,21 +52,13 @@ class WorldYamlLoader:
             world_dict = yaml.load(file, Loader=yaml.FullLoader)
         (world_dir, _) = os.path.split(filename)
         world = self.from_yaml(world_dict, world_dir)
-        world.source_yaml = world_dict
+        world.source_yaml_file = filename
         return world
 
     def create_world(self):
         """Creates an initial world with the specified global parameters."""
-        if "params" in self.data:
-            params = self.data["params"]
-            self.world = World(
-                name=params.get("name", "world"),
-                inflation_radius=params.get("inflation_radius", 0.0),
-                object_radius=params.get("object_radius", 0.0),
-                wall_height=params.get("wall_height", 2.0),
-            )
-        else:
-            self.world = World()
+        params = self.data.get("params", {})
+        self.world = World(**params)
 
         # Set the location/object metadata
         metadata = self.data.get("metadata")
@@ -88,12 +80,12 @@ class WorldYamlLoader:
     def add_rooms(self):
         """Add rooms to the world."""
         for room_data in self.data.get("rooms", []):
-            if "nav_poses" in room_data:
-                room_data["nav_poses"] = [
-                    Pose.construct(p) for p in room_data["nav_poses"]
+            room_args = copy.deepcopy(room_data)
+            if "nav_poses" in room_args:
+                room_args["nav_poses"] = [
+                    Pose.construct(p) for p in room_args["nav_poses"]
                 ]
-
-            self.world.add_room(**room_data)
+            self.world.add_room(**room_args)
 
     def add_hallways(self):
         """Add hallways connecting rooms to the world."""
@@ -103,9 +95,9 @@ class WorldYamlLoader:
     def add_locations(self):
         """Add locations for object spawning to the world."""
         for loc_data in self.data.get("locations", []):
-            loc_data["pose"] = Pose.construct(loc_data["pose"])
-
-            self.world.add_location(**loc_data)
+            loc_args = copy.deepcopy(loc_data)
+            loc_args["pose"] = Pose.construct(loc_args["pose"])
+            self.world.add_location(**loc_args)
 
     def add_objects(self):
         """Add objects to the world."""
@@ -113,45 +105,32 @@ class WorldYamlLoader:
             return
 
         for obj_data in self.data.get("objects", []):
-            if "pose" in obj_data:
-                obj_data["pose"] = Pose.construct(obj_data["pose"])
-            self.world.add_object(**obj_data)
+            obj_args = copy.deepcopy(obj_data)
+            if "pose" in obj_args:
+                obj_args["pose"] = Pose.construct(obj_args["pose"])
+            self.world.add_object(**obj_args)
 
     def add_robots(self):
         """Add robots to the world."""
-        if "robots" not in self.data:
-            return
-
-        for id, robot_data in enumerate(self.data["robots"]):
+        for id, robot_data in enumerate(self.data.get("robots", [])):
             # Create the robot
-            robot_name = robot_data.get("name", f"robot{id}")
-            robot_color = robot_data.get("color", (0.8, 0.0, 0.8))
-            robot = Robot(
-                name=robot_name,
-                radius=robot_data.get("radius", 0.0),
-                height=robot_data.get("height", 0.0),
-                color=robot_color,
-                max_linear_velocity=robot_data.get("max_linear_velocity", np.inf),
-                max_angular_velocity=robot_data.get("max_angular_velocity", np.inf),
-                max_linear_acceleration=robot_data.get(
-                    "max_linear_acceleration", np.inf
-                ),
-                max_angular_acceleration=robot_data.get(
-                    "max_angular_acceleration", np.inf
-                ),
-                path_planner=self.get_path_planner(robot_data),
-                path_executor=self.get_path_executor(robot_data),
-                grasp_generator=self.get_grasp_generator(robot_data),
-                partial_observability=robot_data.get("partial_observability", False),
-                action_execution_options=self.get_action_execution_options(robot_data),
-                initial_battery_level=robot_data.get("initial_battery_level", 100.0),
+            robot_args = copy.deepcopy(robot_data)
+            del robot_args["location"]
+            if "name" not in robot_args:
+                robot_args["name"] = f"robot{id}"
+            robot_args["path_planner"] = self.get_path_planner(robot_args)
+            robot_args["path_executor"] = self.get_path_executor(robot_args)
+            robot_args["grasp_generator"] = self.get_grasp_generator(robot_args)
+            robot_args["action_execution_options"] = self.get_action_execution_options(
+                robot_args
             )
+            robot = Robot(**robot_args)
 
-            loc = robot_data["location"] if "location" in robot_data else None
-            if loc:
+            loc = robot_args.get("location")
+            if loc is not None:
                 loc = self.world.get_entity_by_name(loc)
-            if "pose" in robot_data:
-                pose = Pose.construct(robot_data["pose"])
+            if "pose" in robot_args:
+                pose = Pose.construct(robot_args["pose"])
             else:
                 pose = None
             self.world.add_robot(robot, loc=loc, pose=pose)
@@ -168,6 +147,7 @@ class WorldYamlLoader:
 
         planner_class = get_planner_class(planner_type)
         path_planner = planner_class(**planner_data)
+        del robot_data["path_planner"]
         return path_planner
 
     def get_path_executor(self, robot_data):
@@ -177,6 +157,7 @@ class WorldYamlLoader:
 
         path_executor_data = robot_data["path_executor"].copy()
         path_executor_type = path_executor_data["type"]
+        del robot_data["path_executor"]
         del path_executor_data["type"]
         if path_executor_type == "constant_velocity":
             return ConstantVelocityExecutor(**path_executor_data)
@@ -198,6 +179,7 @@ class WorldYamlLoader:
 
         grasp_params = robot_data["grasping"].copy()
         grasp_gen_type = grasp_params["generator"]
+        del robot_data["grasping"]
         del grasp_params["generator"]
         if grasp_gen_type == "parallel_grasp":
             grasp_properties = ParallelGraspProperties(**grasp_params)

--- a/pyrobosim/pyrobosim/core/yaml_utils.py
+++ b/pyrobosim/pyrobosim/core/yaml_utils.py
@@ -126,7 +126,7 @@ class WorldYamlLoader:
             )
             robot = Robot(**robot_args)
 
-            loc = robot_args.get("location")
+            loc = robot_data.get("location")
             if loc is not None:
                 loc = self.world.get_entity_by_name(loc)
             if "pose" in robot_args:

--- a/pyrobosim/pyrobosim/data/example_location_data.yaml
+++ b/pyrobosim/pyrobosim/data/example_location_data.yaml
@@ -68,7 +68,6 @@ counter:
         - [0, -0.5, 1.57]
   color: [0, 0.2, 0]
 
-
 trash_can:
   footprint:
     type: mesh
@@ -83,7 +82,6 @@ trash_can:
     - [0.5, 0.0, 3.14]
     - [-0.5, 0.0, 0.0]
   color: [0, 0.35, 0.2]
-
 
 charger:
   footprint:

--- a/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
+++ b/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
@@ -4,7 +4,7 @@
 
 # WORLD PARAMETERS
 params:
-  name: test_world
+  name: test_world_multirobot
   object_radius: 0.0375  # Radius around objects
   wall_height: 2.0  # Wall height for exporting to Gazebo
 

--- a/pyrobosim/pyrobosim/gui/main.py
+++ b/pyrobosim/pyrobosim/gui/main.py
@@ -252,7 +252,7 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):
             self.cancel_action_button.setEnabled(False)
             self.open_button.setEnabled(True)
             self.close_button.setEnabled(True)
-            self.reset_world_button.setEnabled(has_source_file)
+            self.reset_world_button.setEnabled(True)
             self.reset_path_planner_button.setEnabled(False)
             self.rand_pose_button.setEnabled(False)
 
@@ -402,7 +402,10 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):
             for robot in self.world.robots:
                 ros_node.remove_robot_ros_interfaces(robot)
 
-        world = WorldYamlLoader().from_yaml(self.world.source_yaml)
+        if self.world.source_yaml_file is not None:
+            world = WorldYamlLoader().from_file(self.world.source_yaml_file)
+        else:
+            world = WorldYamlLoader().from_yaml(self.world.source_yaml)
         self.set_world(world)
 
         # Start up the new robots' ROS interfaces.

--- a/pyrobosim/pyrobosim/manipulation/grasping.py
+++ b/pyrobosim/pyrobosim/manipulation/grasping.py
@@ -639,3 +639,19 @@ class GraspGenerator:
         ax.axes.set_ylim3d(min_y, max_y)
         ax.axes.set_zlim3d(min_z, max_z)
         plt.show()
+
+    def to_dict(self):
+        """
+        Serializes the grasp generator to a dictionary.
+
+        :return: A dictionary containing the grasp generator information.
+        :rtype: dict[str, Any]
+        """
+        return {
+            "generator": "parallel_grasp",
+            "max_width": self.properties.max_width,
+            "depth": self.properties.depth,
+            "height": self.properties.height,
+            "width_clearance": self.properties.width_clearance,
+            "depth_clearance": self.properties.depth_clearance,
+        }

--- a/pyrobosim/pyrobosim/navigation/__init__.py
+++ b/pyrobosim/pyrobosim/navigation/__init__.py
@@ -37,3 +37,20 @@ def get_planner_class(planner_type):
         raise ValueError(f"{planner_type} is not a supported planner type.")
 
     return PATH_PLANNERS_MAP[planner_type]
+
+
+def get_planner_string(planner):
+    """
+    Helper function that returns the planner string from a planner instance.
+
+    :param planner: The path planner instance.
+    :type planner: PathPlanner
+    :return: The string corresponding to the entry in PLANNER_TYPE_MAP
+    :rtype: str
+    """
+    for planner_str, planner_type in PATH_PLANNERS_MAP.items():
+        if isinstance(planner, planner_type):
+            return planner_str
+    raise ValueError(
+        f"Could not find registered key for planner type: {type(planner).__name__}"
+    )

--- a/pyrobosim/pyrobosim/navigation/a_star.py
+++ b/pyrobosim/pyrobosim/navigation/a_star.py
@@ -188,3 +188,21 @@ class AStarPlanner(AStar):
         :rtype: list[:class:`pyrobosim.utils.motion.Path`]
         """
         return self.latest_path
+
+    def to_dict(self):
+        """
+        Serializes the planner to a dictionary.
+
+        :return: A dictionary containing the planner information.
+        :rtype: dict[str, Any]
+        """
+        from . import get_planner_string
+
+        return {
+            "type": get_planner_string(self),
+            "grid_resolution": self.grid_resolution,
+            "grid_inflation_radius": self.grid_inflation_radius,
+            "heuristic": self.heuristic,
+            "diagonal_motion": self.diagonal_motion,
+            "compress_path": self.compress_path,
+        }

--- a/pyrobosim/pyrobosim/navigation/execution.py
+++ b/pyrobosim/pyrobosim/navigation/execution.py
@@ -191,3 +191,20 @@ class ConstantVelocityExecutor:
                     self.abort_execution = True
 
             time.sleep(max(0, self.validation_dt - (time.time() - start_time)))
+
+    def to_dict(self):
+        """
+        Serializes the path executor to a dictionary.
+
+        :return: A dictionary containing the path executor information.
+        :rtype: dict[str, Any]
+        """
+        return {
+            "type": "constant_velocity",
+            "dt": self.dt,
+            "linear_velocity": self.linear_velocity,
+            "max_angular_velocity": self.max_angular_velocity,
+            "validate_during_execution": self.validate_during_execution,
+            "validation_dt": self.validation_dt,
+            "validation_step_dist": self.validation_step_dist,
+        }

--- a/pyrobosim/pyrobosim/navigation/prm.py
+++ b/pyrobosim/pyrobosim/navigation/prm.py
@@ -146,3 +146,20 @@ class PRMPlanner:
         :rtype: list[:class:`pyrobosim.utils.motion.Path`]
         """
         return self.latest_path
+
+    def to_dict(self):
+        """
+        Serializes the planner to a dictionary.
+
+        :return: A dictionary containing the planner information.
+        :rtype: dict[str, Any]
+        """
+        from . import get_planner_string
+
+        return {
+            "type": get_planner_string(self),
+            "collision_check_step_dist": self.collision_check_step_dist,
+            "compress_path": self.compress_path,
+            "max_connection_dist": self.max_connection_dist,
+            "max_nodes": self.max_nodes,
+        }

--- a/pyrobosim/pyrobosim/navigation/rrt.py
+++ b/pyrobosim/pyrobosim/navigation/rrt.py
@@ -384,3 +384,25 @@ class RRTPlanner:
         :rtype: list[:class:`pyrobosim.utils.motion.Path`]
         """
         return self.latest_path
+
+    def to_dict(self):
+        """
+        Serializes the planner to a dictionary.
+
+        :return: A dictionary containing the planner information.
+        :rtype: dict[str, Any]
+        """
+        from . import get_planner_string
+
+        return {
+            "type": get_planner_string(self),
+            "bidirectional": self.bidirectional,
+            "rrt_connect": self.rrt_connect,
+            "rrt_star": self.rrt_star,
+            "collision_check_step_dist": self.collision_check_step_dist,
+            "max_connection_dist": self.max_connection_dist,
+            "max_nodes_sampled": self.max_nodes_sampled,
+            "max_time": self.max_time,
+            "rewire_radius": self.rewire_radius,
+            "compress_path": self.compress_path,
+        }

--- a/pyrobosim/pyrobosim/navigation/world_graph.py
+++ b/pyrobosim/pyrobosim/navigation/world_graph.py
@@ -137,3 +137,19 @@ class WorldGraphPlanner:
         :rtype: list[:class:`pyrobosim.utils.motion.Path`]
         """
         return self.latest_path
+
+    def to_dict(self):
+        """
+        Serializes the planner to a dictionary.
+
+        :return: A dictionary containing the planner information.
+        :rtype: dict[str, Any]
+        """
+        from . import get_planner_string
+
+        return {
+            "type": get_planner_string(self),
+            "collision_check_step_dist": self.collision_check_step_dist,
+            "max_connection_dist": self.max_connection_dist,
+            "compress_path": self.compress_path,
+        }

--- a/pyrobosim/pyrobosim/utils/general.py
+++ b/pyrobosim/pyrobosim/utils/general.py
@@ -33,12 +33,12 @@ def get_data_folder():
 class EntityMetadata:
     """Represents metadata about entities, such as locations or objects."""
 
-    def __init__(self, filename):
+    def __init__(self, filename=None):
         """
         Creates metadata from a YAML file.
 
         :param filename: Path to metadata YAML file.
-        :type filename: str
+        :type filename: str, optional
         """
         if filename:
             if not os.path.isfile(filename):

--- a/pyrobosim/pyrobosim/utils/general.py
+++ b/pyrobosim/pyrobosim/utils/general.py
@@ -77,8 +77,6 @@ class EntityMetadata:
 class InvalidEntityCategoryException(Exception):
     """Raised when an invalid entity metadata category is used."""
 
-    pass
-
 
 def replace_special_yaml_tokens(in_text, root_dir=None):
     """

--- a/pyrobosim/pyrobosim/utils/logging.py
+++ b/pyrobosim/pyrobosim/utils/logging.py
@@ -20,10 +20,11 @@ def create_logger(name, level=logging.INFO):
     logger.setLevel(level)
 
     # TODO: Consider configuring console vs. file logging at some point.
-    log_formatter = logging.Formatter("[%(name)s] %(levelname)s: %(message)s")
-    console_handler = logging.StreamHandler()
-    console_handler.setFormatter(log_formatter)
-    logger.addHandler(console_handler)
+    if not logger.hasHandlers():  # Prevents adding duplicate handlers
+        log_formatter = logging.Formatter("[%(name)s] %(levelname)s: %(message)s")
+        console_handler = logging.StreamHandler()
+        console_handler.setFormatter(log_formatter)
+        logger.addHandler(console_handler)
 
     # Needed to propagate to unit tests via the caplog fixture.
     logger.propagate = True

--- a/pyrobosim/pyrobosim/utils/polygon.py
+++ b/pyrobosim/pyrobosim/utils/polygon.py
@@ -165,7 +165,7 @@ def polygon_and_height_from_footprint(footprint, pose=None, parent_polygon=None)
             polygon, height = polygon_and_height_from_mesh(footprint)
         else:
             get_global_logger().warning(f"Invalid footprint type: {ftype}")
-            return None
+            return (None, None)
 
     # Offset the polygon, if specified
     if "offset" in footprint:
@@ -209,7 +209,7 @@ def polygon_and_height_from_mesh(mesh_data):
     # Get the height as the max of the 3D points.
     height = max([p[2] for p in mesh.convex_hull.vertices]) * scale
 
-    return (Polygon(hull_pts), height)
+    return (Polygon(hull_pts), float(height))
 
 
 def sample_from_polygon(polygon, max_tries=100):

--- a/pyrobosim/pyrobosim/utils/pose.py
+++ b/pyrobosim/pyrobosim/utils/pose.py
@@ -2,6 +2,7 @@
 Pose representation utilities.
 """
 
+import math
 import numpy as np
 from transforms3d.euler import euler2quat, quat2euler
 from transforms3d.quaternions import mat2quat, nearly_equivalent, qnorm, quat2mat
@@ -181,10 +182,10 @@ class Pose:
         return {
             "position": {"x": self.x, "y": self.y, "z": self.z},
             "rotation_quat": {
-                "w": self.q[0],
-                "x": self.q[1],
-                "y": self.q[2],
-                "z": self.q[3],
+                "w": float(self.q[0]),
+                "x": float(self.q[1]),
+                "y": float(self.q[2]),
+                "z": float(self.q[3]),
             },
         }
 
@@ -353,7 +354,7 @@ def get_angle(p1, p2):
     :return: Angle of target pose with respect to reference pose.
     :rtype: float
     """
-    return wrap_angle(np.arctan2(p2[1] - p1[1], p2[0] - p1[0]))
+    return wrap_angle(math.atan2(p2[1] - p1[1], p2[0] - p1[0]))
 
 
 def get_distance(p1, p2):
@@ -368,7 +369,7 @@ def get_distance(p1, p2):
     :rtype: float
     """
     sqrs = [(i - j) ** 2 for i, j in zip(p1, p2)]
-    return np.sqrt(sum(sqrs))
+    return math.sqrt(sum(sqrs))
 
 
 def get_bearing_range(p1, p2):

--- a/pyrobosim/test/core/test_gazebo.py
+++ b/pyrobosim/test/core/test_gazebo.py
@@ -13,7 +13,7 @@ from pyrobosim.utils.general import get_data_folder
 def load_world():
     """Load a test world."""
     world_file = os.path.join(get_data_folder(), "test_world.yaml")
-    return WorldYamlLoader().from_yaml(world_file)
+    return WorldYamlLoader().from_file(world_file)
 
 
 def test_export_gazebo_default_folder():

--- a/pyrobosim/test/core/test_robot.py
+++ b/pyrobosim/test/core/test_robot.py
@@ -24,7 +24,7 @@ from pyrobosim.utils.motion import Path
 class TestRobot:
     @pytest.fixture(autouse=True)
     def create_test_world(self):
-        self.test_world = WorldYamlLoader().from_yaml(
+        self.test_world = WorldYamlLoader().from_file(
             os.path.join(get_data_folder(), "test_world.yaml")
         )
 

--- a/pyrobosim/test/core/test_yaml_utils.py
+++ b/pyrobosim/test/core/test_yaml_utils.py
@@ -461,19 +461,52 @@ def test_yaml_load_and_write_dict():
     world = WorldYamlLoader().from_file(world_file)
     world_dict = WorldYamlWriter().to_dict(world)
 
-    # TODO: Check more than just existence of data in the resulting file.
     assert "params" in world_dict
+    assert world_dict["params"].get("name") == "test_world_multirobot"
+    assert world_dict["params"].get("object_radius") == 0.0375
+    assert world_dict["params"].get("wall_height") == 2.0
+    assert world_dict["params"].get("inflation_radius") == 0.1  # From the largest robot
+
     assert "metadata" in world_dict
+    assert world_dict["metadata"].get("locations") == Location.metadata.filename
+    assert world_dict["metadata"].get("objects") == Object.metadata.filename
+
     assert "robots" in world_dict
     assert len(world_dict["robots"]) == 3
+    assert world_dict["robots"][0].get("name") == "robot0"
+    assert world_dict["robots"][1].get("name") == "robot1"
+    assert world_dict["robots"][2].get("name") == "robot2"
+
     assert "rooms" in world_dict
     assert len(world_dict["rooms"]) == 3
+    assert world_dict["rooms"][0].get("name") == "kitchen"
+    assert world_dict["rooms"][1].get("name") == "bedroom"
+    assert world_dict["rooms"][2].get("name") == "bathroom"
+
     assert "hallways" in world_dict
     assert len(world_dict["hallways"]) == 3
+    assert world_dict["hallways"][0]["name"] == "hall_bathroom_kitchen"
+    assert world_dict["hallways"][1]["name"] == "hall_bathroom_bedroom"
+    assert world_dict["hallways"][2]["name"] == "hall_bedroom_kitchen"
+
     assert "locations" in world_dict
     assert len(world_dict["locations"]) == 5
+    assert world_dict["locations"][0]["name"] == "table0"
+    assert world_dict["locations"][1]["name"] == "my_desk"
+    assert world_dict["locations"][2]["name"] == "counter0"
+    assert world_dict["locations"][3]["name"] == "trash"
+    assert world_dict["locations"][4]["name"] == "charger"
+
     assert "objects" in world_dict
     assert len(world_dict["objects"]) == 8
+    assert world_dict["objects"][0]["name"] == "banana0"
+    assert world_dict["objects"][1]["name"] == "apple0"
+    assert world_dict["objects"][2]["name"] == "gala"
+    assert world_dict["objects"][3]["name"] == "fuji"
+    assert world_dict["objects"][4]["name"] == "water0"
+    assert world_dict["objects"][5]["name"] == "banana1"
+    assert world_dict["objects"][6]["name"] == "water1"
+    assert world_dict["objects"][7]["name"] == "soda"
 
 
 def test_yaml_load_and_write_file():
@@ -484,6 +517,49 @@ def test_yaml_load_and_write_file():
     temp_file = os.path.join(tempfile.mkdtemp(), "test_world.yaml")
     WorldYamlWriter().to_file(world, temp_file)
 
-    # TODO: Check more than just existence of the reloaded world.
     reloaded_world = WorldYamlLoader().from_file(temp_file)
     assert isinstance(reloaded_world, World)
+    assert reloaded_world.name == "test_world_multirobot"
+    assert reloaded_world.object_radius == 0.0375
+    assert reloaded_world.wall_height == 2.0
+    assert reloaded_world.inflation_radius == 0.1
+
+    loc_metadata = reloaded_world.get_location_metadata()
+    for category in ["table", "desk", "counter", "trash_can", "charger"]:
+        assert loc_metadata.has_category(category)
+
+    obj_metadata = reloaded_world.get_object_metadata()
+    for category in ["apple", "banana", "water", "coke"]:
+        assert obj_metadata.has_category(category)
+
+    assert len(reloaded_world.robots) == 3
+    assert reloaded_world.robots[0].name == "robot0"
+    assert reloaded_world.robots[1].name == "robot1"
+    assert reloaded_world.robots[2].name == "robot2"
+
+    assert len(reloaded_world.rooms) == 3
+    assert reloaded_world.rooms[0].name == "kitchen"
+    assert reloaded_world.rooms[1].name == "bedroom"
+    assert reloaded_world.rooms[2].name == "bathroom"
+
+    assert len(reloaded_world.hallways) == 3
+    assert reloaded_world.hallways[0].name == "hall_bathroom_kitchen"
+    assert reloaded_world.hallways[1].name == "hall_bathroom_bedroom"
+    assert reloaded_world.hallways[2].name == "hall_bedroom_kitchen"
+
+    assert len(reloaded_world.locations) == 5
+    assert reloaded_world.locations[0].name == "table0"
+    assert reloaded_world.locations[1].name == "my_desk"
+    assert reloaded_world.locations[2].name == "counter0"
+    assert reloaded_world.locations[3].name == "trash"
+    assert reloaded_world.locations[4].name == "charger"
+
+    assert len(reloaded_world.objects) == 8
+    assert reloaded_world.objects[0].name == "banana0"
+    assert reloaded_world.objects[1].name == "apple0"
+    assert reloaded_world.objects[2].name == "gala"
+    assert reloaded_world.objects[3].name == "fuji"
+    assert reloaded_world.objects[4].name == "water0"
+    assert reloaded_world.objects[5].name == "banana1"
+    assert reloaded_world.objects[6].name == "water1"
+    assert reloaded_world.objects[7].name == "soda"

--- a/pyrobosim/test/core/test_yaml_utils.py
+++ b/pyrobosim/test/core/test_yaml_utils.py
@@ -38,7 +38,7 @@ class TestWorldYamlLoading:
     def test_create_world_from_yaml():
         """Tests creating a world from YAML data."""
         loader = TestWorldYamlLoading.yaml_loader
-        loader.filename = "test_world.yaml"
+        loader.world_dir = get_data_folder()
 
         # If no parameters are provided, loader should load a default world
         loader.data = {}
@@ -74,7 +74,9 @@ class TestWorldYamlLoading:
         }
         loader.create_world()
         assert hasattr(Location, "metadata")
+        assert len(Location.metadata.data) > 0
         assert hasattr(Object, "metadata")
+        assert len(Object.metadata.data) > 0
 
     @staticmethod
     @pytest.mark.dependency(

--- a/pyrobosim/test/navigation/test_astar.py
+++ b/pyrobosim/test/navigation/test_astar.py
@@ -13,7 +13,7 @@ from pyrobosim.utils.pose import Pose
 def test_astar():
     """Test A* planner with and without path compression"""
 
-    world = WorldYamlLoader().from_yaml(
+    world = WorldYamlLoader().from_file(
         os.path.join(get_data_folder(), "test_world.yaml")
     )
 

--- a/pyrobosim/test/navigation/test_prm.py
+++ b/pyrobosim/test/navigation/test_prm.py
@@ -14,7 +14,7 @@ from pyrobosim.utils.pose import Pose
 
 def test_prm_default():
     """Tests planning with default world graph planner settings."""
-    world = WorldYamlLoader().from_yaml(
+    world = WorldYamlLoader().from_file(
         os.path.join(get_data_folder(), "test_world.yaml")
     )
     planner_config = {"world": world}
@@ -32,7 +32,7 @@ def test_prm_default():
 
 def test_prm_default():
     """Tests planning with default world graph planner settings."""
-    world = WorldYamlLoader().from_yaml(
+    world = WorldYamlLoader().from_file(
         os.path.join(get_data_folder(), "test_world.yaml")
     )
     planner_config = {"world": world}
@@ -50,7 +50,7 @@ def test_prm_default():
 
 def test_prm_no_path(caplog):
     """Test that PRM gracefully returns when there is no feasible path."""
-    world = WorldYamlLoader().from_yaml(
+    world = WorldYamlLoader().from_file(
         os.path.join(get_data_folder(), "test_world.yaml")
     )
     planner_config = {"world": world}
@@ -66,7 +66,7 @@ def test_prm_no_path(caplog):
 
 def test_prm_compress_path():
     """Tests planning with path compression option."""
-    world = WorldYamlLoader().from_yaml(
+    world = WorldYamlLoader().from_file(
         os.path.join(get_data_folder(), "test_world.yaml")
     )
     planner_config = {

--- a/pyrobosim/test/navigation/test_rrt.py
+++ b/pyrobosim/test/navigation/test_rrt.py
@@ -14,7 +14,7 @@ from pyrobosim.utils.pose import Pose
 
 def test_rrt_long_distance():
     """Tests planning with default world graph planner settings."""
-    world = WorldYamlLoader().from_yaml(
+    world = WorldYamlLoader().from_file(
         os.path.join(get_data_folder(), "test_world.yaml")
     )
     planner_config = {
@@ -35,7 +35,7 @@ def test_rrt_long_distance():
 
 def test_rrt_short_distance_connect():
     """Tests if direct connection works if goal is within max_connection_distance."""
-    world = WorldYamlLoader().from_yaml(
+    world = WorldYamlLoader().from_file(
         os.path.join(get_data_folder(), "test_world.yaml")
     )
     planner_config = {
@@ -56,7 +56,7 @@ def test_rrt_short_distance_connect():
 
 def test_rrt_no_path(caplog):
     """Test that RRT gracefully returns when there is no feasible path."""
-    world = WorldYamlLoader().from_yaml(
+    world = WorldYamlLoader().from_file(
         os.path.join(get_data_folder(), "test_world.yaml")
     )
     planner_config = {
@@ -75,7 +75,7 @@ def test_rrt_no_path(caplog):
 
 def test_rrt_bidirectional():
     """Tests bidirectional RRT planning."""
-    world = WorldYamlLoader().from_yaml(
+    world = WorldYamlLoader().from_file(
         os.path.join(get_data_folder(), "test_world.yaml")
     )
     planner_config = {
@@ -96,7 +96,7 @@ def test_rrt_bidirectional():
 
 def test_rrt_connect():
     """Tests RRTConnect planning."""
-    world = WorldYamlLoader().from_yaml(
+    world = WorldYamlLoader().from_file(
         os.path.join(get_data_folder(), "test_world.yaml")
     )
     planner_config = {
@@ -117,7 +117,7 @@ def test_rrt_connect():
 
 def test_rrt_star():
     """Tests RRT* planning."""
-    world = WorldYamlLoader().from_yaml(
+    world = WorldYamlLoader().from_file(
         os.path.join(get_data_folder(), "test_world.yaml")
     )
     planner_config = {
@@ -138,7 +138,7 @@ def test_rrt_star():
 
 def test_rrt_compress_path():
     """Tests planning with path compression option."""
-    world = WorldYamlLoader().from_yaml(
+    world = WorldYamlLoader().from_file(
         os.path.join(get_data_folder(), "test_world.yaml")
     )
     planner_config = {

--- a/pyrobosim/test/navigation/test_world_graph_planner.py
+++ b/pyrobosim/test/navigation/test_world_graph_planner.py
@@ -13,7 +13,7 @@ from pyrobosim.utils.pose import Pose
 
 def test_world_graph_default():
     """Tests planning with default world graph planner settings."""
-    world = WorldYamlLoader().from_yaml(
+    world = WorldYamlLoader().from_file(
         os.path.join(get_data_folder(), "test_world.yaml")
     )
     planner_config = {
@@ -31,7 +31,7 @@ def test_world_graph_default():
 
 def test_world_graph_short_connection_distance(caplog):
     """Tests planning with short connection distance, which should fail."""
-    world = WorldYamlLoader().from_yaml(
+    world = WorldYamlLoader().from_file(
         os.path.join(get_data_folder(), "test_world.yaml")
     )
     planner_config = {

--- a/pyrobosim/test/system/test_system.py
+++ b/pyrobosim/test/system/test_system.py
@@ -24,7 +24,7 @@ class TestSystem:
         # Load world from file.
         cur_path = os.path.dirname(os.path.realpath(__file__))
         world_file_path = os.path.join(cur_path, "test_system_world.yaml")
-        world = WorldYamlLoader().from_yaml(world_file_path)
+        world = WorldYamlLoader().from_file(world_file_path)
 
         # Create headless app.
         self.app = PyRoboSimGUI.instance()

--- a/pyrobosim/test/utils/test_knowledge_utils.py
+++ b/pyrobosim/test/utils/test_knowledge_utils.py
@@ -28,7 +28,7 @@ class MockEntity:
 def load_world():
     """Load a test world."""
     world_file = os.path.join(get_data_folder(), "test_world.yaml")
-    return WorldYamlLoader().from_yaml(world_file)
+    return WorldYamlLoader().from_file(world_file)
 
 
 def test_apply_resolution_strategy(caplog):

--- a/pyrobosim/test/utils/test_polygon_utils.py
+++ b/pyrobosim/test/utils/test_polygon_utils.py
@@ -237,7 +237,7 @@ def test_polygon_from_footprint(caplog):
     # Invalid type
     footprint = {"type": "invalid"}
     output = polygon_and_height_from_footprint(footprint, parent_polygon=parent_polygon)
-    assert output is None
+    assert output == (None, None)
     assert "Invalid footprint type: invalid" in caplog.text
 
 

--- a/pyrobosim_ros/examples/demo.py
+++ b/pyrobosim_ros/examples/demo.py
@@ -105,7 +105,7 @@ def create_world():
 
 
 def create_world_from_yaml(world_file):
-    return WorldYamlLoader().from_yaml(os.path.join(data_folder, world_file))
+    return WorldYamlLoader().from_file(os.path.join(data_folder, world_file))
 
 
 def create_ros_node():

--- a/pyrobosim_ros/examples/demo_pddl_planner.py
+++ b/pyrobosim_ros/examples/demo_pddl_planner.py
@@ -143,7 +143,7 @@ class PlannerNode(Node):
         try:
             result = self.world_state_future_response.result()
             update_world_from_state_msg(self.world, result.state)
-        except Exception as e:
+        except Exception:
             self.get_logger().info("Failed to unpack world state.")
 
         # Once the world state is set, plan using the first robot.

--- a/pyrobosim_ros/examples/demo_pddl_planner.py
+++ b/pyrobosim_ros/examples/demo_pddl_planner.py
@@ -29,7 +29,7 @@ def load_world():
     loader = WorldYamlLoader()
     world_file = "pddlstream_simple_world.yaml"
     data_folder = get_data_folder()
-    return loader.from_yaml(os.path.join(data_folder, world_file))
+    return loader.from_file(os.path.join(data_folder, world_file))
 
 
 class PlannerNode(Node):

--- a/pyrobosim_ros/examples/demo_pddl_world.py
+++ b/pyrobosim_ros/examples/demo_pddl_world.py
@@ -18,7 +18,7 @@ from pyrobosim_ros.ros_interface import WorldROSWrapper
 def load_world():
     """Load a test world."""
     world_file = os.path.join(get_data_folder(), "pddlstream_simple_world.yaml")
-    return WorldYamlLoader().from_yaml(world_file)
+    return WorldYamlLoader().from_file(world_file)
 
 
 def create_ros_node():

--- a/pyrobosim_ros/test/test_ros_interface.py
+++ b/pyrobosim_ros/test/test_ros_interface.py
@@ -54,7 +54,7 @@ class TestRosInterface:
 
         # Load world from file.
         world_file_path = os.path.join(get_data_folder(), "test_world_multirobot.yaml")
-        world = WorldYamlLoader().from_yaml(world_file_path)
+        world = WorldYamlLoader().from_file(world_file_path)
 
         # Create ROS interface.
         TestRosInterface.ros_interface = WorldROSWrapper(


### PR DESCRIPTION
This PR adds the ability to serialize any world (including programmatically created ones) to a YAML file.

In turn, this allows for all worlds to be reset from the UI -- not just those originally loaded from file.

In serializing all this data, I went through a couple files and found places where NumPy types were being used instead of regular floats.

There is one breaking change that `WorldYamlLoader.from_yaml()` now loads from a dictionary, and `WorldYamlLoader.from_file()` is a new function that loads from files as previously.

Closes #271 