### PR TITLE
Fix planner initialization after partial hallway observability PR

### DIFF
--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -1166,8 +1166,10 @@ class World:
             self.logger.warning("Could not add robot.")
             self.set_inflation_radius(old_inflation_radius)
 
-        # Update robot's total_internal_polygon
+        # Update robot's total_internal_polygon and initialize planner.
         robot.update_polygons()
+        if robot.path_planner is not None:
+            robot.path_planner.reset()
 
         if show and self.gui is not None:
             self.gui.canvas.show_robots_signal.emit()

--- a/pyrobosim/pyrobosim/navigation/a_star.py
+++ b/pyrobosim/pyrobosim/navigation/a_star.py
@@ -64,7 +64,6 @@ class AStarPlanner(PathPlanner, AStar):  # type: ignore[misc]
         self.heuristic = heuristic
         self.diagonal_motion = diagonal_motion
         self.compress_path = compress_path
-        self.reset()
 
     def _set_actions(self) -> None:
         """Generates the actions available."""

--- a/pyrobosim/pyrobosim/navigation/prm.py
+++ b/pyrobosim/pyrobosim/navigation/prm.py
@@ -41,8 +41,6 @@ class PRMPlanner(PathPlanner):
         self.max_nodes = max_nodes
         self.compress_path = compress_path
 
-        self.reset()
-
     def reset(self) -> None:
         """Resamples the PRM and resets planning metrics."""
         super().reset()

--- a/pyrobosim/pyrobosim/navigation/rrt.py
+++ b/pyrobosim/pyrobosim/navigation/rrt.py
@@ -68,8 +68,6 @@ class RRTPlanner(PathPlanner):
         self.color_goal = [0.0, 0.4, 0.8]
         self.color_alpha = 0.5
 
-        self.reset()
-
     def reset(self) -> None:
         """Resets the search trees and planning metrics."""
         super().reset()

--- a/pyrobosim/pyrobosim/navigation/world_graph.py
+++ b/pyrobosim/pyrobosim/navigation/world_graph.py
@@ -43,8 +43,6 @@ class WorldGraphPlanner(PathPlanner):
         self.planning_time = 0.0
         self.latest_path = Path()
 
-        self.reset()
-
     def reset(self) -> None:
         """
         Initializes the graph from the entity nodes in the world linked to this planner.

--- a/pyrobosim/setup.py
+++ b/pyrobosim/setup.py
@@ -48,6 +48,5 @@ setup(
     install_requires=install_requires,
     packages=find_packages(),
     package_data={project_name: get_files_in_folder(data_dir)},
-    tests_require=["pytest"],
     zip_safe=True,
 )

--- a/test/python_test_requirements.txt
+++ b/test/python_test_requirements.txt
@@ -4,4 +4,4 @@ pytest
 pytest-cov
 pytest-dependency
 pytest-html
-setuptools>=78.1.1
+setuptools>=78.1.1,<80.0.0  # See https://github.com/pypa/setuptools/issues/4971


### PR DESCRIPTION
This PR has a few fixes I found while giving things a tests.

* PRM and RRT was not being `reset()` at the right time, so when you started the multirobot world, the planners did not work unless you reset them manually. Moved the calls to `reset()` for planners in the `World.add_robot()` method to fix this.
* `setuptools` needed to be pinned to below 80.0.0 due to https://github.com/pypa/setuptools/issues/4971 -- this was preventing `colcon build` with `--symlink-install`.
* Removed a seemingly useless `tests_require` line that was giving me a build warning.