### PR TITLE
Use virtual env in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -76,7 +76,7 @@ RUN setup/configure_pddlstream.bash
 # cause version conflicts. Use --system-site-packages so that the ROS 2 Python
 # packages (rclpy, etc.) installed system-wide remain importable. Commands that
 # need these dependencies source the venv explicitly (see also the entrypoint).
-ENV VIRTUAL_ENV=/opt/venv
+ENV VIRTUAL_ENV=/opt/.venvs/pyrobosim
 RUN python3 -m venv --system-site-packages ${VIRTUAL_ENV}
 
 # Install PyRoboSim, docs, and testing dependencies

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ FROM ubuntu:latest AS pyrobosim
 
 # Install dependencies
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update &&\
+RUN apt-get update && \
     apt-get install -y \
         apt-utils \
         libegl1 \
@@ -57,11 +57,12 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install dependencies
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y \
-    apt-utils python3-pip python3-tk python3-venv \
-    libegl1 libgl1-mesa-dev libglu1-mesa-dev '^libxcb.*-dev' libx11-xcb-dev \
-    libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libxrender-dev
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+        apt-utils python3-pip python3-tk python3-venv \
+        libegl1 libgl1-mesa-dev libglu1-mesa-dev '^libxcb.*-dev' libx11-xcb-dev \
+        libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libxrender-dev
 
 # Create a ROS 2 workspace
 RUN mkdir -p /pyrobosim_ws/src/pyrobosim

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,7 +59,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y \
-    apt-utils python3-pip python3-tk \
+    apt-utils python3-pip python3-tk python3-venv \
     libegl1 libgl1-mesa-dev libglu1-mesa-dev '^libxcb.*-dev' libx11-xcb-dev \
     libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libxrender-dev
 
@@ -71,19 +71,28 @@ WORKDIR /pyrobosim_ws/src
 COPY setup/configure_pddlstream.bash /pyrobosim_ws/src/setup/
 RUN setup/configure_pddlstream.bash
 
+# Create a Python virtual environment to isolate pip-installed packages
+# (e.g., numpy, pytest) from the system/apt-managed packages, which otherwise
+# cause version conflicts. Use --system-site-packages so that the ROS 2 Python
+# packages (rclpy, etc.) installed system-wide remain importable. Commands that
+# need these dependencies source the venv explicitly (see also the entrypoint).
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv --system-site-packages ${VIRTUAL_ENV}
+
 # Install PyRoboSim, docs, and testing dependencies
-ENV PIP_BREAK_SYSTEM_PACKAGES=1
 COPY pyrobosim/setup.py pyrobosim/
 COPY docs/python_docs_requirements.txt docs/
 COPY test/python_test_requirements.txt test/
-RUN pip3 install -e ./pyrobosim && \
+RUN source ${VIRTUAL_ENV}/bin/activate && \
+    pip3 install -e ./pyrobosim && \
     pip3 install -r docs/python_docs_requirements.txt && \
     pip3 install -r test/python_test_requirements.txt
 
 # Build the ROS workspace, which includes PyRoboSim
 COPY . /pyrobosim_ws/src/
 WORKDIR /pyrobosim_ws
-RUN . /opt/ros/${ROS_DISTRO}/setup.bash && \
+RUN source ${VIRTUAL_ENV}/bin/activate && \
+    source /opt/ros/${ROS_DISTRO}/setup.bash && \
     colcon build
 
 # Remove display warnings

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Activate the Python virtual environment that holds the pip-installed dependencies.
-source /opt/venv/bin/activate
+source /opt/.venvs/pyrobosim/bin/activate
 
 # Source ROS and the PyRoboSim workspace
 source /opt/ros/${ROS_DISTRO}/setup.bash

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Activate the Python virtual environment that holds the pip-installed dependencies.
+source /opt/venv/bin/activate
+
 # Source ROS and the PyRoboSim workspace
 source /opt/ros/${ROS_DISTRO}/setup.bash
 if [ ! -f /pyrobosim_ws/install/setup.bash ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-addopts = --ignore=dependencies
+addopts = --ignore=dependencies -p no:launch_testing -p no:launch_ros
 markers =
     dependency: dependency tests that require external resources.

--- a/test/run_tests.bash
+++ b/test/run_tests.bash
@@ -37,8 +37,8 @@ popd || exit
 ROS_DISTRO=$1
 if [[ -n "${ROS_DISTRO}" && -n "${COLCON_PREFIX_PATH}" ]]
 then
-    WORKSPACE_DIR="${COLCON_PREFIX_PATH}/../"
-    echo "Running ROS package unit tests from ${WORKSPACE_DIR}..."
+    WORKSPACE_DIR=$(realpath "${COLCON_PREFIX_PATH}/../")
+    echo "Running ROS package unit tests from ${WORKSPACE_DIR} ..."
     pushd "${WORKSPACE_DIR}" > /dev/null || exit
     colcon test \
         --packages-select pyrobosim_ros \


### PR DESCRIPTION
Weirdly enough we just got a regression on `main` because of conflicts between system installed and pip installed packages. This makes the Docker images consistent with how we do our local setups to compensate for ROS using "stable" versions from debians.

Also removes some plugins from the `pytest.ini` so that ROS Humble tests run. The alternative being that we pin `pytest<9.1.0` which is less desirable for this repo.