### PR TITLE
Add support to allow pose angles in degrees

### DIFF
--- a/docs/source/yaml/location_schema.rst
+++ b/docs/source/yaml/location_schema.rst
@@ -22,8 +22,10 @@ The generic location schema, where ``<angle brackets>`` are placeholders, is:
            x: <x2>
            y: <y2>
          rotation_quat:
-           w: <w1>
-           z: <z1>
+           w: <w2>
+           x: <x2>
+           y: <y2>
+           z: <z2>
        -  ...
        - position:
            x: <xN>

--- a/docs/source/yaml/location_schema.rst
+++ b/docs/source/yaml/location_schema.rst
@@ -22,8 +22,8 @@ The generic location schema, where ``<angle brackets>`` are placeholders, is:
            x: <x2>
            y: <y2>
          rotation_quat:
-           w: 0.707
-           z: 0.707
+           w: <w1>
+           z: <z1>
        -  ...
        - position:
            x: <xN>

--- a/docs/source/yaml/location_schema.rst
+++ b/docs/source/yaml/location_schema.rst
@@ -12,9 +12,26 @@ The generic location schema, where ``<angle brackets>`` are placeholders, is:
        type: <footprint_type>
        <property>: <footprint_property>
      nav_poses:
-       - [<x1>, <y1>, <z1>, <yaw1>]
-       - ...
-       - [<xN>, <yN>, <zN>, <yawN>]
+       - position:
+           x: <x1>
+           y: <y1>
+         rotation_eul:
+           yaw: <yaw1>
+           angle_units: "degrees"
+       - position:
+           x: <x2>
+           y: <y2>
+         rotation_quat:
+           w: 0.707
+           z: 0.707
+       -  ...
+       - position:
+           x: <xN>
+           y: <yN>
+           z: <zN>
+         rotation_eul:
+           yaw: <yawN>
+           angle_units: <units>
      locations:
        - name: <location_name>
          footprint:
@@ -25,7 +42,7 @@ The generic location schema, where ``<angle brackets>`` are placeholders, is:
          footprint:
            type: <footprint_type>
            <property>: <footprint_property>
-     color: [<r>, <g>, <b>]
+     color: [<r>, <g>, <b>] or <"color_name"> or <"hexadecimalcode">
      is_open: True
      is_locked: False
      is_charger: False
@@ -87,7 +104,7 @@ A more complex object with a box footprint and two separate object spawns.
          nav_poses:
            - [0, 0.5, 0.0, -1.57]
            - [0, -0.5, 0.0, 1.57]
-     color: [0, 0.2, 0]        # Dark green
+     color: "#003300"        # Dark green
 
 A location with a footprint read from a mesh file.
 Note that the literal ``$DATA`` resolves to the ``pyrobosim/data`` folder, but you can specify an absolute path as well or create your own tokens.

--- a/docs/source/yaml/object_schema.rst
+++ b/docs/source/yaml/object_schema.rst
@@ -11,7 +11,7 @@ The generic object schema, where ``<angle brackets>`` are placeholders, is:
      footprint:
        type: <footprint_type>
        <property>: <footprint_property>
-     color: [<r>, <g>, <b>]
+     color: [<r>, <g>, <b>] or <"color_name"> or <"hexadecimalcode">
 
 Examples
 --------
@@ -35,7 +35,7 @@ A simple object with a box footprint.
        type: box            # Box footprint
        dims: [0.05, 0.2]    # 5 cm by 20 cm
        offset: [0.0, 0.1]   # 10 cm Y offset from origin
-     color: [0.7, 0.7, 0]   # Yellow
+     color: "yellow"   # Yellow
 
 An object with a generic polygon footprint.
 
@@ -64,4 +64,4 @@ Note that the literal ``$DATA`` resolves to the ``pyrobosim/data`` folder, but y
        type: mesh           # Geometry from mesh
        model_path: $DATA/sample_models/coke_can
        mesh_path: meshes/coke_can.dae
-     color: [0.8, 0, 0]     # Red color (for viewing in pyrobosim)
+     color: "#CC0000"     # Red color (for viewing in pyrobosim)

--- a/docs/source/yaml/world_schema.rst
+++ b/docs/source/yaml/world_schema.rst
@@ -29,7 +29,7 @@ The world schema looks as follows, where ``<angle brackets>`` are placeholders:
            y: <y>
          rotation_eul:
            yaw: <yaw>
-         angle_units: <units> # Units can be Radians or Degrees
+           angle_units: <units>  # Can be "radians" (default) or "degrees"
        initial_battery_level: 50.0
        # Dynamics limits
        max_linear_velocity: <value>
@@ -74,7 +74,7 @@ The world schema looks as follows, where ``<angle brackets>`` are placeholders:
          - ...
          - [<xN>, <yN>, <zN>, <yawN>]
        wall_width: <value>
-       color: [<r>, <g>, <b>]
+       color: [<r>, <g>, <b>] or <"color_name"> or <"hexadecimalcode">
      - ...
      - ...
 
@@ -101,6 +101,7 @@ The world schema looks as follows, where ``<angle brackets>`` are placeholders:
           y: <y>
         rotation_eul:
           yaw: <yaw>
+          angle_units: <units>  # Can be "radians" (default) or "degrees"
        is_open: true  # Can only pick, place, and detect if open
        is_locked: true  # Can only open and close if unlocked
        is_charger: false  # Robots can charge at this location
@@ -122,5 +123,6 @@ The world schema looks as follows, where ``<angle brackets>`` are placeholders:
            y: <y>
            z: <z>
 
-Note that you can use both Euler angles and quaternions to specify poses. If using Euler angles, you can specify angle either in radians or degrees.
+Note that you can use both Euler angles and quaternions to specify poses.
+If specifying rotation using Euler angles, you can specify angle either in radians or degrees.
 Any unspecified values will default to ``0.0``.

--- a/docs/source/yaml/world_schema.rst
+++ b/docs/source/yaml/world_schema.rst
@@ -29,6 +29,7 @@ The world schema looks as follows, where ``<angle brackets>`` are placeholders:
            y: <y>
          rotation_eul:
            yaw: <yaw>
+         angle_units: <units> # Units can be Radians or Degrees
        initial_battery_level: 50.0
        # Dynamics limits
        max_linear_velocity: <value>
@@ -121,5 +122,5 @@ The world schema looks as follows, where ``<angle brackets>`` are placeholders:
            y: <y>
            z: <z>
 
-Note that you can use both Euler angles and quaternions to specify poses.
+Note that you can use both Euler angles and quaternions to specify poses. If using Euler angles, you can specify angle either in radians or degrees.
 Any unspecified values will default to ``0.0``.

--- a/pyrobosim/examples/demo.py
+++ b/pyrobosim/examples/demo.py
@@ -75,7 +75,7 @@ def create_world(multirobot=False):
     table = world.add_location(
         category="table",
         parent="kitchen",
-        pose=Pose(x=0.85, y=-0.5, z=0.0, yaw=-90, angle_units="degrees"),
+        pose=Pose(x=0.85, y=-0.5, z=0.0, yaw=-90.0, angle_units="degrees"),
     )
     desk = world.add_location(
         category="desk", parent="bedroom", pose=Pose(x=3.15, y=3.65, z=0.0, yaw=0.0)

--- a/pyrobosim/examples/demo.py
+++ b/pyrobosim/examples/demo.py
@@ -75,7 +75,7 @@ def create_world(multirobot=False):
     table = world.add_location(
         category="table",
         parent="kitchen",
-        pose=Pose(x=0.85, y=-0.5, z=0.0, yaw=-np.pi / 2.0),
+        pose=Pose(x=0.85, y=-0.5, z=0.0, yaw=-90, angle_units="degrees"),
     )
     desk = world.add_location(
         category="desk", parent="bedroom", pose=Pose(x=3.15, y=3.65, z=0.0, yaw=0.0)

--- a/pyrobosim/pyrobosim/data/pddlstream_simple_world.yaml
+++ b/pyrobosim/pyrobosim/data/pddlstream_simple_world.yaml
@@ -125,7 +125,8 @@ locations:
         x: 0.85
         y: -0.5
       rotation_eul:
-        yaw: -1.57
+        yaw: -90.0
+      angle_units: "degrees"
     is_open: True
     is_locked: True
 
@@ -145,7 +146,8 @@ locations:
         x: -2.45
         y: 2.5
       rotation_eul:
-        yaw: 1.767
+        yaw: 101.2
+      angle_units: "degrees"
     is_open: True
     is_locked: True
 
@@ -159,7 +161,8 @@ objects:
         x: 1.0
         y: -0.5
       rotation_eul:
-        yaw: 0.707
+        yaw: 40.5
+      angle_units: "degrees"
 
   - category: apple
     parent: desk0

--- a/pyrobosim/pyrobosim/data/pddlstream_simple_world.yaml
+++ b/pyrobosim/pyrobosim/data/pddlstream_simple_world.yaml
@@ -126,7 +126,7 @@ locations:
         y: -0.5
       rotation_eul:
         yaw: -90.0
-      angle_units: "degrees"
+        angle_units: "degrees"
     is_open: True
     is_locked: True
 
@@ -147,7 +147,7 @@ locations:
         y: 2.5
       rotation_eul:
         yaw: 101.2
-      angle_units: "degrees"
+        angle_units: "degrees"
     is_open: True
     is_locked: True
 
@@ -162,7 +162,7 @@ objects:
         y: -0.5
       rotation_eul:
         yaw: 40.5
-      angle_units: "degrees"
+        angle_units: "degrees"
 
   - category: apple
     parent: desk0

--- a/pyrobosim/pyrobosim/data/test_world.yaml
+++ b/pyrobosim/pyrobosim/data/test_world.yaml
@@ -140,7 +140,7 @@ locations:
         y: -0.5
       rotation_eul:
         yaw: -90.0
-      angle_units: "degrees"
+        angle_units: "degrees"
     is_open: True
     is_locked: True
 
@@ -163,7 +163,7 @@ locations:
         y: 2.5
       rotation_eul:
         yaw: 101.2
-      angle_units: "degrees"
+        angle_units: "degrees"
     is_open: True
     is_locked: True
 
@@ -176,7 +176,7 @@ locations:
         y: 1.1
       rotation_eul:
         yaw: 90.0
-      angle_units: "degrees"
+        angle_units: "degrees"
 
     is_open: False
     is_locked: False
@@ -192,7 +192,7 @@ objects:
         y: -0.5
       rotation_eul:
         yaw: 40.5
-      angle_units: "degrees"
+        angle_units: "degrees"
 
   - category: apple
     parent: my_desk

--- a/pyrobosim/pyrobosim/data/test_world.yaml
+++ b/pyrobosim/pyrobosim/data/test_world.yaml
@@ -139,7 +139,8 @@ locations:
         x: 0.85
         y: -0.5
       rotation_eul:
-        yaw: -1.57
+        yaw: -90.0
+      angle_units: "degrees"
     is_open: True
     is_locked: True
 
@@ -161,7 +162,8 @@ locations:
         x: -2.45
         y: 2.5
       rotation_eul:
-        yaw: 1.767
+        yaw: 101.2
+      angle_units: "degrees"
     is_open: True
     is_locked: True
 
@@ -173,7 +175,9 @@ locations:
         x: 0.9
         y: 1.1
       rotation_eul:
-        yaw: 1.57
+        yaw: 90.0
+      angle_units: "degrees"
+
     is_open: False
     is_locked: False
 
@@ -187,7 +191,8 @@ objects:
         x: 1.0
         y: -0.5
       rotation_eul:
-        yaw: 0.707
+        yaw: 40.5
+      angle_units: "degrees"
 
   - category: apple
     parent: my_desk

--- a/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
+++ b/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
@@ -170,7 +170,8 @@ locations:
         x: 0.85
         y: -0.5
       rotation_eul:
-        yaw: -1.57
+        yaw: -90.0
+      angle_units: "degrees"
     is_open: True
     is_locked: True
 
@@ -192,7 +193,8 @@ locations:
         x: -2.45
         y: 2.5
       rotation_eul:
-        yaw: 1.767
+        yaw: 101.2
+      angle_units: "degrees"
     is_open: True
     is_locked: True
 
@@ -204,7 +206,8 @@ locations:
         x: 0.9
         y: 1.1
       rotation_eul:
-        yaw: 1.57
+        yaw: 90.0
+      angle_units: "degrees"
     is_open: False
     is_locked: False
 
@@ -229,7 +232,8 @@ objects:
         x: 1.0
         y: -0.5
       rotation_eul:
-        yaw: 0.707
+        yaw: 40.5
+      angle_units: "degrees"
 
   - category: apple
     parent: my_desk

--- a/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
+++ b/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
@@ -171,7 +171,7 @@ locations:
         y: -0.5
       rotation_eul:
         yaw: -90.0
-      angle_units: "degrees"
+        angle_units: "degrees"
     is_open: True
     is_locked: True
 
@@ -194,7 +194,7 @@ locations:
         y: 2.5
       rotation_eul:
         yaw: 101.2
-      angle_units: "degrees"
+        angle_units: "degrees"
     is_open: True
     is_locked: True
 
@@ -207,7 +207,7 @@ locations:
         y: 1.1
       rotation_eul:
         yaw: 90.0
-      angle_units: "degrees"
+        angle_units: "degrees"
     is_open: False
     is_locked: False
 
@@ -233,7 +233,7 @@ objects:
         y: -0.5
       rotation_eul:
         yaw: 40.5
-      angle_units: "degrees"
+        angle_units: "degrees"
 
   - category: apple
     parent: my_desk

--- a/pyrobosim/pyrobosim/utils/pose.py
+++ b/pyrobosim/pyrobosim/utils/pose.py
@@ -57,9 +57,7 @@ class Pose:
                 "Additionally, if 'q' is provided, angle units are ignored."
             )
 
-        self.angle_units = angle_units
-
-        if self.angle_units == "degrees":
+        if angle_units == "degrees":
             roll, pitch, yaw = map(math.radians, [roll, pitch, yaw])
 
         self.set_euler_angles(roll, pitch, yaw)
@@ -160,7 +158,6 @@ class Pose:
             "y": pos.get("y", 0.0),
             "z": pos.get("z", 0.0),
         }
-        args["angle_units"] = pose_dict.get("angle_units", "radians")
 
         quat = pose_dict.get("rotation_quat")
         eul = pose_dict.get("rotation_eul")
@@ -181,6 +178,7 @@ class Pose:
                     "yaw": eul.get("yaw", 0.0),
                     "pitch": eul.get("pitch", 0.0),
                     "roll": eul.get("roll", 0.0),
+                    "angle_units": pose_dict.get("angle_units", "radians"),
                 }
             )
         return cls(**args)

--- a/pyrobosim/pyrobosim/utils/pose.py
+++ b/pyrobosim/pyrobosim/utils/pose.py
@@ -73,6 +73,7 @@ class Pose:
         * 6-element lists: ``[x, y, z, roll, pitch, yaw]``
         * 7-element lists: ``[x, y, z, qw, qx, qy, qz]``
         * other lengths: invalid
+        * angle units are always "radians"
 
         :param plist: List containing the input pose (see format above).
         :type plist: list[float]

--- a/pyrobosim/pyrobosim/utils/pose.py
+++ b/pyrobosim/pyrobosim/utils/pose.py
@@ -37,11 +37,11 @@ class Pose:
         :type pitch: float
         :param yaw: Yaw angle (about Z axis), in specified angle units
         :type yaw: float
+        :param angle_units: Units for angle ('radians' or 'degrees'). Default is 'radians'
+        :type angle_units: str
         :param q: Quaternion, specified at [qw, qx, qy, qz]
             If specified, will override roll/pitch/yaw values.
         :type q: list[float]
-        :param angle_units: Units for angle ('radians' or 'degrees'). Default is 'radians'
-        :type angle_units: str
         """
         self.x = x
         self.y = y
@@ -137,12 +137,12 @@ class Pose:
              yaw: 0.5
              pitch: 0.6
              roll: 0.7
+             angle_units: "radians"
            rotation_quat:
              w: 0.7071
              x: 0.0
              y: -0.7071
              z: 0.0
-           angle_units: "radians"
 
         Note that the ``rotation_quat`` key overrides the `rotation_eul` key.
 
@@ -178,7 +178,7 @@ class Pose:
                     "yaw": eul.get("yaw", 0.0),
                     "pitch": eul.get("pitch", 0.0),
                     "roll": eul.get("roll", 0.0),
-                    "angle_units": pose_dict.get("angle_units", "radians"),
+                    "angle_units": eul.get("angle_units", "radians"),
                 }
             )
         return cls(**args)

--- a/pyrobosim/pyrobosim/utils/pose.py
+++ b/pyrobosim/pyrobosim/utils/pose.py
@@ -40,7 +40,7 @@ class Pose:
         :param q: Quaternion, specified at [qw, qx, qy, qz]
             If specified, will override roll/pitch/yaw values.
         :type q: list[float]
-        :param angle_units: Units for angle ('radians' or `degrees`). Default is 'radians'
+        :param angle_units: Units for angle (`radians` or `degrees`). Default is `radians`
         :type angle_units: str
         """
         if angle_units not in ("radians", "degrees"):
@@ -73,7 +73,7 @@ class Pose:
 
         :param plist: List containing the input pose (see format above).
         :type plist: list[float]
-        :param angle_units: Units for angle ('radians' or `degrees`). Default is 'radians'
+        :param angle_units: Units for angle (`radians` or `degrees`). Default is `radians`
         :type angle_units: str
         :return: Pose object
         :rtype: :class:`pyrobosim.utils.pose.Pose`
@@ -148,7 +148,7 @@ class Pose:
 
         :param pose_dict: A pose dictionary.
         :type pose_dict: dict[str, Any]
-        :param angle_units: Units for angle ('radians' or `degrees`). Default is 'radians'
+        :param angle_units: Units for angle (`radians` or `degrees`). Default is `radians`
         :type angle_units: str
         :return: Pose object
         :rype: :class:`pyrobosim.utils.pose.Pose`
@@ -188,7 +188,7 @@ class Pose:
 
         :param data: The input data describing the pose.
         :type data: dict[str, Any] or list or :class:`numpy.ndarray`
-        :param angle_units: Units for angle ('radians' or `degrees`). Default is 'radians'
+        :param angle_units: Units for angle (`radians` or `degrees`). Default is `radians`
         :type angle_units: str
         :return: Pose object
         :rype: :class:`pyrobosim.utils.pose.Pose`

--- a/pyrobosim/test/utils/test_pose_utils.py
+++ b/pyrobosim/test/utils/test_pose_utils.py
@@ -139,17 +139,7 @@ def test_pose_from_transform():
 
 
 @pytest.mark.parametrize(
-    "angle_units, angle_value",
-    [
-        (
-            "radians",
-            np.pi / 2,
-        ),
-        (
-            "degrees",
-            90.0,
-        ),
-    ],
+    "angle_units, angle_value", [("radians", np.pi / 2), ("degrees", 90.0)]
 )
 def test_pose_to_from_dict(angle_units, angle_value):
     """Test creating poses using a dictionary and saving them back out."""
@@ -206,17 +196,7 @@ def test_pose_to_from_dict(angle_units, angle_value):
 
 
 @pytest.mark.parametrize(
-    "angle_units, angle_value",
-    [
-        (
-            "radians",
-            np.pi / 2,
-        ),
-        (
-            "degrees",
-            90.0,
-        ),
-    ],
+    "angle_units, angle_value", [("radians", np.pi / 2), ("degrees", 90.0)]
 )
 def test_construct_pose(angle_units, angle_value):
     """Test pose construct function that accepts various types"""

--- a/pyrobosim/test/utils/test_pose_utils.py
+++ b/pyrobosim/test/utils/test_pose_utils.py
@@ -28,6 +28,7 @@ def test_pose_default_args():
     assert pose.z == pytest.approx(0.0)
     assert pose.eul == pytest.approx([0.0, 0.0, 0.0])
     assert pose.q == pytest.approx([1.0, 0.0, 0.0, 0.0])
+    assert pose.angle_units == "radians"
 
 
 def test_pose_from_position():
@@ -40,13 +41,20 @@ def test_pose_from_position():
     assert pose.q == pytest.approx([1.0, 0.0, 0.0, 0.0])
 
 
-def test_pose_from_euler_angles():
-    """Test creating a pose using Euler angles."""
-    pose = Pose(roll=np.pi / 2, pitch=0.0, yaw=-np.pi / 2)
+@pytest.mark.parametrize(
+    "angle_units, roll, pitch, yaw, expected_euler",
+    [
+        ("radians", np.pi / 2, 0.0, -np.pi / 2, [np.pi / 2, 0.0, -np.pi / 2]),
+        ("degrees", 90, 0, -90, [np.pi / 2, 0.0, -np.pi / 2]),
+    ],
+)
+def test_pose_from_euler_angles(angle_units, roll, pitch, yaw, expected_euler):
+    """Test creating a pose using Euler angles specified in different units."""
+    pose = Pose(roll=roll, pitch=pitch, yaw=yaw, angle_units=angle_units)
     assert pose.x == pytest.approx(0.0)
     assert pose.y == pytest.approx(0.0)
     assert pose.z == pytest.approx(0.0)
-    assert pose.eul == pytest.approx([np.pi / 2, 0.0, -np.pi / 2])
+    assert pose.eul == pytest.approx(expected_euler)
     assert pose.q == pytest.approx([0.5, 0.5, 0.5, -0.5])
 
 
@@ -73,21 +81,41 @@ def test_pose_from_lists():
     assert pose.y == pytest.approx(2.0)
     assert pose.z == pytest.approx(3.0)
 
-    # 4-element lists should be [x, y, z, yaw]
-    pose = Pose.from_list([1.0, 2.0, 3.0, np.pi / 2])
+    # 4-element lists should be [x, y, z, yaw], angle_units in radians
+    pose = Pose.from_list([1.0, 2.0, 3.0, np.pi / 2], "radians")
     assert pose.x == pytest.approx(1.0)
     assert pose.y == pytest.approx(2.0)
     assert pose.z == pytest.approx(3.0)
     assert pose.eul == pytest.approx([0.0, 0.0, np.pi / 2])
     assert pose.q == pytest.approx([np.sqrt(2) / 2, 0.0, 0.0, np.sqrt(2) / 2])
+    assert pose.angle_units == "radians"
 
-    # 6-element lists should be [x, y, z, roll, pitch, yaw]
-    pose = Pose.from_list([1.0, 2.0, 3.0, np.pi / 2, 0.0, -np.pi / 2])
+    # 4-element lists should be [x, y, z, yaw], angle_units in degrees
+    pose = Pose.from_list([1.0, 2.0, 3.0, 90], "degrees")
+    assert pose.x == pytest.approx(1.0)
+    assert pose.y == pytest.approx(2.0)
+    assert pose.z == pytest.approx(3.0)
+    assert pose.eul == pytest.approx([0.0, 0.0, np.pi / 2])
+    assert pose.q == pytest.approx([np.sqrt(2) / 2, 0.0, 0.0, np.sqrt(2) / 2])
+    assert pose.angle_units == "degrees"
+
+    # 6-element lists should be [x, y, z, roll, pitch, yaw], angle_units in radians
+    pose = Pose.from_list([1.0, 2.0, 3.0, np.pi / 2, 0.0, -np.pi / 2], "radians")
     assert pose.x == pytest.approx(1.0)
     assert pose.y == pytest.approx(2.0)
     assert pose.z == pytest.approx(3.0)
     assert pose.eul == pytest.approx([np.pi / 2, 0.0, -np.pi / 2])
     assert pose.q == pytest.approx([0.5, 0.5, 0.5, -0.5])
+    assert pose.angle_units == "radians"
+
+    # 6-element lists should be [x, y, z, roll, pitch, yaw], angle_units in degrees
+    pose = Pose.from_list([1.0, 2.0, 3.0, 90, 0.0, -90], "degrees")
+    assert pose.x == pytest.approx(1.0)
+    assert pose.y == pytest.approx(2.0)
+    assert pose.z == pytest.approx(3.0)
+    assert pose.eul == pytest.approx([np.pi / 2, 0.0, -np.pi / 2])
+    assert pose.q == pytest.approx([0.5, 0.5, 0.5, -0.5])
+    assert pose.angle_units == "degrees"
 
     # 7-element lists should be [x, y, z, qw, qx, qy, qz]
     pose = Pose.from_list([1.0, 2.0, 3.0, 0.5, 0.5, 0.5, -0.5])
@@ -101,6 +129,13 @@ def test_pose_from_lists():
     with pytest.raises(ValueError) as exc_info:
         Pose.from_list([1.0, 2.0, 3.0, 4.0, 5.0])
     assert exc_info.value.args[0] == "List must contain 2, 3, 4, 6, or 7 elements."
+
+    # Invalid angle_units raise an exception
+    with pytest.raises(ValueError) as exc_info:
+        Pose(angle_units="notavalidangle")
+    assert (
+        exc_info.value.args[0] == "Angles should be either in 'radians' or 'degrees'."
+    )
 
 
 def test_pose_from_transform():
@@ -122,15 +157,16 @@ def test_pose_from_transform():
     assert pose.q == pytest.approx([0.5, 0.5, 0.5, -0.5])
 
 
-def test_pose_to_from_dict():
+def test_pose_to_from_dict_angle_in_radians():
     """Test creating poses using a dictionary and saving them back out."""
     pose_dict = {}
-    pose = Pose.from_dict(pose_dict)
+    pose = Pose.from_dict(pose_dict, "radians")
     assert pose.x == pytest.approx(0.0)
     assert pose.y == pytest.approx(0.0)
     assert pose.z == pytest.approx(0.0)
     assert pose.eul == pytest.approx([0.0, 0.0, 0.0])
     assert pose.q == pytest.approx([1.0, 0.0, 0.0, 0.0])
+    assert pose.angle_units == "radians"
 
     pose_dict = {
         "position": {"x": 1.0, "y": 2.0, "z": 3.0},
@@ -140,11 +176,12 @@ def test_pose_to_from_dict():
             "roll": -np.pi / 2.0,
         },
     }
-    pose = Pose.from_dict(pose_dict)
+    pose = Pose.from_dict(pose_dict, angle_units="radians")
     assert pose.x == pytest.approx(1.0)
     assert pose.y == pytest.approx(2.0)
     assert pose.z == pytest.approx(3.0)
     assert pose.eul == pytest.approx([-np.pi / 2.0, np.pi / 4.0, np.pi / 2.0])
+    assert pose.angle_units == "radians"
 
     pose_dict = {
         "position": {"x": 1.0, "y": 2.0, "z": 3.0},
@@ -155,12 +192,13 @@ def test_pose_to_from_dict():
         },
         "rotation_quat": {"w": 0.707107, "x": -0.707107, "y": 0.0, "z": 0.0},
     }
-    pose = Pose.from_dict(pose_dict)
+    pose = Pose.from_dict(pose_dict, angle_units="radians")
     assert pose.x == pytest.approx(1.0)
     assert pose.y == pytest.approx(2.0)
     assert pose.z == pytest.approx(3.0)
     assert pose.eul == pytest.approx([-np.pi / 2.0, 0.0, 0.0])
     assert pose.q == pytest.approx([0.707107, -0.707107, 0.0, 0.0])
+    assert pose.angle_units == "radians"
 
     out_dict = pose.to_dict()
     assert "position" in out_dict
@@ -183,15 +221,110 @@ def test_pose_to_from_dict():
     assert quat["z"] == pytest.approx(0.0)
 
 
-def test_construct_pose():
+def test_pose_to_from_dict_angle_in_degrees():
+    """Test creating poses using a dictionary and saving them back out."""
+    pose_dict = {}
+    pose = Pose.from_dict(pose_dict, angle_units="degrees")
+    assert pose.x == pytest.approx(0.0)
+    assert pose.y == pytest.approx(0.0)
+    assert pose.z == pytest.approx(0.0)
+    assert pose.eul == pytest.approx([0.0, 0.0, 0.0])
+    assert pose.q == pytest.approx([1.0, 0.0, 0.0, 0.0])
+    assert pose.angle_units == "degrees"
+
+    pose_dict = {
+        "position": {"x": 1.0, "y": 2.0, "z": 3.0},
+        "rotation_eul": {
+            "yaw": 90,
+            "pitch": 45,
+            "roll": -90,
+        },
+    }
+    pose = Pose.from_dict(pose_dict, angle_units="degrees")
+    assert pose.x == pytest.approx(1.0)
+    assert pose.y == pytest.approx(2.0)
+    assert pose.z == pytest.approx(3.0)
+    assert pose.eul == pytest.approx([-np.pi / 2.0, np.pi / 4.0, np.pi / 2.0])
+    assert pose.angle_units == "degrees"
+
+    pose_dict = {
+        "position": {"x": 1.0, "y": 2.0, "z": 3.0},
+        "rotation_eul": {
+            "yaw": 90,
+            "pitch": 45,
+            "roll": -90,
+        },
+        "rotation_quat": {"w": 0.707107, "x": -0.707107, "y": 0.0, "z": 0.0},
+    }
+    pose = Pose.from_dict(pose_dict, angle_units="degrees")
+    assert pose.x == pytest.approx(1.0)
+    assert pose.y == pytest.approx(2.0)
+    assert pose.z == pytest.approx(3.0)
+    assert pose.eul == pytest.approx([-np.pi / 2.0, 0.0, 0.0])
+    assert pose.q == pytest.approx([0.707107, -0.707107, 0.0, 0.0])
+    assert pose.angle_units == "degrees"
+
+    out_dict = pose.to_dict()
+    assert "position" in out_dict
+    pos = out_dict["position"]
+    assert "x" in pos
+    assert pos["x"] == pytest.approx(1.0)
+    assert "y" in pos
+    assert pos["y"] == pytest.approx(2.0)
+    assert "z" in pos
+    assert pos["z"] == pytest.approx(3.0)
+    assert "rotation_quat" in out_dict
+    quat = out_dict["rotation_quat"]
+    assert "w" in quat
+    assert quat["w"] == pytest.approx(0.707107)
+    assert "x" in quat
+    assert quat["x"] == pytest.approx(-0.707107)
+    assert "y" in quat
+    assert quat["y"] == pytest.approx(0.0)
+    assert "z" in quat
+    assert quat["z"] == pytest.approx(0.0)
+
+
+def test_construct_pose_angle_in_radians():
     """Test pose construct function that accepts various types."""
-    pose_from_list = Pose.construct([1.0, 2.0, 3.0, np.pi / 2.0])
+    pose_from_list = Pose.construct([1.0, 2.0, 3.0, np.pi / 2.0], "radians")
 
     pose_from_dict = Pose.construct(
         {
             "position": {"x": 1.0, "y": 2.0, "z": 3.0},
             "rotation_eul": {"yaw": np.pi / 2.0},
-        }
+        },
+        "radians",
+    )
+
+    tform = np.array(
+        [
+            [0.0, -1.0, 0.0, 1.0],
+            [1.0, 0.0, 0.0, 2.0],
+            [0.0, 0.0, 1.0, 3.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+    pose_from_tform = Pose.construct(tform)
+
+    assert pose_from_list.is_approx(pose_from_dict)
+    assert pose_from_dict.is_approx(pose_from_tform)
+
+    with pytest.raises(ValueError) as exc_info:
+        Pose.construct(42)
+    assert exc_info.value.args[0] == "Cannot construct pose from object of type int."
+
+
+def test_construct_pose_angle_in_degrees():
+    """Test pose construct function that accepts various types."""
+    pose_from_list = Pose.construct([1.0, 2.0, 3.0, 90], "degrees")
+
+    pose_from_dict = Pose.construct(
+        {
+            "position": {"x": 1.0, "y": 2.0, "z": 3.0},
+            "rotation_eul": {"yaw": 90},
+        },
+        "degrees",
     )
 
     tform = np.array(
@@ -239,18 +372,57 @@ def test_get_angular_distance():
     assert pose1.get_angular_distance(pose2) == pytest.approx(-3 * np.pi / 4)
 
 
-def test_get_matrices():
-    """Tests getting matrices from a pose."""
-    pose = Pose(x=1.0, y=2.0, z=3.0, roll=np.pi / 2, pitch=0.0, yaw=-np.pi / 2)
-
-    expected_tform = np.array(
-        [
-            [0.0, 1.0, 0.0, 1.0],
-            [0.0, 0.0, -1.0, 2.0],
-            [-1.0, 0.0, 0.0, 3.0],
-            [0.0, 0.0, 0.0, 1.0],
-        ]
+@pytest.mark.parametrize(
+    "x, y, z, roll, pitch, yaw, angle_units, expected_tform",
+    [
+        (
+            1.0,
+            2.0,
+            3.0,
+            np.pi / 2,
+            0.0,
+            -np.pi / 2,
+            "radians",
+            np.array(
+                [
+                    [0.0, 1.0, 0.0, 1.0],
+                    [0.0, 0.0, -1.0, 2.0],
+                    [-1.0, 0.0, 0.0, 3.0],
+                    [0.0, 0.0, 0.0, 1.0],
+                ]
+            ),
+        ),
+        (
+            1.0,
+            2.0,
+            3.0,
+            90,
+            0.0,
+            -90,
+            "degrees",
+            np.array(
+                [
+                    [0.0, 1.0, 0.0, 1.0],
+                    [0.0, 0.0, -1.0, 2.0],
+                    [-1.0, 0.0, 0.0, 3.0],
+                    [0.0, 0.0, 0.0, 1.0],
+                ]
+            ),
+        ),
+    ],
+)
+def test_get_matrices(x, y, z, roll, pitch, yaw, angle_units, expected_tform):
+    """Test getting matrices from a pose with different angle units"""
+    pose = Pose(
+        x=x,
+        y=y,
+        z=z,
+        roll=roll,
+        pitch=pitch,
+        yaw=yaw,
+        angle_units=angle_units,
     )
+
     expected_translation_matrix = np.eye(4)
     expected_translation_matrix[:3, 3] = expected_tform[:3, 3]
 
@@ -259,16 +431,99 @@ def test_get_matrices():
     assert pose.get_translation_matrix() == pytest.approx(expected_translation_matrix)
 
 
-def test_is_approx():
+@pytest.mark.parametrize(
+    "pose1, pose2, rel_tol, abs_tol, expected_result",
+    [
+        (
+            Pose(
+                x=1.0,
+                y=2.0,
+                z=3.0,
+                roll=np.pi / 2,
+                pitch=0.0,
+                yaw=-np.pi / 2,
+                angle_units="radians",
+            ),
+            Pose(
+                x=1.0 + 1e-4,
+                y=2.0,
+                z=3.0,
+                roll=np.pi / 2,
+                pitch=1e-4,
+                yaw=-np.pi / 2,
+                angle_units="radians",
+            ),
+            1e-3,
+            1e-3,
+            True,
+        ),
+        (
+            Pose(
+                x=1.0,
+                y=2.0,
+                z=3.0,
+                roll=np.pi / 2,
+                pitch=0.0,
+                yaw=-np.pi / 2,
+                angle_units="radians",
+            ),
+            Pose(
+                x=1.0 + 1e-4,
+                y=2.0,
+                z=3.0,
+                roll=np.pi / 2,
+                pitch=1e-4,
+                yaw=-np.pi / 2,
+                angle_units="radians",
+            ),
+            1e-5,
+            1e-5,
+            False,
+        ),
+        (
+            Pose(
+                x=1.0, y=2.0, z=3.0, roll=90, pitch=0.0, yaw=-90, angle_units="degrees"
+            ),
+            Pose(
+                x=1.0 + 1e-4,
+                y=2.0,
+                z=3.0,
+                roll=90,
+                pitch=1e-4,
+                yaw=-90,
+                angle_units="degrees",
+            ),
+            1e-3,
+            1e-3,
+            True,
+        ),
+        (
+            Pose(
+                x=1.0, y=2.0, z=3.0, roll=90, pitch=0.0, yaw=-90, angle_units="degrees"
+            ),
+            Pose(
+                x=1.0 + 1e-4,
+                y=2.0,
+                z=3.0,
+                roll=90,
+                pitch=1e-4,
+                yaw=-90,
+                angle_units="degrees",
+            ),
+            1e-5,
+            1e-5,
+            False,
+        ),
+    ],
+)
+def test_is_approx(pose1, pose2, rel_tol, abs_tol, expected_result):
     """Test approximate equivalence functionality"""
-    pose1 = Pose(x=1.0, y=2.0, z=3.0, roll=np.pi / 2, pitch=0.0, yaw=-np.pi / 2)
-    pose2 = Pose(x=1.0 + 1e-4, y=2.0, z=3.0, roll=np.pi / 2, pitch=1e-4, yaw=-np.pi / 2)
 
     # Default values are too tight for the poses above
     assert not pose1.is_approx(pose2)
 
     # Can relax tolerances
-    assert pose1.is_approx(pose2, rel_tol=1e-3, abs_tol=1e-3)
+    assert pose1.is_approx(pose2, rel_tol=rel_tol, abs_tol=abs_tol) == expected_result
 
     # Check datatype exception.
     with pytest.raises(TypeError) as exc_info:

--- a/pyrobosim/test/utils/test_pose_utils.py
+++ b/pyrobosim/test/utils/test_pose_utils.py
@@ -28,7 +28,6 @@ def test_pose_default_args():
     assert pose.z == pytest.approx(0.0)
     assert pose.eul == pytest.approx([0.0, 0.0, 0.0])
     assert pose.q == pytest.approx([1.0, 0.0, 0.0, 0.0])
-    assert pose.angle_units == "radians"
 
 
 def test_pose_from_position():
@@ -42,19 +41,20 @@ def test_pose_from_position():
 
 
 @pytest.mark.parametrize(
-    "angle_units, roll, pitch, yaw, expected_euler",
+    "angle_units, roll, pitch, yaw",
     [
-        ("radians", np.pi / 2, 0.0, -np.pi / 2, [np.pi / 2, 0.0, -np.pi / 2]),
-        ("degrees", 90.0, 0.0, -90.0, [np.pi / 2, 0.0, -np.pi / 2]),
+        ("radians", np.pi / 2, 0.0, -np.pi / 2),
+        ("degrees", 90.0, 0.0, -90.0),
     ],
 )
-def test_pose_from_euler_angles(angle_units, roll, pitch, yaw, expected_euler):
+def test_pose_from_euler_angles(angle_units, roll, pitch, yaw):
     """Test creating a pose using Euler angles specified in different units."""
     pose = Pose(roll=roll, pitch=pitch, yaw=yaw, angle_units=angle_units)
+
     assert pose.x == pytest.approx(0.0)
     assert pose.y == pytest.approx(0.0)
     assert pose.z == pytest.approx(0.0)
-    assert pose.eul == pytest.approx(expected_euler)
+    assert pose.eul == pytest.approx([np.pi / 2, 0.0, -np.pi / 2])
     assert pose.q == pytest.approx([0.5, 0.5, 0.5, -0.5])
 
 
@@ -88,7 +88,6 @@ def test_pose_from_lists():
     assert pose.z == pytest.approx(3.0)
     assert pose.eul == pytest.approx([0.0, 0.0, np.pi / 2])
     assert pose.q == pytest.approx([np.sqrt(2) / 2, 0.0, 0.0, np.sqrt(2) / 2])
-    assert pose.angle_units == "radians"
 
     # 6-element lists should be [x, y, z, roll, pitch, yaw]
     pose = Pose.from_list([1.0, 2.0, 3.0, np.pi / 2, 0.0, -np.pi / 2])
@@ -97,7 +96,6 @@ def test_pose_from_lists():
     assert pose.z == pytest.approx(3.0)
     assert pose.eul == pytest.approx([np.pi / 2, 0.0, -np.pi / 2])
     assert pose.q == pytest.approx([0.5, 0.5, 0.5, -0.5])
-    assert pose.angle_units == "radians"
 
     # 7-element lists should be [x, y, z, qw, qx, qy, qz]
     pose = Pose.from_list([1.0, 2.0, 3.0, 0.5, 0.5, 0.5, -0.5])
@@ -141,23 +139,19 @@ def test_pose_from_transform():
 
 
 @pytest.mark.parametrize(
-    "angle_units, angle_value, expected_eul, expected_q",
+    "angle_units, angle_value",
     [
         (
             "radians",
             np.pi / 2,
-            [-np.pi / 2, np.pi / 4, np.pi / 2],
-            [0.707107, -0.707107, 0.0, 0.0],
         ),
         (
             "degrees",
             90.0,
-            [-np.pi / 2, np.pi / 4, np.pi / 2],
-            [0.707107, -0.707107, 0.0, 0.0],
         ),
     ],
 )
-def test_pose_to_from_dict(angle_units, angle_value, expected_eul, expected_q):
+def test_pose_to_from_dict(angle_units, angle_value):
     """Test creating poses using a dictionary and saving them back out."""
     pose_dict = {}
     pose = Pose.from_dict(pose_dict)
@@ -180,8 +174,7 @@ def test_pose_to_from_dict(angle_units, angle_value, expected_eul, expected_q):
     assert pose.x == pytest.approx(1.0)
     assert pose.y == pytest.approx(2.0)
     assert pose.z == pytest.approx(3.0)
-    assert pose.eul == pytest.approx(expected_eul)
-    assert pose.angle_units == angle_units
+    assert pose.eul == pytest.approx([-np.pi / 2, np.pi / 4, np.pi / 2])
 
     pose_dict["rotation_quat"] = {"w": 0.707107, "x": -0.707107, "y": 0.0, "z": 0.0}
     pose = Pose.from_dict(pose_dict)
@@ -189,7 +182,7 @@ def test_pose_to_from_dict(angle_units, angle_value, expected_eul, expected_q):
     assert pose.y == pytest.approx(2.0)
     assert pose.z == pytest.approx(3.0)
     assert pose.eul == pytest.approx([-np.pi / 2, 0.0, 0.0])
-    assert pose.q == pytest.approx(expected_q)
+    assert pose.q == pytest.approx([0.707107, -0.707107, 0.0, 0.0])
 
     out_dict = pose.to_dict()
     assert "position" in out_dict
@@ -213,35 +206,19 @@ def test_pose_to_from_dict(angle_units, angle_value, expected_eul, expected_q):
 
 
 @pytest.mark.parametrize(
-    "angle_units, angle_value, expected_tform",
+    "angle_units, angle_value",
     [
         (
             "radians",
             np.pi / 2,
-            np.array(
-                [
-                    [0.0, -1.0, 0.0, 1.0],
-                    [1.0, 0.0, 0.0, 2.0],
-                    [0.0, 0.0, 1.0, 3.0],
-                    [0.0, 0.0, 0.0, 1.0],
-                ]
-            ),
         ),
         (
             "degrees",
             90.0,
-            np.array(
-                [
-                    [0.0, -1.0, 0.0, 1.0],
-                    [1.0, 0.0, 0.0, 2.0],
-                    [0.0, 0.0, 1.0, 3.0],
-                    [0.0, 0.0, 0.0, 1.0],
-                ]
-            ),
         ),
     ],
 )
-def test_construct_pose(angle_units, angle_value, expected_tform):
+def test_construct_pose(angle_units, angle_value):
     """Test pose construct function that accepts various types"""
     pose_from_list = Pose.construct([1.0, 2.0, 3.0, np.pi / 2])
     pose_from_dict = Pose.construct(
@@ -250,6 +227,15 @@ def test_construct_pose(angle_units, angle_value, expected_tform):
             "rotation_eul": {"yaw": angle_value},
             "angle_units": angle_units,
         }
+    )
+
+    expected_tform = np.array(
+        [
+            [0.0, -1.0, 0.0, 1.0],
+            [1.0, 0.0, 0.0, 2.0],
+            [0.0, 0.0, 1.0, 3.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
     )
 
     pose_from_tform = Pose.construct(expected_tform)
@@ -290,45 +276,13 @@ def test_get_angular_distance():
 
 
 @pytest.mark.parametrize(
-    "x, y, z, roll, pitch, yaw, angle_units, expected_tform",
+    "x, y, z, roll, pitch, yaw, angle_units",
     [
-        (
-            1.0,
-            2.0,
-            3.0,
-            np.pi / 2,
-            0.0,
-            -np.pi / 2,
-            "radians",
-            np.array(
-                [
-                    [0.0, 1.0, 0.0, 1.0],
-                    [0.0, 0.0, -1.0, 2.0],
-                    [-1.0, 0.0, 0.0, 3.0],
-                    [0.0, 0.0, 0.0, 1.0],
-                ]
-            ),
-        ),
-        (
-            1.0,
-            2.0,
-            3.0,
-            90.0,
-            0.0,
-            -90.0,
-            "degrees",
-            np.array(
-                [
-                    [0.0, 1.0, 0.0, 1.0],
-                    [0.0, 0.0, -1.0, 2.0],
-                    [-1.0, 0.0, 0.0, 3.0],
-                    [0.0, 0.0, 0.0, 1.0],
-                ]
-            ),
-        ),
+        (1.0, 2.0, 3.0, np.pi / 2, 0.0, -np.pi / 2, "radians"),
+        (1.0, 2.0, 3.0, 90.0, 0.0, -90.0, "degrees"),
     ],
 )
-def test_get_matrices(x, y, z, roll, pitch, yaw, angle_units, expected_tform):
+def test_get_matrices(x, y, z, roll, pitch, yaw, angle_units):
     """Test getting matrices from a pose with different angle units"""
     pose = Pose(
         x=x,
@@ -340,6 +294,15 @@ def test_get_matrices(x, y, z, roll, pitch, yaw, angle_units, expected_tform):
         angle_units=angle_units,
     )
 
+    expected_tform = np.array(
+        [
+            [0.0, 1.0, 0.0, 1.0],
+            [0.0, 0.0, -1.0, 2.0],
+            [-1.0, 0.0, 0.0, 3.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+
     expected_translation_matrix = np.eye(4)
     expected_translation_matrix[:3, 3] = expected_tform[:3, 3]
 
@@ -348,116 +311,59 @@ def test_get_matrices(x, y, z, roll, pitch, yaw, angle_units, expected_tform):
     assert pose.get_translation_matrix() == pytest.approx(expected_translation_matrix)
 
 
-@pytest.mark.parametrize(
-    "pose1, pose2, rel_tol, abs_tol, expected_result",
-    [
-        (
-            Pose(
-                x=1.0,
-                y=2.0,
-                z=3.0,
-                roll=np.pi / 2,
-                pitch=0.0,
-                yaw=-np.pi / 2,
-                angle_units="radians",
-            ),
-            Pose(
-                x=1.0 + 1e-4,
-                y=2.0,
-                z=3.0,
-                roll=np.pi / 2,
-                pitch=1e-4,
-                yaw=-np.pi / 2,
-                angle_units="radians",
-            ),
-            1e-3,
-            1e-3,
-            True,
-        ),
-        (
-            Pose(
-                x=1.0,
-                y=2.0,
-                z=3.0,
-                roll=np.pi / 2,
-                pitch=0.0,
-                yaw=-np.pi / 2,
-                angle_units="radians",
-            ),
-            Pose(
-                x=1.0 + 1e-4,
-                y=2.0,
-                z=3.0,
-                roll=np.pi / 2,
-                pitch=1e-4,
-                yaw=-np.pi / 2,
-                angle_units="radians",
-            ),
-            1e-5,
-            1e-5,
-            False,
-        ),
-        (
-            Pose(
-                x=1.0,
-                y=2.0,
-                z=3.0,
-                roll=90.0,
-                pitch=0.0,
-                yaw=-90.0,
-                angle_units="degrees",
-            ),
-            Pose(
-                x=1.0 + 1e-4,
-                y=2.0,
-                z=3.0,
-                roll=90.0,
-                pitch=1e-4,
-                yaw=-90.0,
-                angle_units="degrees",
-            ),
-            1e-3,
-            1e-3,
-            True,
-        ),
-        (
-            Pose(
-                x=1.0,
-                y=2.0,
-                z=3.0,
-                roll=90.0,
-                pitch=0.0,
-                yaw=-90.0,
-                angle_units="degrees",
-            ),
-            Pose(
-                x=1.0 + 1e-4,
-                y=2.0,
-                z=3.0,
-                roll=90.0,
-                pitch=1e-4,
-                yaw=-90.0,
-                angle_units="degrees",
-            ),
-            1e-5,
-            1e-5,
-            False,
-        ),
-    ],
-)
-def test_is_approx(pose1, pose2, rel_tol, abs_tol, expected_result):
-    """Test approximate equivalence functionality"""
+def test_is_approx_radians():
+    """Test approximate equivalence functionality for pose in radians"""
+    pose1 = Pose(
+        x=1.0,
+        y=2.0,
+        z=3.0,
+        roll=np.pi / 2,
+        pitch=0.0,
+        yaw=-np.pi / 2,
+        angle_units="radians",
+    )
+    pose2 = Pose(
+        x=1.0 + 1e-4,
+        y=2.0,
+        z=3.0,
+        roll=np.pi / 2,
+        pitch=1e-4,
+        yaw=-np.pi / 2,
+        angle_units="radians",
+    )
 
     # Default values are too tight for the poses above
     assert not pose1.is_approx(pose2)
 
     # Can relax tolerances
-    assert pose1.is_approx(pose2, rel_tol=rel_tol, abs_tol=abs_tol) == expected_result
+    assert pose1.is_approx(pose2, rel_tol=1e-3, abs_tol=1e-3)
 
     # Check datatype exception.
     with pytest.raises(TypeError) as exc_info:
         pose1.is_approx(42.0)
     assert exc_info.value.args[0] == "Expected a Pose object."
+
+
+def test_is_approx_degrees():
+    """Test approximate equivalence functionality for pose in degrees"""
+    pose1 = Pose(
+        x=1.0, y=2.0, z=3.0, roll=np.pi / 2, pitch=0.0, yaw=-90.0, angle_units="degrees"
+    )
+    pose2 = Pose(
+        x=1.0 + 1e-4,
+        y=2.0,
+        z=3.0,
+        roll=np.pi / 2,
+        pitch=1e-4,
+        yaw=-90.0,
+        angle_units="degrees",
+    )
+
+    # Default values are too tight for the poses above
+    assert not pose1.is_approx(pose2)
+
+    # Can relax tolerances
+    assert pose1.is_approx(pose2, rel_tol=1e-3, abs_tol=1e-3)
 
 
 def test_equality():

--- a/pyrobosim/test/utils/test_pose_utils.py
+++ b/pyrobosim/test/utils/test_pose_utils.py
@@ -167,8 +167,8 @@ def test_pose_to_from_dict(angle_units, angle_value):
             "yaw": angle_value,
             "pitch": angle_value / 2,
             "roll": -angle_value,
+            "angle_units": angle_units,
         },
-        "angle_units": angle_units,
     }
     pose = Pose.from_dict(pose_dict)
     assert pose.x == pytest.approx(1.0)
@@ -224,8 +224,7 @@ def test_construct_pose(angle_units, angle_value):
     pose_from_dict = Pose.construct(
         {
             "position": {"x": 1.0, "y": 2.0, "z": 3.0},
-            "rotation_eul": {"yaw": angle_value},
-            "angle_units": angle_units,
+            "rotation_eul": {"yaw": angle_value, "angle_units": angle_units},
         }
     )
 

--- a/pyrobosim/test/utils/test_pose_utils.py
+++ b/pyrobosim/test/utils/test_pose_utils.py
@@ -326,14 +326,14 @@ def test_is_approx_radians():
 def test_is_approx_degrees():
     """Test approximate equivalence functionality for pose in degrees"""
     pose1 = Pose(
-        x=1.0, y=2.0, z=3.0, roll=np.pi / 2, pitch=0.0, yaw=-90.0, angle_units="degrees"
+        x=1.0, y=2.0, z=3.0, roll=90.0, pitch=0.0, yaw=-90.0, angle_units="degrees"
     )
     pose2 = Pose(
         x=1.0 + 1e-4,
         y=2.0,
         z=3.0,
-        roll=np.pi / 2,
-        pitch=1e-4,
+        roll=90.0,
+        pitch=0.0057,
         yaw=-90.0,
         angle_units="degrees",
     )


### PR DESCRIPTION
This PR added the functionality to specify Pose angles in degrees also.

-  `angle_units` parameter is introduced to specify the units of the angle.
-  if `angle_units` is not specified, the default unit is set to `radians`.
-  modified demo script to verify the correct behavior when `angle_units` is set to `degrees`.

Unit Tests added to verify and test new functionality