### PR TITLE
Cleanup stale ROS interfaces when resetting world

### DIFF
--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -116,8 +116,8 @@ class World:
 
         if self.gui is not None:
             self.gui.canvas.show()
+            self.gui.update_buttons_signal.emit()
             self.gui.canvas.draw_signal.emit()
-            self.gui.on_robot_changed()
 
         self.logger.info("Reset world successfully.")
         return True  # No error handling yet

--- a/pyrobosim/pyrobosim/core/yaml_utils.py
+++ b/pyrobosim/pyrobosim/core/yaml_utils.py
@@ -182,6 +182,13 @@ class WorldYamlLoader:
                 pose = None
             self.world.add_robot(robot, loc=loc, pose=pose, show=False)
 
+        # Clean up any unused ROS interface due to resetting the world.
+        new_robot_names = self.world.get_robot_names()
+        if self.world.ros_node is not None:
+            for robot_name in self.world.ros_node.latest_robot_cmds:
+                if robot_name not in new_robot_names:
+                    self.world.ros_node.remove_robot_interfaces(robot_name)
+
     def get_path_planner(self, robot_data: dict[str, Any]) -> Any:
         """Gets path planner to add to a robot."""
         from ..navigation.types import PathPlanner

--- a/pyrobosim_ros/pyrobosim_ros/ros_interface.py
+++ b/pyrobosim_ros/pyrobosim_ros/ros_interface.py
@@ -341,13 +341,13 @@ class WorldROSWrapper(Node):  # type: ignore[misc]
         if self.executor is not None:
             self.executor.wake()
 
-    def remove_robot_ros_interfaces(self, robot: Robot) -> None:
+    def remove_robot_ros_interfaces(self, robot: Robot | str) -> None:
         """
         Removes ROS interfaces for a specific robot.
 
-        :param robot: Robot instance.
+        :param robot: Robot instance or name.
         """
-        name = robot.name
+        name = robot if isinstance(robot, str) else robot.name
 
         sub = self.robot_command_subs.get(name)
         if sub:
@@ -359,10 +359,10 @@ class WorldROSWrapper(Node):  # type: ignore[misc]
             self.destroy_publisher(pub)
             del self.robot_state_pubs[name]
 
-        pub_timer = self.robot_state_pub_timers.get(robot.name)
+        pub_timer = self.robot_state_pub_timers.get(name)
         if pub_timer:
             pub_timer.destroy()
-            del self.robot_state_pub_timers[robot.name]
+            del self.robot_state_pub_timers[name]
 
         plan_path_server = self.robot_plan_path_servers.get(name)
         if plan_path_server:


### PR DESCRIPTION
While https://github.com/sea-bass/pyrobosim/pull/382 helps real with ROS middleware issues, it did have an edge case if you added any new robots at runtime, as its ROS interfaces would not get cleaned up on reset even if that robot did not exist after the reset!

This PR thereby checks if there are any lingering ROS interfaces that do not correspond to currently existing robot, and does delete those.

As a bonus, I also found a one-line change that optimizes the rendering speed on world resets. Thank goodness.