### PR TITLE
3.2.0

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ copyright = "2022-2024, Sebastian Castro"
 author = "Sebastian Castro"
 
 # The full version, including alpha/beta/rc tags
-version = release = "3.1.0"
+version = release = "3.2.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyrobosim/setup.py
+++ b/pyrobosim/setup.py
@@ -36,7 +36,7 @@ readme_text = readme_path.read_text() if readme_path.exists() else ""
 
 setup(
     name=project_name,
-    version="3.1.0",
+    version="3.2.0",
     url="https://github.com/sea-bass/pyrobosim",
     author="Sebastian Castro",
     author_email="sebas.a.castro@gmail.com",

--- a/pyrobosim/test/test_pyrobosim.py
+++ b/pyrobosim/test/test_pyrobosim.py
@@ -12,4 +12,4 @@ def test_import():
 
 def test_version():
     ver = version("pyrobosim")
-    assert ver == "3.1.0", "Incorrect pyrobosim version"
+    assert ver == "3.2.0", "Incorrect pyrobosim version"

--- a/pyrobosim_msgs/package.xml
+++ b/pyrobosim_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>pyrobosim_msgs</name>
-  <version>3.1.0</version>
+  <version>3.2.0</version>
   <description>ROS interface definitions for pyrobosim.</description>
   <maintainer email="sebas.a.castro@gmail.com">Sebastian Castro</maintainer>
   <license>MIT</license>

--- a/pyrobosim_ros/package.xml
+++ b/pyrobosim_ros/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>pyrobosim_ros</name>
-  <version>3.1.0</version>
+  <version>3.2.0</version>
   <description>ROS 2 wrapper around pyrobosim.</description>
   <maintainer email="sebas.a.castro@gmail.com">Sebastian Castro</maintainer>
   <license>MIT</license>

--- a/pyrobosim_ros/setup.py
+++ b/pyrobosim_ros/setup.py
@@ -9,7 +9,7 @@ install_requires = [
 
 setup(
     name=project_name,
-    version="3.1.0",
+    version="3.2.0",
     url="https://github.com/sea-bass/pyrobosim",
     author="Sebastian Castro",
     author_email="sebas.a.castro@gmail.com",

--- a/setup/setup_pyrobosim.bash
+++ b/setup/setup_pyrobosim.bash
@@ -53,8 +53,8 @@ then
   echo "PYROBOSIM_ROS_WORKSPACE=${ROS_WORKSPACE}" >> ${ENV_FILE}
   echo "PYROBOSIM_ROS_DISTRO=${ROS_DISTRO,,}" >> ${ENV_FILE}
 
-  # Install packages needed to run colcon build from within our virtual environment.
-  pip3 install colcon-common-extensions
+  # Install packages needed to run colcon build and use rclpy from within our virtual environment.
+  pip3 install colcon-common-extensions typing_extensions
 
   # Install any ROS package dependencies that may be missing.
   pushd ${ROS_WORKSPACE} > /dev/null


### PR DESCRIPTION
Prepares for the 3.2.0 release.

I also went through clean setup on ROS 2 Rolling and realized that the virtual environment also needs the `typing_extensions` package to properly import from `rclpy.action`. So snuck that in here too.