### PR TITLE
Add AutoAPMS to usage examples

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,6 +37,7 @@ Below is a list of known projects that use ``pyrobosim``.
 * `Task Planning in Robotics <https://roboticseabass.com/2022/07/19/task-planning-in-robotics/>`_ and `Integrated Task and Motion Planning in Robotics <https://roboticseabass.com/2022/07/30/integrated-task-and-motion-planning-in-robotics/>`_ blog posts, by Sebastian Castro (2022)
 * `Hierarchically Decentralized Heterogeneous Multi-Robot Task Allocation System <https://arxiv.org/abs/2405.02484>`_, by Sujeet Kashid and Ashwin D. Kumat (2024)
 * `Hands-On with ROS 2 Deliberation Technologies <https://github.com/ros-wg-delib/roscon24-workshop>`_ workshop at `ROSCon 2024 <https://roscon.ros.org/2024/>`_, by Christian Henkel, Sebastian Castro, Davide Faconti, David Oberacker, David Conner, and Matthias Mayr (2024)
+* `AutoAPMS: A unified software framework for creating behavior-based robotic applications <https://github.com/robin-mueller/auto-apms>`_, by Robin Müller (2025)
 
 If you have something to add, please submit a pull request!
 


### PR DESCRIPTION
I'd like to add my software to the usage examples since I use pyrobosim for demonstrating its use case. I also plan to extend the interface to pyrobosim to allow users to easily prototype the behaviors they create using AutoAPMS without having to set up the workspace themselves. Pyrobosim is the default simulation environment and comes out of the box when installing AutoAPMS.