### PR TITLE
Do not remove and re-add ROS interfaces on world reset

### DIFF
--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -1176,13 +1176,18 @@ class World:
         if self.ros_node is not None:
             self.ros_node.add_robot_ros_interfaces(robot)
 
-    def remove_robot(self, robot: Robot | str, show: bool = True) -> bool:
+    def remove_robot(
+        self, robot: Robot | str, show: bool = True, remove_ros_interfaces: bool = True
+    ) -> bool:
         """
         Removes a robot from the world.
 
         :param robot: Robot instance or name to remove.
         :param show: If True (default), causes the GUI to be updated.
             This is mostly for internal usage to speed up reloading.
+        :param remove_ros_interfaces: If True (default), and the world has a ROS interface,
+            it removes them. This is configurable since resetting the world is prone to a rclpy bug.
+            See https://github.com/ros2/rclpy/issues/1206 for more details.
         :return: True if the robot was successfully removed, else False.
         """
         if isinstance(robot, Robot):
@@ -1197,7 +1202,7 @@ class World:
         self.name_to_entity.pop(resolved_robot.name)
         if show and self.gui is not None:
             self.gui.canvas.show_robots_signal.emit()
-        if self.ros_node is not None:
+        if remove_ros_interfaces and (self.ros_node is not None):
             self.ros_node.remove_robot_ros_interfaces(resolved_robot)
 
         # Find the new max inflation radius and revert it.
@@ -1209,11 +1214,21 @@ class World:
             self.set_inflation_radius(new_inflation_radius)
         return True
 
-    def remove_all_robots(self) -> None:
-        """Cleanly removes all robots from the world."""
+    def remove_all_robots(self, remove_ros_interfaces: bool = True) -> None:
+        """
+        Cleanly removes all robots from the world.
+
+        :param remove_ros_interfaces: If True (default), and the world has a ROS interface,
+            it removes them. This is configurable since resetting the world is prone to a rclpy bug.
+            See https://github.com/ros2/rclpy/issues/1206 for more details.
+        """
         for robot in reversed(self.robots):
             # Only update the UI on the last robot to remove.
-            self.remove_robot(robot, show=(len(self.robots) == 1))
+            self.remove_robot(
+                robot,
+                show=(len(self.robots) == 1),
+                remove_ros_interfaces=remove_ros_interfaces,
+            )
 
     def set_inflation_radius(self, inflation_radius: float = 0.0) -> None:
         """

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -1202,8 +1202,11 @@ class World:
         self.name_to_entity.pop(resolved_robot.name)
         if show and self.gui is not None:
             self.gui.canvas.show_robots_signal.emit()
-        if remove_ros_interfaces and (self.ros_node is not None):
-            self.ros_node.remove_robot_ros_interfaces(resolved_robot)
+        if self.ros_node is not None:
+            if remove_ros_interfaces:
+                self.ros_node.remove_robot_ros_interfaces(resolved_robot)
+            else:  # Still want to stop publisher timers while resetting.
+                self.ros_node.stop_robot_ros_timers(resolved_robot)
 
         # Find the new max inflation radius and revert it.
         new_inflation_radius = max(

--- a/pyrobosim/pyrobosim/core/yaml_utils.py
+++ b/pyrobosim/pyrobosim/core/yaml_utils.py
@@ -88,7 +88,7 @@ class WorldYamlLoader:
             self.world = World(**params)
         else:
             world.remove_all_objects()
-            world.remove_all_robots()
+            world.remove_all_robots(remove_ros_interfaces=False)  # OK for resetting.
             world.remove_all_locations()
             world.remove_all_hallways()
             world.remove_all_rooms()

--- a/pyrobosim_ros/pyrobosim_ros/ros_interface.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_interface.py
@@ -264,67 +264,72 @@ class WorldROSWrapper(Node):  # type: ignore[misc]
         self.latest_robot_cmds[robot.name] = None
 
         # Create subscriber
-        sub = self.create_subscription(
-            Twist,
-            f"{robot.name}/cmd_vel",
-            lambda msg: self.velocity_command_callback(msg, robot),
-            10,
-            callback_group=ReentrantCallbackGroup(),
-        )
-        self.robot_command_subs[robot.name] = sub
+        if robot.name not in self.robot_command_subs:
+            self.robot_command_subs[robot.name] = self.create_subscription(
+                Twist,
+                f"{robot.name}/cmd_vel",
+                lambda msg: self.velocity_command_callback(msg, robot),
+                10,
+                callback_group=ReentrantCallbackGroup(),
+            )
 
         # Create robot state publisher timer
-        pub = self.create_publisher(
-            RobotState,
-            f"{robot.name}/robot_state",
-            10,
-            callback_group=ReentrantCallbackGroup(),
+        if robot.name not in self.robot_state_pubs:
+            self.robot_state_pubs[robot.name] = self.create_publisher(
+                RobotState,
+                f"{robot.name}/robot_state",
+                10,
+                callback_group=ReentrantCallbackGroup(),
+            )
+
+        pub_fn = partial(
+            self.publish_robot_state, pub=self.robot_state_pubs[robot.name], robot=robot
         )
-        pub_fn = partial(self.publish_robot_state, pub=pub, robot=robot)
         pub_timer = self.create_timer(self.state_pub_rate, pub_fn)
-        self.robot_state_pubs[robot.name] = pub
         self.robot_state_pub_timers[robot.name] = pub_timer
 
         robot_action_callback_group = ReentrantCallbackGroup()
 
         # Specialized action servers for path planning and execution.
-        plan_path_server = ActionServer(
-            self,
-            PlanPath,
-            f"{robot.name}/plan_path",
-            execute_callback=partial(self.robot_path_plan_callback, robot=robot),
-            callback_group=robot_action_callback_group,
-        )
-        self.robot_plan_path_servers[robot.name] = plan_path_server
+        if robot.name not in self.robot_plan_path_servers:
+            self.robot_plan_path_servers[robot.name] = ActionServer(
+                self,
+                PlanPath,
+                f"{robot.name}/plan_path",
+                execute_callback=partial(self.robot_path_plan_callback, robot=robot),
+                callback_group=robot_action_callback_group,
+            )
 
-        follow_path_server = ActionServer(
-            self,
-            FollowPath,
-            f"{robot.name}/follow_path",
-            execute_callback=partial(self.robot_path_follow_callback, robot=robot),
-            cancel_callback=partial(self.robot_path_cancel_callback, robot=robot),
-            callback_group=robot_action_callback_group,
-        )
-        self.robot_follow_path_servers[robot.name] = follow_path_server
+        if robot.name not in self.robot_follow_path_servers:
+            self.robot_follow_path_servers[robot.name] = ActionServer(
+                self,
+                FollowPath,
+                f"{robot.name}/follow_path",
+                execute_callback=partial(self.robot_path_follow_callback, robot=robot),
+                cancel_callback=partial(self.robot_path_cancel_callback, robot=robot),
+                callback_group=robot_action_callback_group,
+            )
 
         # Service server for resetting path planner.
-        reset_path_planner_srv = self.create_service(
-            Trigger,
-            f"{robot.name}/reset_path_planner",
-            partial(self.robot_path_planner_reset_callback, robot=robot),
-            callback_group=ReentrantCallbackGroup(),
-        )
-        self.robot_reset_path_planner_servers[robot.name] = reset_path_planner_srv
+        if robot.name not in self.robot_reset_path_planner_servers:
+            self.robot_reset_path_planner_servers[robot.name] = self.create_service(
+                Trigger,
+                f"{robot.name}/reset_path_planner",
+                partial(self.robot_path_planner_reset_callback, robot=robot),
+                callback_group=ReentrantCallbackGroup(),
+            )
 
         # Specialized action server for object detection.
-        object_detection_server = ActionServer(
-            self,
-            DetectObjects,
-            f"{robot.name}/detect_objects",
-            execute_callback=partial(self.robot_detect_objects_callback, robot=robot),
-            callback_group=robot_action_callback_group,
-        )
-        self.robot_object_detection_servers[robot.name] = object_detection_server
+        if robot.name not in self.robot_object_detection_servers:
+            self.robot_object_detection_servers[robot.name] = ActionServer(
+                self,
+                DetectObjects,
+                f"{robot.name}/detect_objects",
+                execute_callback=partial(
+                    self.robot_detect_objects_callback, robot=robot
+                ),
+                callback_group=robot_action_callback_group,
+            )
 
         # Set up logger interface for robot
         robot.logger = get_logger(robot.name)

--- a/pyrobosim_ros/pyrobosim_ros/ros_interface.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_interface.py
@@ -356,10 +356,7 @@ class WorldROSWrapper(Node):  # type: ignore[misc]
             self.destroy_publisher(pub)
             del self.robot_state_pubs[name]
 
-        pub_timer = self.robot_state_pub_timers.get(name)
-        if pub_timer:
-            pub_timer.destroy()
-            del self.robot_state_pub_timers[name]
+        self.stop_robot_ros_timers(robot)
 
         plan_path_server = self.robot_plan_path_servers.get(name)
         if plan_path_server:
@@ -383,6 +380,17 @@ class WorldROSWrapper(Node):  # type: ignore[misc]
 
         if self.executor is not None:
             self.executor.wake()
+
+    def stop_robot_ros_timers(self, robot: Robot) -> None:
+        """
+        Stops any running ROS timers for a specific robot.
+
+        :param robot: Robot instance.
+        """
+        pub_timer = self.robot_state_pub_timers.get(robot.name)
+        if pub_timer:
+            pub_timer.destroy()
+            del self.robot_state_pub_timers[robot.name]
 
     def dynamics_callback(self) -> None:
         """


### PR DESCRIPTION
Done purely to mitigate the effects of this bug: https://github.com/ros2/rclpy/issues/1206