### PR TITLE
Add ROSCon 2024 workshop worlds

### DIFF
--- a/pyrobosim/pyrobosim/data/roscon_2024_location_data.yaml
+++ b/pyrobosim/pyrobosim/data/roscon_2024_location_data.yaml
@@ -1,0 +1,173 @@
+# Location metadata for ROSCon 2024 deliberation workshop
+# https://github.com/ros-wg-delib/roscon24-workshop
+
+table:
+  footprint:
+    type: box
+    dims: [1.2, 0.8]
+    height: 0.5
+  nav_poses:
+    - position:  # above
+        x: 0.0
+        y: 0.65
+      rotation_eul:
+        yaw: -1.57
+    - position:  # below
+        x: 0.0
+        y: -0.65
+      rotation_eul:
+        yaw: 1.57
+    - position:  # left
+        x: -0.85
+        y: 0.0
+    - position:  # right
+        x: 0.85
+        y: 0.0
+      rotation_eul:
+        yaw: 3.14
+  locations:
+    - name: "tabletop"
+      footprint:
+        type: parent
+        padding: 0.05
+  color: [0.2, 0.2, 0.2]
+
+desk:
+  footprint:
+    type: box
+    dims: [0.6, 1.2]
+    height: 0.5
+  nav_poses:
+    - position:  # left
+        x: -0.5
+        y: 0.0
+    - position:  # right
+        x: 0.5
+        y: 0.0
+      rotation_eul:
+        yaw: 3.14
+  locations:
+    - name: "desktop"
+      footprint:
+        type: parent
+        padding: 0.05
+  color: [0.5, 0.2, 0.2]
+
+storage:
+  footprint:
+    type: box
+    dims: [1.0, 0.6]
+    height: 0.5
+  nav_poses:
+    - position:  # above
+        x: 0.0
+        y: 0.55
+      rotation_eul:
+        yaw: -1.57
+    - position:  # below
+        x: 0.0
+        y: -0.55
+      rotation_eul:
+        yaw: 1.57
+  locations:
+    - name: "storage"
+      footprint:
+        type: parent
+        padding: 0.05
+  color: [0.2, 0.5, 0.2]
+
+trashcan_small:
+  footprint:
+    type: circle
+    radius: 0.25
+    height: 0.5
+  nav_poses:
+    - position:  # above
+        x: 0.0
+        y: 0.5
+      rotation_eul:
+        yaw: -1.57
+    - position:  # below
+        x: 0.0
+        y: -0.5
+      rotation_eul:
+        yaw: 1.57
+    - position:  # left
+        x: -0.5
+        y: 0.0
+    - position:  # right
+        x: 0.5
+        y: 0.0
+      rotation_eul:
+        yaw: 3.14
+  locations:
+    - name: "disposal"
+      footprint:
+        type: parent
+        padding: 0.05
+  color: [0.1, 0.1, 0.1]
+
+trashcan_large:
+  footprint:
+    type: circle
+    radius: 0.525
+    height: 0.5
+  nav_poses:
+    - position:  # above
+        x: 0.0
+        y: 0.75
+      rotation_eul:
+        yaw: -1.57
+    - position:  # below
+        x: 0.0
+        y: -0.75
+      rotation_eul:
+        yaw: 1.57
+    - position:  # left
+        x: -0.75
+        y: 0.0
+    - position:  # right
+        x: 0.75
+        y: 0.0
+      rotation_eul:
+        yaw: 3.14
+  locations:
+    - name: "disposal"
+      footprint:
+        type: parent
+        padding: 0.05
+  color: [0.1, 0.1, 0.1]
+
+charger:
+  footprint:
+    type: polygon
+    coords:
+      - [-0.5, -0.2]
+      - [0.5, -0.2]
+      - [0.5, 0.2]
+      - [-0.5, 0.2]
+    height: 0.1
+  locations:
+    - name: "dock"
+      footprint:
+        type: parent
+      nav_poses:
+        - position:  # above
+            x: 0.0
+            y: 0.4
+          rotation_eul:
+            yaw: -1.57
+        - position:  # below
+            x: 0.0
+            y: -0.4
+          rotation_eul:
+            yaw: 1.57
+        - position:  # left
+            x: -0.7
+            y: 0.0
+        - position:  # right
+            x: 0.7
+            y: 0.0
+          rotation_eul:
+            yaw: 3.14
+  color: [0.4, 0.4, 0]

--- a/pyrobosim/pyrobosim/data/roscon_2024_object_data.yaml
+++ b/pyrobosim/pyrobosim/data/roscon_2024_object_data.yaml
@@ -1,0 +1,32 @@
+# Object metadata for ROSCon 2024 deliberation workshop
+# https://github.com/ros-wg-delib/roscon24-workshop
+
+bread:
+  footprint:
+    type: box
+    dims: [0.15, 0.2]
+  color: [0.7, 0.5, 0]
+
+snacks:
+  footprint:
+    type: box
+    dims: [0.12, 0.15]
+  color: [0.0, 0.0, 0.6]
+
+soda:
+  footprint:
+    type: box
+    dims: [0.12, 0.15]
+  color: [0.8, 0.0, 0.0]
+
+butter:
+  footprint:
+    type: box
+    dims: [0.1, 0.15]
+  color: [0.6, 0.6, 0.0]
+
+waste:
+  footprint:
+    type: circle
+    radius: 0.075
+  color: [0.3, 0.5, 0.1]

--- a/pyrobosim/pyrobosim/data/roscon_2024_workshop_world.yaml
+++ b/pyrobosim/pyrobosim/data/roscon_2024_workshop_world.yaml
@@ -1,0 +1,263 @@
+# World based on the ROSCon 2024 deliberation workshop.
+# https://github.com/ros-wg-delib/roscon24-workshop
+
+metadata:
+  locations: $PWD/roscon_2024_location_data.yaml
+  objects: $PWD/roscon_2024_object_data.yaml
+
+params:
+  name: delib_ws_problem_1
+  inflation_radius: 0.01
+  object_radius: 0.01
+
+robots:
+  - name: robot
+    radius: 0.1
+    location: dining
+    path_executor:
+      type: constant_velocity
+    path_planner:
+      type: rrt
+      bidirectional: true
+      max_connection_dist: 1.0
+      max_time: 5.0
+
+rooms:
+  - name: dining
+    footprint:
+      type: polygon
+      coords:
+        - [-1.6, -1.0]
+        - [1.6, -1.0]
+        - [1.6, 1.0]
+        - [-1.6, 1.0]
+    # Add navigation poses since the centroid is blocked by the table.
+    nav_poses:
+      - position:  # left
+          x: -1.0
+          y: 0.0
+      - position:  # right
+          x: 1.0
+          y: 0.0
+        rotation_eul:
+          yaw: 3.14
+      - position:  # above
+          x: 0.0
+          y: 0.8
+        rotation_eul:
+          yaw: -1.57
+      - position:  # below
+          x: 0.0
+          y: -0.8
+        rotation_eul:
+          yaw: 1.57
+    wall_width: 0.2
+    color: [0, 1, 0]
+
+  - name: kitchen
+    footprint:
+      type: polygon
+      coords:
+        - [-4, -3]
+        - [-0.5, -3]
+        - [-0.5, -1.75]
+        - [-2.25, -1.75]
+        - [-2.25, -0.5]
+        - [-4, -0.5]
+    wall_width: 0.2
+    color: [1, 0, 0]
+
+  - name: trash
+    footprint:
+      type: polygon
+      coords:
+        - [-4, 0.5]
+        - [-2.25, 0.5]
+        - [-2.25, 1.75]
+        - [-0.5, 1.75]
+        - [-0.5, 3]
+        - [-4, 3]
+    wall_width: 0.2
+    color: [0.1, 0.1, 0.1]
+
+  - name: closet
+    footprint:
+      type: polygon
+      coords:
+        - [0.5, 1.75]
+        - [2.25, 1.75]
+        - [2.25, 0.5]
+        - [4, 0.5]
+        - [4, 3]
+        - [0.5, 3]
+    wall_width: 0.2
+    color: [0.7, 0.4, 0.5]
+
+  - name: office
+    footprint:
+      type: polygon
+      coords:
+        - [0.5, -3]
+        - [4, -3]
+        - [4, -0.5]
+        - [2.25, -0.5]
+        - [2.25, -1.75]
+        - [0.5, -1.75]
+    wall_width: 0.2
+    color: [0.0, 0.0, 1.0]
+
+hallways:
+  - room_start: dining
+    room_end: office
+    width: 0.6
+    conn_method: angle
+    conn_angle: -1.57
+    offset: 1.1
+    is_open: true
+    is_locked: false
+
+  - room_start: dining
+    room_end: closet
+    width: 0.6
+    conn_method: angle
+    conn_angle: 1.57
+    offset: -1.1
+    is_open: true
+    is_locked: false
+
+  - room_start: dining
+    room_end: trash
+    width: 0.6
+    conn_method: angle
+    conn_angle: 1.57
+    offset: 1.1
+    is_open: true
+    is_locked: false
+
+  - room_start: dining
+    room_end: kitchen
+    width: 0.6
+    conn_method: angle
+    conn_angle: -1.57
+    offset: -1.1
+    is_open: true
+    is_locked: false
+
+  - room_start: kitchen
+    room_end: trash
+    width: 0.8
+    conn_method: angle
+    conn_angle: 1.57
+    offset: 0.6
+    is_open: true
+    is_locked: false
+
+  - room_start: kitchen
+    room_end: office
+    width: 0.8
+    conn_method: angle
+    conn_angle: 0.0
+    offset: -0.5
+    is_open: true
+    is_locked: false
+
+  - room_start: closet
+    room_end: trash
+    width: 0.8
+    conn_method: angle
+    conn_angle: 3.14
+    offset: -0.5
+    is_open: true
+    is_locked: false
+
+  - room_start: closet
+    room_end: office
+    width: 0.8
+    conn_method: angle
+    conn_angle: -1.57
+    offset: 0.6
+    is_open: true
+    is_locked: false
+
+locations:
+  - name: table
+    parent: dining
+    category: table
+    pose:
+      position:
+        x: 0.0
+        y: 0.15
+
+  - name: desk
+    parent: office
+    category: desk
+    pose:
+      position:
+        x: 3.6
+        y: -2.3
+
+  - name: fridge
+    parent: kitchen
+    category: storage
+    pose:
+      position:
+        x: -3.0
+        y: -2.65
+    is_open: true
+
+  - name: pantry
+    parent: kitchen
+    category: storage
+    pose:
+      position:
+        x: -3.65
+        y: -1.5
+      rotation_eul:
+        yaw: 1.57
+    is_open: true
+
+  - name: bin
+    parent: office
+    category: trashcan_small
+    pose:
+      position:
+        x: 2.6
+        y: -0.85
+
+  - name: dumpster
+    parent: trash
+    category: trashcan_large
+    pose:
+      position:
+        x: -3.4
+        y: 2.4
+
+  - name: charger
+    parent: closet
+    category: charger
+    pose:
+      position:
+        x: 3.5
+        y: 2.5
+      rotation_eul:
+        yaw: -0.785
+    is_charger: true
+
+objects:
+  - parent: pantry
+    category: bread
+
+  - parent: pantry
+    category: snacks
+
+  - parent: fridge
+    category: soda
+
+  - parent: fridge
+    category: butter
+
+  - parent: desk
+    category: waste
+
+  - parent: bin
+    category: waste


### PR DESCRIPTION
This adds a world "snapshotted" from the ROSCon 2024 workshop: https://github.com/ros-wg-delib/roscon24-workshop

```
python pyrobosim/examples/demo.py --world-file roscon_2024_workshop_world.yaml
```

![image](https://github.com/user-attachments/assets/71ee9753-cd93-4b38-a729-9353c1398273)
