### PR TITLE
Use Ubuntu 24.04 in Python CI job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   # Build and test the base, non-ROS image
   python-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   # Build and test the base, non-ROS image
   python-test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ ARG ROS_DISTRO=humble
 # base PyRoboSim build for Ubuntu
 #
 ##################################
-FROM ubuntu:latest AS pyrobosim
+FROM ubuntu:24.04 AS pyrobosim
 
 # Install dependencies
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Tests are failing on `ubuntu-latest` which recently changed to 26.04. Pinning this back for now until I have time to fix the issue for real.