### PR TITLE
Refactor world resetting to allow standalone use and ROS service

### DIFF
--- a/pyrobosim/pyrobosim/data/example_location_data_accessories.yaml
+++ b/pyrobosim/pyrobosim/data/example_location_data_accessories.yaml
@@ -35,19 +35,19 @@ charger:
       nav_poses:
         - position:  # below
             x: 0.0
-            y: -0.5
+            y: -0.35
           rotation_eul:
             yaw: 1.57
         - position:  # left
-            x: -0.35
+            x: -0.5
             y: 0.0
         - position:  # above
             x: 0.0
-            y: 0.5
+            y: 0.35
           rotation_eul:
             yaw: -1.57
         - position:  # right
-            x: 0.35
+            x: 0.5
             y: 0.0
           rotation_eul:
             yaw: 3.14

--- a/pyrobosim/pyrobosim/gui/main.py
+++ b/pyrobosim/pyrobosim/gui/main.py
@@ -81,11 +81,7 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):  # type: ignore [misc]
 
         :param world: World object to attach.
         """
-        from ..core.yaml_utils import WorldYamlWriter
-
         self.world = world
-        if self.world.source_yaml is None:
-            self.world.source_yaml = WorldYamlWriter().to_dict(self.world)
         self.world.gui = self
         self.canvas.world = world
 
@@ -391,31 +387,7 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):  # type: ignore [misc]
 
     def on_reset_world_click(self) -> None:
         """Callback to reset the entire world."""
-        from ..core.yaml_utils import WorldYamlLoader
-
-        # Shut down all the old robots' ROS interfaces.
-        ros_node = self.world.ros_node
-        if ros_node is not None:
-            for robot in self.world.robots:
-                ros_node.remove_robot_ros_interfaces(robot)
-
-        if self.world.source_yaml_file is not None:
-            world = WorldYamlLoader().from_file(self.world.source_yaml_file)
-        elif self.world.source_yaml is not None:
-            world = WorldYamlLoader().from_yaml(self.world.source_yaml)
-        else:
-            raise RuntimeError("Could not find source YAML representation!")
-        self.set_world(world)
-
-        # Start up the new robots' ROS interfaces.
-        if ros_node is not None:
-            ros_node.set_world(world)
-            for robot in self.world.robots:
-                ros_node.add_robot_ros_interfaces(robot)
-
-        self.canvas.show()
-        self.canvas.draw_signal.emit()
-        self.on_robot_changed()
+        self.world.reset()
 
     def on_reset_path_planner_click(self) -> None:
         """Callback to reset the path planner for the current robot."""

--- a/pyrobosim/test/core/test_world.py
+++ b/pyrobosim/test/core/test_world.py
@@ -430,10 +430,6 @@ class TestWorldModeling:
             pose_start, pose_goal, step_dist=0.5
         )
 
-    ##############################################
-    # These tests incrementally clean up a world #
-    ##############################################
-
     @staticmethod
     @pytest.mark.dependency(  # type: ignore[misc]
         depends=[
@@ -441,6 +437,24 @@ class TestWorldModeling:
             "TestWorldModeling::test_collides_with_robots",
             "TestWorldModeling::test_is_connectable",
         ]
+    )
+    def test_reset_world() -> None:
+        """Tests resetting a world."""
+        TestWorldModeling.world.reset()
+
+        assert TestWorldModeling.world.num_rooms == 2
+        assert TestWorldModeling.world.num_locations == 2
+        assert TestWorldModeling.world.num_hallways == 1
+        assert TestWorldModeling.world.num_objects == 2
+        assert len(TestWorldModeling.world.robots) == 2
+
+    ##############################################
+    # These tests incrementally clean up a world #
+    ##############################################
+
+    @staticmethod
+    @pytest.mark.dependency(  # type: ignore[misc]
+        depends=["TestWorldModeling::test_reset_world"]
     )
     def test_remove_robot(caplog: LogCaptureFixture) -> None:
         """Tests deleting robots from the world"""

--- a/pyrobosim_msgs/CMakeLists.txt
+++ b/pyrobosim_msgs/CMakeLists.txt
@@ -29,6 +29,7 @@ set(msg_files
 
 set(srv_files
   "srv/RequestWorldState.srv"
+  "srv/ResetWorld.srv"
   "srv/SetLocationState.srv"
 )
 

--- a/pyrobosim_msgs/srv/ResetWorld.srv
+++ b/pyrobosim_msgs/srv/ResetWorld.srv
@@ -1,0 +1,12 @@
+# ROS service to reset the world state.
+
+# Request
+# If true, resets the world to exactly the state when it was first loading.
+# Otherwise, if loaded from YAML, randomly sampled positions will change.
+bool deterministic
+
+---
+
+# Response
+# Indicates whether the world reset operation was successful:
+bool success


### PR DESCRIPTION
This PR takes over from #321 to refactor world resetting so that it's usable in all modes of operation: standalone, through ROS service, and through the GUI.

Closes #319 