### PR TITLE
Fix object detection action callback

### DIFF
--- a/pyrobosim_ros/pyrobosim_ros/ros_interface.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_interface.py
@@ -639,14 +639,9 @@ class WorldROSWrapper(Node):  # type: ignore[misc]
         :param robot: The robot instance corresponding to this request.
         :return: The object detection action result.
         """
-        if self.world.gui is not None:
-            execution_result = self.world.gui.canvas.detect_objects(
-                robot, goal_handle.request.target_object
-            )
-        else:
-            execution_result = robot.detect_objects(
-                target_object=goal_handle.request.target_object
-            )
+        execution_result = robot.detect_objects(
+            target_object=goal_handle.request.target_object
+        )
 
         detected_objects_msg = [
             ObjectState(


### PR DESCRIPTION
Now we can just directly call robot actions and the GUI logic is handled under the hood. I must have missed this.

Closes #337