### PR TITLE
Add latest path reset to AStarPlanner

### DIFF
--- a/pyrobosim/pyrobosim/navigation/a_star.py
+++ b/pyrobosim/pyrobosim/navigation/a_star.py
@@ -133,6 +133,7 @@ class AStarPlanner(AStar):
 
     def reset(self):
         """Resets the occupancy grid."""
+        self.latest_path = Path()
         self.grid = OccupancyGrid.from_world(
             self.world,
             resolution=self.grid_resolution,


### PR DESCRIPTION
When initializing `AStarPlanner` the GUI throws the following error:
```
Traceback (most recent call last):
  File "/home/robin/Desktop/px4-ros2-env/install/auto_apms_simulation/lib/auto_apms_simulation/world.py", line 41, in <module>
    main()
  File "/home/robin/Desktop/px4-ros2-env/install/auto_apms_simulation/lib/auto_apms_simulation/world.py", line 37, in main
    start_gui(node.world)
  File "/home/robin/Desktop/px4-ros2-env/install/auto_apms_simulation/local/lib/python3.10/dist-packages/pyrobosim/gui/main.py", line 23, in start_gui
    app = PyRoboSimGUI(world, sys.argv)
  File "/home/robin/Desktop/px4-ros2-env/install/auto_apms_simulation/local/lib/python3.10/dist-packages/pyrobosim/gui/main.py", line 44, in __init__
    self.main_window = PyRoboSimMainWindow(self.world, show)
  File "/home/robin/Desktop/px4-ros2-env/install/auto_apms_simulation/local/lib/python3.10/dist-packages/pyrobosim/gui/main.py", line 75, in __init__
    self.canvas.show()
  File "/home/robin/Desktop/px4-ros2-env/install/auto_apms_simulation/local/lib/python3.10/dist-packages/pyrobosim/gui/world_canvas.py", line 324, in show
    self.show_planner_and_path(robot=self.world.robots[0])
  File "/home/robin/Desktop/px4-ros2-env/install/auto_apms_simulation/local/lib/python3.10/dist-packages/pyrobosim/gui/world_canvas.py", line 359, in show_planner_and_path
    path = path or robot.path_planner.get_latest_path()
  File "/home/robin/Desktop/px4-ros2-env/install/auto_apms_simulation/local/lib/python3.10/dist-packages/pyrobosim/navigation/a_star.py", line 190, in get_latest_path
    return self.latest_path
AttributeError: 'AStarPlanner' object has no attribute 'latest_path'. Did you mean: 'get_latest_path'?
``` 
This PR resolves this issue by adding an initial value to `latest_path` similar to the other planners.