### PR TITLE
Allow resetting worlds with a specific RNG seed

### DIFF
--- a/pyrobosim/pyrobosim/core/types.py
+++ b/pyrobosim/pyrobosim/core/types.py
@@ -125,7 +125,7 @@ class EntityMetadata:
         self.data = self._load_metadata(filename)
 
         # List of file paths from which metadata has been loaded.
-        self.sources: list[str] = [filename] if filename is not None else []
+        self.sources: set[str] = set([filename]) if filename is not None else set()
 
     def _load_metadata(self, filename: str | None) -> dict[str, Any]:
         """
@@ -176,7 +176,7 @@ class EntityMetadata:
                 raise MetadataConflictException(key, self.data[key], value, filename)
             self.data[key] = value
 
-        self.sources.append(filename)
+        self.sources.add(filename)
 
     def get_categories(self) -> list[str]:
         """

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -87,17 +87,24 @@ class World:
 
         self.logger.info("Created world.")
 
-    def reset(self, deterministic: bool = False) -> bool:
+    def reset(self, deterministic: bool = False, seed: int = -1) -> bool:
         """
         Resets the world to its initial state.
 
         :param deterministic: If True, resets the world completely deterministically.
             Otherwise, sampled poses may be resampled randomly.
+        :param seed: The seed to use for random number generation.
+            This is useful for applications such as machine learning where you want to control randomness.
+            If -1 (default), does not use a fixed seed.
         :return: True if the reset was successful, else False.
         """
         from ..core.yaml_utils import WorldYamlLoader, WorldYamlWriter
 
-        self.logger.info("Resetting world...")
+        if seed < 0:
+            self.logger.info("Resetting world...")
+        else:
+            np.random.seed(seed)
+            self.logger.info(f"Resetting world with seed {seed}...")
 
         if (not deterministic) and (self.source_yaml_file is not None):
             WorldYamlLoader().from_file(self.source_yaml_file, world=self)

--- a/pyrobosim/pyrobosim/core/yaml_utils.py
+++ b/pyrobosim/pyrobosim/core/yaml_utils.py
@@ -301,8 +301,8 @@ class WorldYamlWriter:
         }
 
         # Extract the location and object metadata.
-        loc_metadata_files = world.get_location_metadata().sources
-        obj_metadata_files = world.get_object_metadata().sources
+        loc_metadata_files = list(world.get_location_metadata().sources)
+        obj_metadata_files = list(world.get_object_metadata().sources)
 
         world_dict["metadata"] = {
             "locations": loc_metadata_files,

--- a/pyrobosim/test/core/test_world.py
+++ b/pyrobosim/test/core/test_world.py
@@ -431,13 +431,38 @@ class TestWorldModeling:
     )
     def test_reset_world() -> None:
         """Tests resetting a world."""
-        TestWorldModeling.world.reset()
+        world = TestWorldModeling.world
 
-        assert TestWorldModeling.world.num_rooms == 2
-        assert TestWorldModeling.world.num_locations == 2
-        assert TestWorldModeling.world.num_hallways == 1
-        assert TestWorldModeling.world.num_objects == 2
-        assert len(TestWorldModeling.world.robots) == 2
+        world.reset()
+        assert world.num_rooms == 2
+        assert world.num_locations == 2
+        assert world.num_hallways == 1
+        assert world.num_objects == 2
+        assert len(world.robots) == 2
+
+        # Reset with "deterministic" mode
+        original_robot_0_pose = world.robots[0].get_pose()
+        original_apple_pose = world.objects[0].pose
+        world.reset(deterministic=True)
+        assert world.robots[0].get_pose() == original_robot_0_pose
+        assert world.objects[0].pose == original_apple_pose
+
+        # Now reset with a fixed seed.
+        seed = 1234
+        world.reset(seed=seed)
+
+        assert world.num_rooms == 2
+        assert world.num_locations == 2
+        assert world.num_hallways == 1
+        assert world.num_objects == 2
+        assert len(world.robots) == 2
+
+        original_robot_0_pose = world.robots[0].get_pose()
+        original_apple_pose = world.objects[0].pose
+        for i in range(10):
+            world.reset(seed=seed)
+            assert world.robots[0].get_pose() == original_robot_0_pose
+            assert world.objects[0].pose == original_apple_pose
 
     ##############################################
     # These tests incrementally clean up a world #

--- a/pyrobosim/test/core/test_yaml_utils.py
+++ b/pyrobosim/test/core/test_yaml_utils.py
@@ -481,8 +481,8 @@ def test_yaml_load_and_write_dict() -> None:
     assert world_dict["params"].get("inflation_radius") == 0.1  # From the largest robot
 
     assert "metadata" in world_dict
-    assert world_dict["metadata"].get("locations") == Location.metadata.sources
-    assert world_dict["metadata"].get("objects") == Object.metadata.sources
+    assert world_dict["metadata"].get("locations") == list(Location.metadata.sources)
+    assert world_dict["metadata"].get("objects") == list(Object.metadata.sources)
 
     assert "robots" in world_dict
     assert len(world_dict["robots"]) == 3

--- a/pyrobosim_msgs/srv/ResetWorld.srv
+++ b/pyrobosim_msgs/srv/ResetWorld.srv
@@ -5,6 +5,11 @@
 # Otherwise, if loaded from YAML, randomly sampled positions will change.
 bool deterministic
 
+# The seed to use for random number generation.
+# This is useful for applications such as machine learning where you want to control randomness.
+# If -1 (default), does not use a fixed seed.
+int64 seed -1
+
 ---
 
 # Response

--- a/pyrobosim_ros/pyrobosim_ros/ros_interface.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_interface.py
@@ -890,7 +890,9 @@ class WorldROSWrapper(Node):  # type: ignore[misc]
         for thread in cancel_threads:
             thread.join()
 
-        response.success = self.world.reset(deterministic=request.deterministic)
+        response.success = self.world.reset(
+            deterministic=request.deterministic, seed=request.seed
+        )
         return response
 
 


### PR DESCRIPTION
Closes #380 

This additionally fixes an issue in which the world metadata kept ballooning in size on subsequent world resets, causing exponential slowdowns. This will be a very important fix to have right away.