### PR TITLE
Fix error when resolving possible objects to pick while some are carried by other robots

### DIFF
--- a/pyrobosim/pyrobosim/utils/knowledge.py
+++ b/pyrobosim/pyrobosim/utils/knowledge.py
@@ -340,12 +340,16 @@ def resolve_to_object(
             obj
             for obj in possible_objects
             if (
-                obj.parent == location
-                or obj.parent.name == location
-                or obj.parent.parent == location
-                or obj.parent.parent.name == location
-                or obj.parent.category == location
-                or obj.parent.parent.category == location
+                # Check whether the parent is a robot performing further checks
+                hasattr(obj.parent, "parent")
+                and (
+                    obj.parent == location
+                    or obj.parent.name == location
+                    or obj.parent.parent == location
+                    or obj.parent.parent.name == location
+                    or obj.parent.category == location
+                    or obj.parent.parent.category == location
+                )
             )
         ]
 

--- a/pyrobosim/pyrobosim/utils/knowledge.py
+++ b/pyrobosim/pyrobosim/utils/knowledge.py
@@ -333,7 +333,7 @@ def resolve_to_object(
             obj
             for obj in possible_objects
             if (
-                # Check whether the parent is a robot before performing further checks
+                # Verify the object's parent is not a robot before performing further checks
                 hasattr(obj.parent, "parent")
                 and obj.parent.parent.parent.name == room_name
             )
@@ -344,7 +344,7 @@ def resolve_to_object(
             obj
             for obj in possible_objects
             if (
-                # Check whether the parent is a robot before performing further checks
+                # Verify the object's parent is not a robot before performing further checks
                 hasattr(obj.parent, "parent")
                 and (
                     obj.parent == location

--- a/pyrobosim/pyrobosim/utils/knowledge.py
+++ b/pyrobosim/pyrobosim/utils/knowledge.py
@@ -332,7 +332,11 @@ def resolve_to_object(
         possible_objects = [
             obj
             for obj in possible_objects
-            if obj.parent.parent.parent.name == room_name
+            if (
+                # Check whether the parent is a robot before performing further checks
+                hasattr(obj.parent, "parent")
+                and obj.parent.parent.parent.name == room_name
+            )
         ]
 
     if location is not None:
@@ -340,7 +344,7 @@ def resolve_to_object(
             obj
             for obj in possible_objects
             if (
-                # Check whether the parent is a robot performing further checks
+                # Check whether the parent is a robot before performing further checks
                 hasattr(obj.parent, "parent")
                 and (
                     obj.parent == location


### PR DESCRIPTION
When picking objects with multiple robots in a world, it is likely, that some are currently carried and do not reside on locations anymore. Since `Robot` doesn't have a `parent` attribute, an error is raised when checking each object's location.

```
[world.py-1] [ERROR] [1734861471.897019297] [pyrobosim]: Error raised in execute callback: 'Robot' object has no attribute 'parent'
[world.py-1] Traceback (most recent call last):
[world.py-1]   File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/action/server.py", line 333, in _execute_goal
[world.py-1]     execute_result = await await_or_execute(execute_callback, goal_handle)
[world.py-1]   File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/executors.py", line 107, in await_or_execute
[world.py-1]     return callback(*args)
[world.py-1]   File "/home/robin/Desktop/px4-ros2-env/install/auto_apms_simulation/local/lib/python3.10/dist-packages/pyrobosim_ros/ros_interface.py", line 418, in action_callback
[world.py-1]     execution_result = robot.execute_action(robot_action)
[world.py-1]   File "/home/robin/Desktop/px4-ros2-env/install/auto_apms_simulation/local/lib/python3.10/dist-packages/pyrobosim/core/robot.py", line 917, in execute_action
[world.py-1]     result = self.pick_object(action.object, action.pose)
[world.py-1]   File "/home/robin/Desktop/px4-ros2-env/install/auto_apms_simulation/local/lib/python3.10/dist-packages/pyrobosim/core/robot.py", line 494, in pick_object
[world.py-1]     obj = query_to_entity(
[world.py-1]   File "/home/robin/Desktop/px4-ros2-env/install/auto_apms_simulation/local/lib/python3.10/dist-packages/pyrobosim/utils/knowledge.py", line 185, in query_to_entity
[world.py-1]     obj_candidate = resolve_to_object(
[world.py-1]   File "/home/robin/Desktop/px4-ros2-env/install/auto_apms_simulation/local/lib/python3.10/dist-packages/pyrobosim/utils/knowledge.py", line 339, in resolve_to_object
[world.py-1]     possible_objects = [
[world.py-1]   File "/home/robin/Desktop/px4-ros2-env/install/auto_apms_simulation/local/lib/python3.10/dist-packages/pyrobosim/utils/knowledge.py", line 345, in <listcomp>
[world.py-1]     or obj.parent.parent == location
[world.py-1] AttributeError: 'Robot' object has no attribute 'parent'
```

This PR fixes this issue by checking if the parent has an attribute called `parent` effectively verifying that it's not a robot. Consequently, objects can not be picked when they are carried by robots.

> [!NOTE]  
> I've also tried to verify using `isinstance(obj.parent, Robot)` but this requires to import `Robot` and causes a circular import error when done on top. It's also possible to import it inside the `resolve_to_object` method, but I guess this solution is sufficient.