### PR TITLE
Make sure robot.cancel_actions will return

### DIFF
--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -946,12 +946,14 @@ class Robot:
             self.logger.warning("There is no running action or plan to cancel.")
             return
 
+        if self.executing_nav and self.path_executor is not None:
+            # Stop path executor
+            self.logger.info("Canceling path execution...")
+            self.path_executor.cancel_execution = True
+            while self.executing_nav:
+                time.sleep(0.1)
+
         if self.executing_action:
-            if self.executing_nav and self.path_executor is not None:
-                self.logger.info("Canceling path execution...")
-                self.path_executor.cancel_execution = True
-                while self.executing_nav:
-                    time.sleep(0.1)
             # Wait for execute_action to return
             while self.executing_action:
                 time.sleep(0.1)

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -946,15 +946,20 @@ class Robot:
             self.logger.warning("There is no running action or plan to cancel.")
             return
 
-        if self.executing_nav and self.path_executor is not None:
-            self.logger.info("Canceling path execution...")
-            self.path_executor.cancel_execution = True
-            while self.executing_nav:
+        if self.executing_action:
+            if self.executing_nav and self.path_executor is not None:
+                self.logger.info("Canceling path execution...")
+                self.path_executor.cancel_execution = True
+                while self.executing_nav:
+                    time.sleep(0.1)
+            # Wait for execute_action to return
+            while self.executing_action:
                 time.sleep(0.1)
 
-        if self.executing_action or self.executing_plan:
+        if self.executing_plan:
             self.canceling_execution = True
-            while self.canceling_execution:
+            # Wait for execute_plan to return
+            while self.executing_plan:
                 time.sleep(0.1)
 
     def execute_plan(self, plan, delay=0.5):

--- a/pyrobosim/test/core/test_robot.py
+++ b/pyrobosim/test/core/test_robot.py
@@ -568,11 +568,19 @@ class TestRobot:
         )
 
         # Start a thread that cancels the actions mid execution.
-        threading.Timer(1.0, robot.cancel_actions).start()
+        cancel_thread = threading.Timer(1.0, robot.cancel_actions)
+        cancel_thread.start()
 
         # Run action and check that it failed due to being canceled.
         result = robot.execute_action(action)
         assert result.status == ExecutionStatus.CANCELED
+        
+        # We want to make sure the cancellation thread is finished 
+        # (cancel_actions has returned). 
+        # Consequently, we must give the thread some time to detect the 
+        # correct lifetime status
+        time.sleep(0.1)
+        assert not cancel_thread.is_alive()
 
         # Retry the action, which should now succeed.
         assert robot.execute_action(action).is_success()

--- a/pyrobosim/test/core/test_robot.py
+++ b/pyrobosim/test/core/test_robot.py
@@ -574,10 +574,10 @@ class TestRobot:
         # Run action and check that it failed due to being canceled.
         result = robot.execute_action(action)
         assert result.status == ExecutionStatus.CANCELED
-        
-        # We want to make sure the cancellation thread is finished 
-        # (cancel_actions has returned). 
-        # Consequently, we must give the thread some time to detect the 
+
+        # We want to make sure the cancellation thread is finished
+        # (cancel_actions has returned).
+        # Consequently, we must give the thread some time to detect the
         # correct lifetime status
         time.sleep(0.1)
         assert not cancel_thread.is_alive()


### PR DESCRIPTION
Currently, the `Robot.cancel_actions()` method will wait for the `Robot.canceling_execution` flag becoming `False` indefinitely when `Robot.execute_action()` fails to set `self.executing_action = False` before `Robot.cancel_actions()` (e.g. running in a separate thread) checks that in the if statement.
https://github.com/sea-bass/pyrobosim/blob/c36d1989ff27b1d66b738ef3dec9bfd336bbcbf4/pyrobosim/pyrobosim/core/robot.py#L955-L958
This is because `Robot.canceling_execution` is only updated by `Robot.execute_plan()` and not `Robot.execute_action()`.

In this PR I suggest an alternative function design for canceling actions as well as plans using `Robot.cancel_actions()` that ensures it will complete when the respective execution callback returns.