### PR TITLE
Shorten coverage comment so table shows up

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,6 +92,7 @@ jobs:
           junitxml-path: ./test/results/test_results.xml
           pytest-xml-coverage-path: ./test/results/test_results_coverage.xml
           coverage-path-prefix: pyrobosim/pyrobosim/
+          remove-links-to-files: true  # gets around issues of comment being too long
         if: ${{ !github.event.pull_request.head.repo.fork }}
       - name: Create coverage badge
         uses: schneegans/dynamic-badges-action@v1.7.0


### PR DESCRIPTION
See https://github.com/MishaKav/pytest-coverage-comment/issues/209

Applies some of the suggestions there to ensure we get detailed coverage comments. Figured I'd remove links to files since the links to lines with missing coverage are generally more useful.