### PR TITLE
Use common Entity parent class constructor

### DIFF
--- a/pyrobosim/pyrobosim/core/hallway.py
+++ b/pyrobosim/pyrobosim/core/hallway.py
@@ -68,6 +68,7 @@ class Hallway(Entity):
             raise ValueError("width must be a positive value.")
 
         # Unpack input
+        super().__init__(name=name)
         self.room_start = room_start
         self.room_end = room_end
         self.name = self.reversed_name = name
@@ -77,7 +78,6 @@ class Hallway(Entity):
         self.viz_color = parse_color(color)
         self.is_open = is_open
         self.is_locked = is_locked
-        self.children: list[Entity] = []
 
         # Parse the connection method
         # If the connection is "auto" or "angle", the hallway is a simple rectangle

--- a/pyrobosim/pyrobosim/core/locations.py
+++ b/pyrobosim/pyrobosim/core/locations.py
@@ -74,10 +74,9 @@ class Location(Entity):
         :param is_charger: If True, the robot charges its battery at this location.
         """
         # Extract the model information from the model list
-        self.name = name
-        self.category = category
+        super().__init__(name=name)
         self.parent = parent
-        self.children: list[Entity] = []
+        self.category = category
         self.is_open = is_open
 
         category_metadata = Location.metadata.get(category)
@@ -225,10 +224,9 @@ class ObjectSpawn(Entity):
         :param category_metadata: Metadata dictionary for the parent category.
         :param parent: Parent of the location (typically a :class:`pyrobosim.core.locations.Location`)
         """
-        self.name = name
+        super().__init__(name=name)
         assert parent is not None
         self.parent = parent
-        self.children: list[Entity] = []
         self.category = parent.category
         self.set_open(parent.is_open, recursive=True)
 

--- a/pyrobosim/pyrobosim/core/objects.py
+++ b/pyrobosim/pyrobosim/core/objects.py
@@ -73,10 +73,9 @@ class Object(Entity):
          - a hexadecimal string (e.g., "#FF0000").
          If using a category with a defined color, this parameter overrides the category color.
         """
-        self.category = category
-        self.name = name
+        super().__init__(name=name)
         self.parent = parent
-        self.children = []
+        self.category = category
 
         self.inflation_radius = inflation_radius
         self.collision_polygon = Polygon()

--- a/pyrobosim/pyrobosim/core/robot.py
+++ b/pyrobosim/pyrobosim/core/robot.py
@@ -87,8 +87,7 @@ class Robot(Entity):
         from .world import World
 
         # Basic properties
-        super().__init__()
-        self.name = name
+        super().__init__(name=name)
         self.radius = radius
         self.height = height
         self.color = parse_color(color)

--- a/pyrobosim/pyrobosim/core/room.py
+++ b/pyrobosim/pyrobosim/core/room.py
@@ -55,7 +55,7 @@ class Room(Entity):
         """
         from .hallway import Hallway  # Avoids circular import
 
-        self.name = name
+        super().__init__(name=name)
         self.wall_width = wall_width
         self.viz_color = parse_color(color)
 

--- a/pyrobosim/pyrobosim/core/types.py
+++ b/pyrobosim/pyrobosim/core/types.py
@@ -53,8 +53,13 @@ class Entity:
     viz_color: Sequence[float]
     """The color of the visualization polygon patch and text."""
 
-    def __init__(self) -> None:
-        """Construct a new Entity instance."""
+    def __init__(self, *, name: str) -> None:
+        """
+        Construct a new Entity instance.
+
+        :param name: A required entity name.
+        """
+        self.name = name
         self.parent: Entity | None = None
         self.children: list[Entity] = []
 

--- a/pyrobosim/test/utils/test_knowledge_utils.py
+++ b/pyrobosim/test/utils/test_knowledge_utils.py
@@ -65,7 +65,7 @@ def test_apply_first_resolution_strategy() -> None:
 
 def test_apply_nearest_resolution_strategy(caplog: LogCaptureFixture) -> None:
     # Test 'nearest' strategy
-    entity_list = [Entity(), Entity(), Entity()]
+    entity_list = [Entity(name="e1"), Entity(name="e2"), Entity(name="e3")]
     entity_list[0].pose = Pose(x=1.0, y=0.0)
     entity_list[1].pose = Pose(x=2.0, y=0.0)
     entity_list[2].pose = Pose(x=3.0, y=0.0)

--- a/pyrobosim_ros/examples/demo_pddl_planner.py
+++ b/pyrobosim_ros/examples/demo_pddl_planner.py
@@ -142,14 +142,11 @@ class PlannerNode(Node):  # type: ignore[misc]
             return
 
         # Unpack the latest world state.
-        try:
-            if self.world_state_future_response is not None:
-                result = self.world_state_future_response.result()
-                if result is None:
-                    raise RuntimeError("Result was none -- this should not happen.")
-                update_world_from_state_msg(self.world, result.state)
-        except Exception:
-            self.get_logger().info("Failed to unpack world state.")
+        if self.world_state_future_response is not None:
+            result = self.world_state_future_response.result()
+            if result is None:
+                raise RuntimeError("Result was none -- this should not happen.")
+            update_world_from_state_msg(self.world, result.state)
 
         # Once the world state is set, plan using the first robot.
         self.get_logger().info("Planning...")


### PR DESCRIPTION
I found an error in the ROS PDDL demo that was catching an exception but still proceeding with a task plan.

In un-catching this exception, I found the bug was another post-type annotation refactor issue. In this case, the `Room` class did not have a `parent` attribute. So I've made all `Entity` subclasses actually use their parent class' constructor, which fixes the underlying issue in the demo.