### PR TITLE
Fix bug in logger messages

### DIFF
--- a/pyrobosim/pyrobosim/navigation/execution.py
+++ b/pyrobosim/pyrobosim/navigation/execution.py
@@ -93,7 +93,8 @@ class ConstantVelocityExecutor(PathExecutor):
             max_angular_velocity=self.max_angular_velocity,
         )
         if self.traj is None:
-            self.robot.logger.warning("Failed to get trajectory from path.")
+            message = "Failed to get trajectory from path."
+            self.robot.logger.warning(message)
             return ExecutionResult(
                 status=ExecutionStatus.PRECONDITION_FAILURE,
                 message=message,
@@ -101,7 +102,8 @@ class ConstantVelocityExecutor(PathExecutor):
 
         traj_interp = interpolate_trajectory(self.traj, self.dt)
         if traj_interp is None:
-            self.robot.logger.warning("Failed to interpolate trajectory.")
+            message = "Failed to interpolate trajectory."
+            self.robot.logger.warning(message)
             return ExecutionResult(
                 status=ExecutionStatus.PRECONDITION_FAILURE,
                 message=message,


### PR DESCRIPTION
# PR Summary
PR ensures the `message` variable is defined before being passed to the `logger` and `ExecutionResult`. This prevents runtime errors due to undefined variable usage on lines 100 and 109.