### PR TITLE
Handle empty polygons in inflate_polygon

### DIFF
--- a/pyrobosim/pyrobosim/core/hallway.py
+++ b/pyrobosim/pyrobosim/core/hallway.py
@@ -2,7 +2,7 @@
 
 import math
 from shapely import intersects_xy
-from shapely.geometry import LineString, MultiLineString, Polygon
+from shapely.geometry import LineString, MultiLineString
 from shapely.plotting import patch_from_polygon
 
 from ..utils.pose import Pose, get_angle, get_bearing_range
@@ -130,13 +130,10 @@ class Hallway:
         :type inflation_radius: float, optional
         """
         # Internal collision polygon:
-        # Deflate the resulting difference polygon, protecting against inflation radius greater than the half-width of the hallway.
-        if inflation_radius >= self.width / 2.0:
-            self.internal_collision_polygon = Polygon()
-        else:
-            self.internal_collision_polygon = inflate_polygon(
-                self.polygon, -inflation_radius
-            )
+        # Deflate the resulting difference polygon
+        self.internal_collision_polygon = inflate_polygon(
+            self.polygon, -inflation_radius
+        )
         # Subtract deflated room polygons from the hallway polygon
         self.internal_collision_polygon = self.internal_collision_polygon.difference(
             inflate_polygon(self.room_start.polygon, -inflation_radius)

--- a/pyrobosim/pyrobosim/core/hallway.py
+++ b/pyrobosim/pyrobosim/core/hallway.py
@@ -2,7 +2,7 @@
 
 import math
 from shapely import intersects_xy
-from shapely.geometry import LineString, MultiLineString
+from shapely.geometry import LineString, MultiLineString, Polygon
 from shapely.plotting import patch_from_polygon
 
 from ..utils.pose import Pose, get_angle, get_bearing_range
@@ -130,10 +130,13 @@ class Hallway:
         :type inflation_radius: float, optional
         """
         # Internal collision polygon:
-        # Deflate the resulting difference polygon
-        self.internal_collision_polygon = inflate_polygon(
-            self.polygon, -inflation_radius
-        )
+        # Deflate the resulting difference polygon, protecting against inflation radius greater than the half-width of the hallway.
+        if inflation_radius >= self.width / 2.0:
+            self.internal_collision_polygon = Polygon()
+        else:
+            self.internal_collision_polygon = inflate_polygon(
+                self.polygon, -inflation_radius
+            )
         # Subtract deflated room polygons from the hallway polygon
         self.internal_collision_polygon = self.internal_collision_polygon.difference(
             inflate_polygon(self.room_start.polygon, -inflation_radius)

--- a/pyrobosim/pyrobosim/utils/polygon.py
+++ b/pyrobosim/pyrobosim/utils/polygon.py
@@ -92,6 +92,9 @@ def inflate_polygon(poly, radius):
     :return: The inflated Shapely polygon.
     :rtype: :class:`shapely.geometry.Polygon`
     """
+    if poly.is_empty:
+        return poly
+
     inflated_poly = poly.buffer(
         radius, cap_style=CAP_STYLE.flat, join_style=JOIN_STYLE.mitre
     )
@@ -111,6 +114,9 @@ def transform_polygon(polygon, pose):
     :return: The transformed Shapely polygon.
     :rtype: :class:`shapely.geometry.Polygon`
     """
+    if polygon.is_empty:
+        return polygon
+
     if pose is not None:
         polygon = translate(polygon, xoff=pose.x, yoff=pose.y)
         polygon = rotate(

--- a/pyrobosim/pyrobosim/utils/polygon.py
+++ b/pyrobosim/pyrobosim/utils/polygon.py
@@ -92,12 +92,11 @@ def inflate_polygon(poly, radius):
     :return: The inflated Shapely polygon.
     :rtype: :class:`shapely.geometry.Polygon`
     """
-    if poly.is_empty:
-        return poly
-
     inflated_poly = poly.buffer(
         radius, cap_style=CAP_STYLE.flat, join_style=JOIN_STYLE.mitre
     )
+    if inflated_poly.is_empty:
+        return inflated_poly
     return orient(inflated_poly)
 
 
@@ -114,9 +113,6 @@ def transform_polygon(polygon, pose):
     :return: The transformed Shapely polygon.
     :rtype: :class:`shapely.geometry.Polygon`
     """
-    if polygon.is_empty:
-        return polygon
-
     if pose is not None:
         polygon = translate(polygon, xoff=pose.x, yoff=pose.y)
         polygon = rotate(

--- a/pyrobosim/test/utils/test_polygon_utils.py
+++ b/pyrobosim/test/utils/test_polygon_utils.py
@@ -75,7 +75,12 @@ def test_get_polygon_centroid():
 
 
 def test_inflate_polygon():
+    empty_poly = Polygon()
     square_poly = Polygon(square_coords)
+
+    # Empty polygon
+    inflated_poly = inflate_polygon(empty_poly, 0.0)
+    assert inflated_poly == empty_poly
 
     # Zero inflation radius
     inflated_poly = inflate_polygon(square_poly, 0.0)
@@ -108,7 +113,12 @@ def test_inflate_polygon():
 
 
 def test_transform_polygon():
+    empty_poly = Polygon()
     square_poly = Polygon(box_to_coords(dims=[1.0, 2.0]))
+
+    # Empty polygon
+    transformed_poly = transform_polygon(empty_poly, None)
+    assert transformed_poly == empty_poly
 
     # No transformation, using None as pose
     transformed_poly = transform_polygon(square_poly, None)


### PR DESCRIPTION
This PR handles a few edge cases due to infinitely thin hallways in two dimensions, since Shapely doesn't seem to handle them gracefully:

1. No clearance between the walls of the two neighboring rooms (requires checking polygon emptiness before inflating)
2. Hallway half-width smaller than the world inflation radius (requires checking these values and returning an empty Polygon)

I think in both cases, I've narrowed it down to this: https://github.com/shapely/shapely/pull/2214

Closes #325 