### PR TITLE
Allow building docs in Docker containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,6 @@
 # Files and folders that don't need to be in the Docker build context.
 dependencies/
 docker/Dockerfile
-docs/
 test/results/
 
 # Metadata that doesn't need to be in the Docker build context.

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 # Files and folders that don't need to be in the Docker build context.
+docker-compose.yaml
 dependencies/
 docker/Dockerfile
 test/results/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -48,6 +48,9 @@ services:
       - ${XAUTHORITY:-$HOME/.Xauthority}:/root/.Xauthority
     command: sleep infinity
 
+  docs:
+    extends: base
+    command: src/docs/generate_docs.bash
   test:
     extends: base
     command: src/test/run_tests.bash ${ROS_DISTRO:-humble}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,10 +35,12 @@ services:
       - QT_X11_NO_MITSHM=1
       - NVIDIA_DRIVER_CAPABILITIES=all
     volumes:
-      # Mount the source code and testing utilities.
+      # Mount the source code.
       - ./pyrobosim/:/pyrobosim_ws/src/pyrobosim/:rw
       - ./pyrobosim_msgs/:/pyrobosim_ws/src/pyrobosim_msgs/:rw
       - ./pyrobosim_ros/:/pyrobosim_ws/src/pyrobosim_ros/:rw
+      # Mount docs and testing utilities.
+      - ./docs/:/pyrobosim_ws/src/docs/:rw
       - ./test/:/pyrobosim_ws/src/test/:rw
       - ./pytest.ini:/pyrobosim_ws/pytest.ini:rw
       # Allows graphical programs in the container.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,10 +32,12 @@ WORKDIR /opt/pyrobosim/
 COPY setup/configure_pddlstream.bash setup/
 RUN setup/configure_pddlstream.bash
 
-# Install pip dependencies for testing
+# Install pip dependencies for docs and testing
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
+COPY docs/python_docs_requirements.txt docs/
 COPY test/python_test_requirements.txt test/
-RUN pip3 install -r test/python_test_requirements.txt
+RUN pip3 install -r docs/python_docs_requirements.txt && \
+    pip3 install -r test/python_test_requirements.txt
 
 # Copy the rest of the source directory and install pyrobosim
 COPY . /opt/pyrobosim/
@@ -61,23 +63,23 @@ RUN apt-get install -y \
     libegl1 libgl1-mesa-dev libglu1-mesa-dev '^libxcb.*-dev' libx11-xcb-dev \
     libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libxrender-dev
 
-# Create a colcon workspace
+# Create a ROS 2 workspace
 RUN mkdir -p /pyrobosim_ws/src/pyrobosim
+WORKDIR /pyrobosim_ws/src
 
 # Install dependencies
 COPY setup/configure_pddlstream.bash /pyrobosim_ws/src/setup/
-WORKDIR /pyrobosim_ws/src/setup
-RUN ./configure_pddlstream.bash
+RUN setup/configure_pddlstream.bash
 
-COPY . /pyrobosim_ws/src/
-
-# Install pyrobosim and testing dependencies
+# Install docs and testing dependencies
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
-WORKDIR /pyrobosim_ws/src
-RUN pip3 install -e ./pyrobosim && \
+COPY docs/python_docs_requirements.txt docs/
+COPY test/python_test_requirements.txt test/
+RUN pip3 install -r docs/python_docs_requirements.txt && \
     pip3 install -r test/python_test_requirements.txt
 
-# Build the ROS workspace
+# Build the ROS workspace, which includes pyrobosim
+COPY . /pyrobosim_ws/src/
 WORKDIR /pyrobosim_ws
 RUN . /opt/ros/${ROS_DISTRO}/setup.bash && \
     colcon build

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,11 +71,13 @@ WORKDIR /pyrobosim_ws/src
 COPY setup/configure_pddlstream.bash /pyrobosim_ws/src/setup/
 RUN setup/configure_pddlstream.bash
 
-# Install docs and testing dependencies
+# Install pyrobosim, docs, and testing dependencies
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
+COPY pyrobosim/setup.py pyrobosim/
 COPY docs/python_docs_requirements.txt docs/
 COPY test/python_test_requirements.txt test/
-RUN pip3 install -r docs/python_docs_requirements.txt && \
+RUN pip3 install -e ./pyrobosim && \
+    pip3 install -r docs/python_docs_requirements.txt && \
     pip3 install -r test/python_test_requirements.txt
 
 # Build the ROS workspace, which includes pyrobosim


### PR DESCRIPTION
We're now mounting the `docs` folder and installing the pip requirements for building docs.

I also added a `docs` service so you can do `docker compose run docs` to generate the documentation.

FYI @kumar-sanjeeev 