### PR TITLE
Fix valueerror in main gui for random object samples

### DIFF
--- a/pyrobosim/pyrobosim/gui/main.py
+++ b/pyrobosim/pyrobosim/gui/main.py
@@ -370,7 +370,12 @@ class PyRoboSimMainWindow(QtWidgets.QMainWindow):  # type: ignore [misc]
 
     def rand_obj_cb(self) -> None:
         """Callback to randomize manipulation object goal."""
-        obj_name = np.random.choice(self.world.get_object_names())
+        object_names = self.world.get_object_names()
+        if not object_names:
+            # No objects to choose from; warn and do nothing.
+            self.world.logger.warning("No objects available to pick a random goal.")
+            return
+        obj_name = np.random.choice(object_names)
         self.goal_textbox.setText(obj_name)
 
     def on_robot_changed(self) -> None:


### PR DESCRIPTION
## Error in demo

Wasn't sure if this was intended error however here is potential logging adjustment if so.

<img width="911" height="415" alt="image" src="https://github.com/user-attachments/assets/de26a7f1-b081-449d-9369-de7df83601bc" />

There are some warnings in the code related to use of numpy which might be relevant for future upgrades.

ruff check --select "NPY"
