### PR TITLE
Enable copy buttons on command blocks in docs

### DIFF
--- a/docs/python_docs_requirements.txt
+++ b/docs/python_docs_requirements.txt
@@ -1,2 +1,3 @@
 sphinx
 sphinx_rtd_theme
+sphinx-copybutton

--- a/docs/python_docs_requirements.txt
+++ b/docs/python_docs_requirements.txt
@@ -1,3 +1,3 @@
 sphinx
-sphinx_rtd_theme
 sphinx-copybutton
+sphinx_rtd_theme

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,7 @@ version = release = "3.3.0"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.autosummary", "sphinx_rtd_theme"]
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.autosummary", "sphinx_rtd_theme", "sphinx_copybutton"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,12 @@ version = release = "3.3.0"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.autosummary", "sphinx_rtd_theme", "sphinx_copybutton"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx_rtd_theme",
+    "sphinx_copybutton",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]


### PR DESCRIPTION
Adds the 'sphinx-copybutton' extension so users can easily copy terminal commands from the docs. A simple, nice-to-have improvement to the documentation!