### PR TITLE
Fix robot spawning when location is not set in YAML

### DIFF
--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -99,7 +99,7 @@ class World:
 
         self.logger.info("Resetting world...")
 
-        if deterministic and (self.source_yaml_file is not None):
+        if (not deterministic) and (self.source_yaml_file is not None):
             WorldYamlLoader().from_file(self.source_yaml_file, world=self)
         else:
             if self.source_yaml is None:

--- a/pyrobosim/pyrobosim/core/yaml_utils.py
+++ b/pyrobosim/pyrobosim/core/yaml_utils.py
@@ -154,7 +154,8 @@ class WorldYamlLoader:
         for id, robot_data in enumerate(self.data.get("robots", [])):
             # Create the robot
             robot_args = copy.deepcopy(robot_data)
-            del robot_args["location"]
+            if "location" in robot_args:
+                del robot_args["location"]
             if "name" not in robot_args:
                 robot_args["name"] = f"robot{id}"
             robot_args["path_planner"] = self.get_path_planner(robot_args)

--- a/pyrobosim/pyrobosim/utils/world_collision.py
+++ b/pyrobosim/pyrobosim/utils/world_collision.py
@@ -91,7 +91,7 @@ def check_occupancy(
     else:
         x, y = pose
 
-    if robot is None:
+    if (robot is None) or (robot.total_internal_polygon.is_empty):
         polygon = world.total_internal_polygon
     else:
         polygon = robot.total_internal_polygon


### PR DESCRIPTION
When `location: "some_loc_name"` is not specified in a world YAML file for a robot, there were a few small bugs that prevented the robot from spawning correctly.