### PR TITLE
Allow specifying lists of locations or location queries for robot and object spawning

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,6 +104,7 @@ jobs:
   # Build and test with ROS 2
   ros2-test:
     strategy:
+      fail-fast: false
       matrix:
         ros_distro: [humble, jazzy, kilted, rolling]
 

--- a/docs/source/yaml/world_schema.rst
+++ b/docs/source/yaml/world_schema.rst
@@ -30,7 +30,7 @@ The world schema looks as follows, where ``<angle brackets>`` are placeholders:
      - name: <name>
        radius: <value>  # Robot radius
        height: <value>  # Robot height
-       location: <loc_name>  # Initial location
+       location: <loc_name>  # Initial location (can also be a list)
        pose:  # Initial pose, if not specified will sample
          position:
            x: <x>
@@ -139,7 +139,7 @@ The world schema looks as follows, where ``<angle brackets>`` are placeholders:
    objects:
      - name: <obj_name>  # If not specified, will be automatic
        category: <obj_category>  # From object YAML file
-       parent: <loc_name>
+       parent: <loc_name>  # Initial location (can also be a list)
        pose:  # If not specified, will sample
          position:
            x: <x>

--- a/pyrobosim/examples/demo.py
+++ b/pyrobosim/examples/demo.py
@@ -112,7 +112,7 @@ def create_world(multirobot: bool = False) -> World:
     world.add_object(category="apple", parent=table)
     world.add_object(category="water", parent=counter)
     world.add_object(category="banana", parent=counter)
-    world.add_object(category="water", parent=["table", "desk"])
+    world.add_object(category="water", parent="desk")
 
     # Add robots
     grasp_props = ParallelGraspProperties(

--- a/pyrobosim/examples/demo.py
+++ b/pyrobosim/examples/demo.py
@@ -112,7 +112,7 @@ def create_world(multirobot: bool = False) -> World:
     world.add_object(category="apple", parent=table)
     world.add_object(category="water", parent=counter)
     world.add_object(category="banana", parent=counter)
-    world.add_object(category="water", parent=desk)
+    world.add_object(category="water", parent=["table", "desk"])
 
     # Add robots
     grasp_props = ParallelGraspProperties(
@@ -167,7 +167,7 @@ def create_world(multirobot: bool = False) -> World:
             grasp_generator=GraspGenerator(grasp_props),
             partial_obs_objects=args.partial_obs_objects,
         )
-        world.add_robot(robot1, loc="bathroom")
+        world.add_robot(robot1, loc=["bathroom", "counter"])
         planner_config_prm = {
             "collision_check_step_dist": 0.025,
             "max_connection_dist": 1.5,
@@ -185,7 +185,7 @@ def create_world(multirobot: bool = False) -> World:
             grasp_generator=GraspGenerator(grasp_props),
             partial_obs_objects=args.partial_obs_objects,
         )
-        world.add_robot(robot2, loc="bedroom")
+        world.add_robot(robot2, loc=["bedroom", "desk"])
         planner_config_astar = {
             "grid_resolution": 0.05,
             "grid_inflation_radius": 0.15,

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -15,7 +15,6 @@ from .room import Room
 from .robot import Robot
 from .types import Entity, EntityMetadata, InvalidEntityCategoryException, set_parent
 from ..planning.actions import ExecutionResult, ExecutionStatus
-from ..utils.knowledge import query_to_entity
 from ..utils.logging import create_logger
 from ..utils.pose import Pose
 from ..utils.polygon import sample_from_polygon, transform_polygon
@@ -911,6 +910,7 @@ class World:
                 parent = np.random.choice(parent)
 
             if isinstance(parent, str):
+                from ..utils.knowledge import query_to_entity
                 parent = query_to_entity(
                     self, parent, mode="location", resolution_strategy="random"
                 )
@@ -1124,7 +1124,9 @@ class World:
 
         robot_pose: Pose | None = None
         if isinstance(loc, list):
-            resolved_loc: Entity | str | None = np.random.choice(loc)
+            resolved_loc: Entity | str | list[Entity | str] | None = np.random.choice(
+                loc
+            )
         else:
             resolved_loc = loc
 
@@ -1148,6 +1150,7 @@ class World:
         else:
             # First, validate that the location is valid for a robot
             if isinstance(resolved_loc, str):
+                from ..utils.knowledge import query_to_entity
                 resolved_loc = query_to_entity(
                     self, resolved_loc, mode="location", resolution_strategy="random"
                 )

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -1125,9 +1125,7 @@ class World:
 
         robot_pose: Pose | None = None
         if isinstance(loc, list):
-            resolved_loc: Entity | str | list[Entity | str] | None = np.random.choice(
-                loc
-            )
+            resolved_loc: Entity | str | None = np.random.choice(loc)
         else:
             resolved_loc = loc
 

--- a/pyrobosim/pyrobosim/core/world.py
+++ b/pyrobosim/pyrobosim/core/world.py
@@ -911,6 +911,7 @@ class World:
 
             if isinstance(parent, str):
                 from ..utils.knowledge import query_to_entity
+
                 parent = query_to_entity(
                     self, parent, mode="location", resolution_strategy="random"
                 )
@@ -1151,6 +1152,7 @@ class World:
             # First, validate that the location is valid for a robot
             if isinstance(resolved_loc, str):
                 from ..utils.knowledge import query_to_entity
+
                 resolved_loc = query_to_entity(
                     self, resolved_loc, mode="location", resolution_strategy="random"
                 )

--- a/pyrobosim/pyrobosim/core/yaml_utils.py
+++ b/pyrobosim/pyrobosim/core/yaml_utils.py
@@ -174,8 +174,6 @@ class WorldYamlLoader:
             robot = Robot(**robot_args)
 
             loc = robot_data.get("location")
-            if loc is not None:
-                loc = self.world.get_entity_by_name(loc)
             if "pose" in robot_args:
                 pose = construct_pose_from_args(robot_args["pose"], self.world)
             else:

--- a/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
+++ b/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
@@ -54,7 +54,7 @@ robots:
 
   - radius: 0.08
     color: "#CCCC00"
-    location: bathroom
+    location: [bathroom, counter]
     grasping:
       generator: parallel_grasp
       max_width: 0.175
@@ -72,7 +72,7 @@ robots:
   - name: "robot2"
     radius: 0.06
     color: [0.0, 0.8, 0.8]
-    location: bedroom
+    location: [bedroom, desk]
     path_planner:  # Rapidly-expanding Random Tree (RRT) planner
       type: astar
       grid_resolution: 0.05
@@ -277,7 +277,7 @@ objects:
     parent: counter0_right
 
   - category: water
-    parent: my_desk
+    parent: [table, desk]
 
   - name: soda
     category: coke

--- a/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
+++ b/pyrobosim/pyrobosim/data/test_world_multirobot.yaml
@@ -277,7 +277,7 @@ objects:
     parent: counter0_right
 
   - category: water
-    parent: [table, desk]
+    parent: desk
 
   - name: soda
     category: coke

--- a/pyrobosim/pyrobosim/utils/knowledge.py
+++ b/pyrobosim/pyrobosim/utils/knowledge.py
@@ -5,6 +5,7 @@ Utilities to reason about entities using world knowledge
 
 import random
 import sys
+from typing import TYPE_CHECKING
 
 from ..core.hallway import Hallway
 from ..core.locations import Location, ObjectSpawn
@@ -12,7 +13,9 @@ from ..core.robot import Robot
 from ..core.room import Room
 from ..core.types import Entity
 from ..core.objects import Object
-from ..core.world import World
+
+if TYPE_CHECKING:
+    from ..core.world import World
 from ..utils.graph_types import Node
 from ..utils.logging import get_global_logger
 

--- a/pyrobosim/pyrobosim/utils/knowledge.py
+++ b/pyrobosim/pyrobosim/utils/knowledge.py
@@ -5,7 +5,6 @@ Utilities to reason about entities using world knowledge
 
 import random
 import sys
-from typing import TYPE_CHECKING
 
 from ..core.hallway import Hallway
 from ..core.locations import Location, ObjectSpawn
@@ -13,9 +12,7 @@ from ..core.robot import Robot
 from ..core.room import Room
 from ..core.types import Entity
 from ..core.objects import Object
-
-if TYPE_CHECKING:
-    from ..core.world import World
+from ..core.world import World
 from ..utils.graph_types import Node
 from ..utils.logging import get_global_logger
 

--- a/pyrobosim/test/core/test_yaml_utils.py
+++ b/pyrobosim/test/core/test_yaml_utils.py
@@ -541,7 +541,11 @@ def test_yaml_load_and_write_dict() -> None:
     assert robot1_dict.get("max_angular_velocity") == np.inf
     assert robot1_dict.get("max_linear_acceleration") == np.inf
     assert robot1_dict.get("max_angular_acceleration") == np.inf
-    assert robot1_dict.get("location") == "bathroom"
+    assert robot1_dict.get("location") in (
+        "bathroom",
+        "counter0_left",
+        "counter0_right",
+    )
     robot1_pose = world.robots[1].get_pose()
     assert robot1_dict.get("pose").get("position").get("x") == robot1_pose.x
     assert robot1_dict.get("pose").get("position").get("y") == robot1_pose.y
@@ -578,7 +582,7 @@ def test_yaml_load_and_write_dict() -> None:
     assert robot2_dict.get("max_angular_velocity") == np.inf
     assert robot2_dict.get("max_linear_acceleration") == np.inf
     assert robot2_dict.get("max_angular_acceleration") == np.inf
-    assert robot2_dict.get("location") == "bedroom"
+    assert robot2_dict.get("location") in ("bedroom", "my_desk_desktop")
     robot2_pose = world.robots[2].get_pose()
     assert robot2_dict.get("pose").get("position").get("x") == robot2_pose.x
     assert robot2_dict.get("pose").get("position").get("y") == robot2_pose.y

--- a/pyrobosim_ros/examples/demo.py
+++ b/pyrobosim_ros/examples/demo.py
@@ -109,7 +109,7 @@ def create_world() -> World:
     world.add_object(category="apple", parent=table)
     world.add_object(category="water", parent=counter)
     world.add_object(category="banana", parent=counter)
-    world.add_object(category="water", parent=desk)
+    world.add_object(category="water", parent=["table", "desk"])
 
     # Add a robot
     # Create path planner

--- a/pyrobosim_ros/examples/demo.py
+++ b/pyrobosim_ros/examples/demo.py
@@ -109,7 +109,7 @@ def create_world() -> World:
     world.add_object(category="apple", parent=table)
     world.add_object(category="water", parent=counter)
     world.add_object(category="banana", parent=counter)
-    world.add_object(category="water", parent=["table", "desk"])
+    world.add_object(category="water", parent="desk")
 
     # Add a robot
     # Create path planner


### PR DESCRIPTION
This PR expands object and robot spawning functionality in 2 ways:

* Allows specifying a list of entities or entity names, e.g., `["table0", "my_desk"]`
* Allows specifying location categories as well, e.g., `["table", "desk"]`, or even full queries like `"kitchen table"`!

And a combination of them all, of course!

Closes #390